### PR TITLE
Add batch wallet recovery flow with events and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "contracts/batch-transfer",
     "contracts/batch-conversion",
     "contracts/batch-rewards",
+    "contracts/batch-wallet-creation",
     "contracts/budget-recommendations",
     "contracts/shared-budgets",
     "contracts/multi-currency-wallet",


### PR DESCRIPTION
Closes #23

---


- Summary
  
  - Add a batch wallet recovery flow to the batch-wallet-creation contract to handle ownership recovery when keys are lost.
- Changes
  
  - Introduce WalletRecoveryRequest , WalletRecoveryResult , and BatchRecoveryResult types.
  - Add batch_recover_wallets entrypoint with admin-only access.
  - Validate each recovery request:
    - Old owner address is valid and has an existing wallet.
    - New owner address is valid and does not already have a wallet.
  - Reassign wallets by moving storage from Wallets(old_owner) to Wallets(new_owner) while preserving wallet IDs.
  - Emit recovery events:
    - recovery_started
    - wallet_recovered
    - wallet_recovery_failure
    - recovery_completed
  - Extend tests to cover:
    - Single successful recovery.
    - Partial failures within a batch (non-existing source, conflicting destination).
    - Event emission for recovery batches.
    - Empty batch and unauthorized caller panics.
- Validation
  
  - cargo test -p batch-wallet-creation
- Acceptance Criteria mapping
  
  - Wallets recovered successfully: batch_recover_wallets reassigns ownership while preserving wallet IDs.
  - Events emitted: dedicated recovery events for start, per-request success/failure, and completion.
  - Handle partial failures: invalid recovery requests fail independently without aborting the entire batch.
  - Unit and integration tests included: new tests added under contracts/batch-wallet-creation/src/test.rs .

closes issue #23 