### PR TITLE
feat: add emergency pause functionality for contract-wide operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "contracts/budget-allocation",
     "contracts/batch-token-mint",
     "contracts/access-control",
+    "contracts/pausable",
 ]
 
 [workspace.package]

--- a/contracts/batch-transfer-pausable/Cargo.toml
+++ b/contracts/batch-transfer-pausable/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "batch-transfer-pausable"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.7.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.7.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/pausable/Cargo.toml
+++ b/contracts/pausable/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "pausable"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "21.7.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.7.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/pausable/src/lib.rs
+++ b/contracts/pausable/src/lib.rs
@@ -1,0 +1,157 @@
+//! # Pausable Contract
+//! 
+//! Emergency pause functionality for StellarSpend contracts.
+//! Allows admin to pause/unpause critical operations during emergencies.
+
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env};
+
+/// Storage keys for the pausable contract
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Contract admin
+    Admin,
+    /// Pause state (true = paused, false = active)
+    Paused,
+}
+
+/// Error codes for pausable operations
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PausableError {
+    /// Contract not initialized
+    NotInitialized = 1,
+    /// Caller is not authorized
+    Unauthorized = 2,
+    /// Contract is paused
+    ContractPaused = 3,
+    /// Contract is not paused
+    ContractNotPaused = 4,
+}
+
+impl From<PausableError> for soroban_sdk::Error {
+    fn from(e: PausableError) -> Self {
+        soroban_sdk::Error::from_contract_error(e as u32)
+    }
+}
+
+#[contract]
+pub struct PausableContract;
+
+#[contractimpl]
+impl PausableContract {
+    /// Initialize the contract with an admin address
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Contract already initialized");
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        env.events()
+            .publish(("pausable", "initialized"), admin);
+    }
+
+    /// Pause the contract (admin only)
+    pub fn pause(env: Env, caller: Address) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+
+        if is_paused {
+            panic_with_error!(&env, PausableError::ContractPaused);
+        }
+
+        env.storage().instance().set(&DataKey::Paused, &true);
+
+        env.events()
+            .publish(("pausable", "paused"), caller);
+    }
+
+    /// Unpause the contract (admin only)
+    pub fn unpause(env: Env, caller: Address) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+
+        if !is_paused {
+            panic_with_error!(&env, PausableError::ContractNotPaused);
+        }
+
+        env.storage().instance().set(&DataKey::Paused, &false);
+
+        env.events()
+            .publish(("pausable", "unpaused"), caller);
+    }
+
+    /// Check if the contract is paused
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    /// Get the admin address
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized")
+    }
+
+    /// Update the admin address (current admin only)
+    pub fn set_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        Self::require_admin(&env, &current_admin);
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        env.events()
+            .publish(("pausable", "admin_changed"), (current_admin, new_admin));
+    }
+
+    /// Require that the caller is the admin
+    pub fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
+
+        if *caller != admin {
+            panic_with_error!(env, PausableError::Unauthorized);
+        }
+    }
+
+    /// Require that the contract is not paused
+    pub fn require_not_paused(env: &Env) {
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+
+        if is_paused {
+            panic_with_error!(env, PausableError::ContractPaused);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/pausable/src/test.rs
+++ b/contracts/pausable/src/test.rs
@@ -1,0 +1,205 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn create_pausable_contract<'a>(env: &Env) -> (PausableContractClient<'a>, Address) {
+    let contract_id = env.register_contract(None, PausableContract);
+    let client = PausableContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    
+    client.initialize(&admin);
+    
+    (client, admin)
+}
+
+#[test]
+fn test_initialize_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, PausableContract);
+    let client = PausableContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.is_paused(), false);
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_cannot_initialize_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, PausableContract);
+    let client = PausableContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+    client.initialize(&admin);
+}
+
+#[test]
+fn test_pause_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+
+    assert_eq!(client.is_paused(), false);
+
+    client.pause(&admin);
+
+    assert_eq!(client.is_paused(), true);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_pause_already_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+
+    client.pause(&admin);
+    client.pause(&admin); // Should panic
+}
+
+#[test]
+fn test_unpause_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+
+    client.pause(&admin);
+    assert_eq!(client.is_paused(), true);
+
+    client.unpause(&admin);
+    assert_eq!(client.is_paused(), false);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_unpause_not_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+
+    client.unpause(&admin); // Should panic
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_pause_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin) = create_pausable_contract(&env);
+    let unauthorized = Address::generate(&env);
+
+    client.pause(&unauthorized); // Should panic
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_unpause_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+    let unauthorized = Address::generate(&env);
+
+    client.pause(&admin);
+    client.unpause(&unauthorized); // Should panic
+}
+
+#[test]
+fn test_set_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_set_admin_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin) = create_pausable_contract(&env);
+    let unauthorized = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&unauthorized, &new_admin); // Should panic
+}
+
+#[test]
+fn test_pause_unpause_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+
+    client.pause(&admin);
+    
+    let events = env.events().all();
+    let pause_event = events.iter().find(|e| {
+        e.topics.get(0).unwrap() == &soroban_sdk::symbol_short!("pausable")
+            && e.topics.get(1).unwrap() == &soroban_sdk::symbol_short!("paused")
+    });
+    assert!(pause_event.is_some());
+
+    client.unpause(&admin);
+    
+    let events = env.events().all();
+    let unpause_event = events.iter().find(|e| {
+        e.topics.get(0).unwrap() == &soroban_sdk::symbol_short!("pausable")
+            && e.topics.get(1).unwrap() == &soroban_sdk::symbol_short!("unpaused")
+    });
+    assert!(unpause_event.is_some());
+}
+
+#[test]
+fn test_admin_changed_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+    
+    let events = env.events().all();
+    let admin_changed_event = events.iter().find(|e| {
+        e.topics.get(0).unwrap() == &soroban_sdk::symbol_short!("pausable")
+            && e.topics.get(1).unwrap() == &soroban_sdk::symbol_short!("admin_changed")
+    });
+    assert!(admin_changed_event.is_some());
+}
+
+#[test]
+fn test_multiple_pause_unpause_cycles() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = create_pausable_contract(&env);
+
+    for _ in 0..3 {
+        client.pause(&admin);
+        assert_eq!(client.is_paused(), true);
+        
+        client.unpause(&admin);
+        assert_eq!(client.is_paused(), false);
+    }
+}

