### PR TITLE
feat(metadata): add structured metadata support for transactions

### DIFF
--- a/contracts/metadata.rs
+++ b/contracts/metadata.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use drip_sdk::prelude::*; // Replace with your DRIP framework
+
+const MAX_METADATA_SIZE: usize = 1024; // 1 KB max for metadata
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Metadata {
+    pub data: HashMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StoreMetadataMsg {
+    pub tx_id: String,
+    pub metadata: Metadata,
+}
+
+#[contract]
+impl MetadataContract {
+    #[action]
+    pub fn store_metadata(&mut self, msg: StoreMetadataMsg) -> Result<()> {
+        // Validate metadata size
+        let serialized = serde_json::to_string(&msg.metadata)?;
+        if serialized.len() > MAX_METADATA_SIZE {
+            return Err(Error::Custom("Metadata exceeds maximum size".into()));
+        }
+
+        // Optionally: Validate format keys/values
+        for (key, value) in &msg.metadata.data {
+            if key.is_empty() || value.is_empty() {
+                return Err(Error::Custom("Metadata keys and values cannot be empty".into()));
+            }
+        }
+
+        // Store metadata
+        self.metadata_storage.insert(msg.tx_id.clone(), msg.metadata.clone());
+
+        // Emit event
+        emit_event!("metadata_stored", {
+            "tx_id": msg.tx_id,
+            "size": serialized.len().to_string()
+        });
+
+        Ok(())
+    }
+
+    #[action]
+    pub fn get_metadata(&self, tx_id: String) -> Option<Metadata> {
+        self.metadata_storage.get(&tx_id).cloned()
+    }
+}

--- a/tests/metadata_tests.rs
+++ b/tests/metadata_tests.rs
@@ -1,0 +1,53 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_store_valid_metadata() {
+        let mut contract = MetadataContract::default();
+        let mut data = HashMap::new();
+        data.insert("type".to_string(), "payment".to_string());
+        data.insert("amount".to_string(), "100".to_string());
+
+        let msg = StoreMetadataMsg {
+            tx_id: "tx123".to_string(),
+            metadata: Metadata { data },
+        };
+
+        assert!(contract.store_metadata(msg.clone()).is_ok());
+
+        let retrieved = contract.get_metadata("tx123".to_string());
+        assert_eq!(retrieved.unwrap(), msg.metadata);
+    }
+
+    #[test]
+    fn test_metadata_size_limit() {
+        let mut contract = MetadataContract::default();
+
+        let mut data = HashMap::new();
+        data.insert("big".to_string(), "x".repeat(MAX_METADATA_SIZE + 1));
+
+        let msg = StoreMetadataMsg {
+            tx_id: "tx_big".to_string(),
+            metadata: Metadata { data },
+        };
+
+        let result = contract.store_metadata(msg);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_metadata_format() {
+        let mut contract = MetadataContract::default();
+
+        let mut data = HashMap::new();
+        data.insert("".to_string(), "value".to_string()); // invalid key
+
+        let msg = StoreMetadataMsg {
+            tx_id: "tx_invalid".to_string(),
+            metadata: Metadata { data },
+        };
+
+        assert!(contract.store_metadata(msg).is_err());
+    }
+}


### PR DESCRIPTION
- Store structured metadata with key-value pairs for each transaction
- Validate metadata format and enforce maximum size limit (1 KB)
- Emit `metadata_stored` events for off-chain listeners
- Add retrieval function for stored metadata
- Implement unit tests covering valid, oversized, and invalid metadata

closes #144