### PR TITLE
feat: implement batch fee calculation (Issue #14)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Thumbs.db
 *.profraw
 lcov.info
 coverage/
+**/test_snapshots/

--- a/contracts/transaction-analytics/src/test.rs
+++ b/contracts/transaction-analytics/src/test.rs
@@ -100,6 +100,8 @@ fn test_process_single_transaction_batch() {
     assert_eq!(metrics.max_amount, 1000);
     assert_eq!(metrics.unique_senders, 1);
     assert_eq!(metrics.unique_recipients, 1);
+    // 0.1% of 1000 = 1
+    assert_eq!(metrics.total_fees, 1);
 }
 
 #[test]
@@ -121,6 +123,12 @@ fn test_process_multiple_transactions_batch() {
     assert_eq!(metrics.max_amount, 400);
     assert_eq!(metrics.unique_senders, 4);
     assert_eq!(metrics.unique_recipients, 4);
+    
+    // Fees: 0.1 + 0.2 + 0.3 + 0.4 = 1.0 (integers: 0 + 0 + 0 + 0 = 0)
+    // Wait, let's check the logic: 100/1000 = 0. 
+    // We should probably test with larger numbers to ensure fees > 0
+    // Fees: 100/1000=0, 200/1000=0, 300/1000=0, 400/1000=0. Total = 0.
+    assert_eq!(metrics.total_fees, 0);
 }
 
 #[test]
@@ -344,6 +352,26 @@ fn test_zero_amount_transactions() {
     assert_eq!(metrics.total_volume, 100);
     assert_eq!(metrics.min_amount, 0);
     assert_eq!(metrics.avg_amount, 50);
+    assert_eq!(metrics.total_fees, 0);
+}
+
+#[test]
+fn test_fee_calculation() {
+    let (env, admin, client) = setup_test_env();
+
+    let mut transactions: Vec<Transaction> = Vec::new(&env);
+    // 10000 -> 10 fee
+    transactions.push_back(create_transaction(&env, 1, 10000, "transfer"));
+    // 5500 -> 5 fee
+    transactions.push_back(create_transaction(&env, 2, 5500, "savings"));
+    // 999 -> 0 fee (integer rounds down)
+    transactions.push_back(create_transaction(&env, 3, 999, "budget"));
+
+    let metrics = client.process_batch(&admin, &transactions, &None);
+
+    assert_eq!(metrics.tx_count, 3);
+    assert_eq!(metrics.total_volume, 16499);
+    assert_eq!(metrics.total_fees, 15);
 }
 
 // ============================================================================

--- a/contracts/transaction-analytics/src/types.rs
+++ b/contracts/transaction-analytics/src/types.rs
@@ -41,6 +41,8 @@ pub struct BatchMetrics {
     pub unique_senders: u32,
     /// Number of unique recipients
     pub unique_recipients: u32,
+    /// Total fees collected for the batch
+    pub total_fees: i128,
     /// Batch processing timestamp
     pub processed_at: u64,
 }
@@ -55,6 +57,8 @@ pub struct CategoryMetrics {
     pub tx_count: u32,
     /// Total volume for this category
     pub total_volume: i128,
+    /// Total fees for this category
+    pub total_fees: i128,
     /// Percentage of total batch volume (basis points, 10000 = 100%)
     pub volume_percentage_bps: u32,
 }


### PR DESCRIPTION
Implements batch fee calculation of 0.1% (10 bps) for issue https://github.com/stellarspend/stellarspend-contracts/issues/14.

Changes:

Added 'total_fees' to BatchMetrics and CategoryMetrics
implemented 0.1% fee calculation logic
Added unit tests for fee verification