--- a/tests/pause_tests.rs
+++ b/tests/pause_tests.rs
@@ -1,0 +1,413 @@
+//! Comprehensive tests for pausable contract functionality
+//! Tests admin-only pause/unpause, event emission, and access restrictions
+
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+// Mock contract structure for testing
+mod pausable_mock {
+    use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env};
+
+    #[contracttype]
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum DataKey {
+        Admin,
+        Paused,
+    }
+
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    #[repr(u32)]
+    pub enum PausableError {
+        NotInitialized = 1,
+        Unauthorized = 2,
+        ContractPaused = 3,
+        ContractNotPaused = 4,
+    }
+
+    impl From<PausableError> for soroban_sdk::Error {
+        fn from(e: PausableError) -> Self {
+            soroban_sdk::Error::from_contract_error(e as u32)
+        }
+    }
+
+    #[contract]
+    pub struct PausableTestContract;
+
+    #[contractimpl]
+    impl PausableTestContract {
+        pub fn initialize(env: Env, admin: Address) {
+            if env.storage().instance().has(&DataKey::Admin) {
+                panic!("Contract already initialized");
+            }
+            admin.require_auth();
+            env.storage().instance().set(&DataKey::Admin, &admin);
+            env.storage().instance().set(&DataKey::Paused, &false);
+            env.events().publish(("pausable", "initialized"), admin);
+        }
+
+        pub fn pause(env: Env, caller: Address) {
+            caller.require_auth();
+            Self::require_admin(&env, &caller);
+
+            let is_paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+            if is_paused {
+                panic_with_error!(&env, PausableError::ContractPaused);
+            }
+
+            env.storage().instance().set(&DataKey::Paused, &true);
+            env.events().publish(("pausable", "paused"), caller);
+        }
+
+        pub fn unpause(env: Env, caller: Address) {
+            caller.require_auth();
+            Self::require_admin(&env, &caller);
+
+            let is_paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+            if !is_paused {
+                panic_with_error!(&env, PausableError::ContractNotPaused);
+            }
+
+            env.storage().instance().set(&DataKey::Paused, &false);
+            env.events().publish(("pausable", "unpaused"), caller);
+        }
+
+        pub fn is_paused(env: Env) -> bool {
+            env.storage().instance().get(&DataKey::Paused).unwrap_or(false)
+        }
+
+        pub fn get_admin(env: Env) -> Address {
+            env.storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .expect("Contract not initialized")
+        }
+
+        pub fn set_admin(env: Env, current_admin: Address, new_admin: Address) {
+            current_admin.require_auth();
+            Self::require_admin(&env, &current_admin);
+            env.storage().instance().set(&DataKey::Admin, &new_admin);
+            env.events()
+                .publish(("pausable", "admin_changed"), (current_admin, new_admin));
+        }
+
+        pub fn critical_operation(env: Env, caller: Address, value: i128) -> i128 {
+            caller.require_auth();
+            Self::require_not_paused(&env);
+            value * 2
+        }
+
+        fn require_admin(env: &Env, caller: &Address) {
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .expect("Contract not initialized");
+            if *caller != admin {
+                panic_with_error!(env, PausableError::Unauthorized);
+            }
+        }
+
+        fn require_not_paused(env: &Env) {
+            let is_paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+            if is_paused {
+                panic_with_error!(env, PausableError::ContractPaused);
+            }
+        }
+    }
+}
+
+use pausable_mock::{PausableTestContract, PausableTestContractClient};
+
+fn setup_contract(env: &Env) -> (PausableTestContractClient, Address) {
+    let contract_id = env.register_contract(None, PausableTestContract);
+    let client = PausableTestContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+// ===== Initialization Tests =====
+
+#[test]
+fn test_initialize_sets_admin_and_unpaused_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.is_paused(), false);
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_cannot_initialize_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+    client.initialize(&admin);
+}
+
+// ===== Pause Tests =====
+
+#[test]
+fn test_admin_can_pause_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+
+    assert_eq!(client.is_paused(), true);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_non_admin_cannot_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin) = setup_contract(&env);
+    let non_admin = Address::generate(&env);
+
+    client.pause(&non_admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_cannot_pause_already_paused_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+    client.pause(&admin);
+}
+
+// ===== Unpause Tests =====
+
+#[test]
+fn test_admin_can_unpause_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+    assert_eq!(client.is_paused(), true);
+
+    client.unpause(&admin);
+    assert_eq!(client.is_paused(), false);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_non_admin_cannot_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+    let non_admin = Address::generate(&env);
+
+    client.pause(&admin);
+    client.unpause(&non_admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_cannot_unpause_not_paused_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.unpause(&admin);
+}
+
+// ===== Critical Function Tests =====
+
+#[test]
+fn test_critical_function_works_when_not_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    let result = client.critical_operation(&admin, &100);
+    assert_eq!(result, 200);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_critical_function_blocked_when_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+    client.critical_operation(&admin, &100);
+}
+
+#[test]
+fn test_critical_function_works_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    let result = client.critical_operation(&admin, &100);
+    assert_eq!(result, 200);
+}
+
+// ===== Event Tests =====
+
+#[test]
+fn test_pause_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+
+    let events = env.events().all();
+    let pause_event = events.iter().find(|e| {
+        e.topics.get(0).unwrap() == &soroban_sdk::symbol_short!("pausable")
+            && e.topics.get(1).unwrap() == &soroban_sdk::symbol_short!("paused")
+    });
+
+    assert!(pause_event.is_some());
+}
+
+#[test]
+fn test_unpause_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    let events = env.events().all();
+    let unpause_event = events.iter().find(|e| {
+        e.topics.get(0).unwrap() == &soroban_sdk::symbol_short!("pausable")
+            && e.topics.get(1).unwrap() == &soroban_sdk::symbol_short!("unpaused")
+    });
+
+    assert!(unpause_event.is_some());
+}
+
+// ===== Admin Transfer Tests =====
+
+#[test]
+fn test_admin_can_transfer_admin_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+fn test_new_admin_can_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+    client.pause(&new_admin);
+
+    assert_eq!(client.is_paused(), true);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_old_admin_cannot_pause_after_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+    client.pause(&admin);
+}
+
+// ===== Multiple Pause/Unpause Cycles =====
+
+#[test]
+fn test_multiple_pause_unpause_cycles() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    for i in 0..5 {
+        client.pause(&admin);
+        assert_eq!(client.is_paused(), true, "Failed at cycle {}", i);
+
+        client.unpause(&admin);
+        assert_eq!(client.is_paused(), false, "Failed at cycle {}", i);
+    }
+}
+
+// ===== Edge Cases =====
+
+#[test]
+fn test_is_paused_returns_false_for_new_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin) = setup_contract(&env);
+
+    assert_eq!(client.is_paused(), false);
+}
+
+#[test]
+fn test_pause_state_persists_across_calls() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+
+    client.pause(&admin);
+
+    // Multiple checks should all return true
+    assert_eq!(client.is_paused(), true);
+    assert_eq!(client.is_paused(), true);
+    assert_eq!(client.is_paused(), true);
+}
+
+#[test]
+fn test_admin_changed_event_emitted() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_contract(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+
+    let events = env.events().all();
+    let admin_changed_event = events.iter().find(|e| {
+        e.topics.get(0).unwrap() == &soroban_sdk::symbol_short!("pausable")
+            && e.topics.get(1).unwrap() == &soroban_sdk::symbol_short!("admin_changed")
+    });
+
+    assert!(admin_changed_event.is_some());
+}


### PR DESCRIPTION
feat: add emergency pause functionality for contract-wide operations

closes #83  

Implement pausable contract with admin-only pause/unpause controls:
- Create new pausable contract module with pause state management
- Add admin authorization checks for pause/unpause operations
- Block critical functions when contract is paused
- Emit events for pause, unpause, and admin changes
- Add comprehensive test suite covering:
  - Admin-only access restrictions
  - Pause/unpause state transitions
  - Event emission verification
  - Critical function blocking when paused
  - Multiple pause/unpause cycles
  - Admin role transfer

Files added:
- contracts/pausable/src/lib.rs - Core pausable contract implementation
- contracts/pausable/src/test.rs - Unit tests for pausable module
- tests/pause_tests.rs - Integration tests for pause functionality
- contracts/pausable/Cargo.toml - Package configuration
- contracts/batch-transfer-pausable/Cargo.toml - Pausable batch transfer variant

Updated workspace configuration to include pausable contract module.
