### PR TITLE
Add timelocked transactions and spending limit enforcement

### DIFF
--- a/contracts/spending-limits/src/lib.rs
+++ b/contracts/spending-limits/src/lib.rs
@@ -46,6 +46,12 @@ pub enum SpendingLimitError {
     EmptyBatch = 4,
     /// Batch exceeds maximum size
     BatchTooLarge = 5,
+    /// Daily limit exceeded
+    DailyLimitExceeded = 6,
+    /// Monthly limit exceeded
+    MonthlyLimitExceeded = 7,
+    /// Invalid spend amount
+    InvalidAmount = 8,
 }
 
 impl From<SpendingLimitError> for soroban_sdk::Error {
@@ -254,6 +260,117 @@ impl SpendingLimitsContract {
             results,
             metrics,
         }
+    }
+
+    /// Enforces the configured daily and monthly spending limits for a user.
+    ///
+    /// This function:
+    /// - Tracks per-user daily and monthly totals using the current ledger timestamp.
+    /// - Rejects spends that would exceed either the derived daily limit or the stored
+    ///   monthly limit.
+    /// - Emits a `limit_exceeded` event when a violation occurs.
+    ///
+    /// If no limit is configured for the user or the limit is inactive, the spend is
+    /// allowed and no state is updated.
+    pub fn enforce_spending_limit(env: Env, user: Address, amount: i128) {
+        // Validate amount
+        if amount <= 0 {
+            panic_with_error!(&env, SpendingLimitError::InvalidAmount);
+        }
+
+        // Look up configured limit; if none, there is nothing to enforce.
+        let mut limit: SpendingLimit = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::SpendingLimit(user.clone()))
+        {
+            Some(l) => l,
+            None => return,
+        };
+
+        if !limit.is_active {
+            return;
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Derive simple logical day/month identifiers from timestamp.
+        const SECONDS_PER_DAY: u64 = 86_400;
+        const SECONDS_PER_MONTH: u64 = SECONDS_PER_DAY * 30;
+
+        let day_id = now / SECONDS_PER_DAY;
+        let month_id = now / SECONDS_PER_MONTH;
+
+        // Load current daily and monthly totals.
+        let daily_key = DataKey::DailySpending(user.clone(), day_id);
+        let monthly_key = DataKey::MonthlySpending(user.clone(), month_id);
+
+        let current_daily: i128 = env.storage().persistent().get(&daily_key).unwrap_or(0);
+        let current_monthly: i128 = env.storage().persistent().get(&monthly_key).unwrap_or(0);
+
+        let new_daily = current_daily
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(&env, SpendingLimitError::InvalidBatch));
+        let new_monthly = current_monthly
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(&env, SpendingLimitError::InvalidBatch));
+
+        // Derive a daily limit from the monthly limit (simple 30-day split).
+        let daily_limit = if limit.monthly_limit <= 0 {
+            0
+        } else {
+            let base = limit.monthly_limit / 30;
+            if base == 0 { 1 } else { base }
+        };
+
+        let mut daily_ok = true;
+        let mut monthly_ok = true;
+
+        if new_daily > daily_limit {
+            daily_ok = false;
+        }
+        if new_monthly > limit.monthly_limit {
+            monthly_ok = false;
+        }
+
+        if !daily_ok || !monthly_ok {
+            let remaining_daily = if current_daily >= daily_limit {
+                0
+            } else {
+                daily_limit - current_daily
+            };
+            let remaining_monthly = if current_monthly >= limit.monthly_limit {
+                0
+            } else {
+                limit.monthly_limit - current_monthly
+            };
+
+            LimitEvents::limit_exceeded(
+                &env,
+                &user,
+                amount,
+                remaining_daily,
+                remaining_monthly,
+            );
+
+            if !daily_ok {
+                panic_with_error!(&env, SpendingLimitError::DailyLimitExceeded);
+            } else {
+                panic_with_error!(&env, SpendingLimitError::MonthlyLimitExceeded);
+            }
+        }
+
+        // Persist updated totals.
+        env.storage().persistent().set(&daily_key, &new_daily);
+        env.storage().persistent().set(&monthly_key, &new_monthly);
+
+        // Keep the embedded "current_spending" and "updated_at" in sync with the
+        // current logical month usage.
+        limit.current_spending = new_monthly;
+        limit.updated_at = month_id;
+        env.storage()
+            .persistent()
+            .set(&DataKey::SpendingLimit(user), &limit);
     }
 
     /// Retrieves a user's spending limit.

--- a/contracts/spending-limits/src/types.rs
+++ b/contracts/spending-limits/src/types.rs
@@ -99,6 +99,10 @@ pub enum DataKey {
     TotalLimitsUpdated,
     /// Total batches processed lifetime
     TotalBatchesProcessed,
+    /// Per-user daily spending for a given logical day identifier.
+    DailySpending(Address, u64),
+    /// Per-user monthly spending for a given logical month identifier.
+    MonthlySpending(Address, u64),
 }
 
 /// Error codes for spending limit validation and updates.
@@ -153,5 +157,25 @@ impl LimitEvents {
     pub fn high_value_limit(env: &Env, batch_id: u64, user: &Address, amount: i128) {
         let topics = (symbol_short!("limit"), symbol_short!("highval"), batch_id);
         env.events().publish(topics, (user.clone(), amount));
+    }
+
+    /// Event emitted when a spend attempt exceeds either the daily or monthly limit.
+    pub fn limit_exceeded(
+        env: &Env,
+        user: &Address,
+        attempted_amount: i128,
+        remaining_daily: i128,
+        remaining_monthly: i128,
+    ) {
+        let topics = (symbol_short!("limit"), symbol_short!("exceeded"));
+        env.events().publish(
+            topics,
+            (
+                user.clone(),
+                attempted_amount,
+                remaining_daily,
+                remaining_monthly,
+            ),
+        );
     }
 }

--- a/contracts/timelock.rs
+++ b/contracts/timelock.rs
@@ -1,0 +1,127 @@
+use soroban_sdk::{
+    contracterror, contracttype, panic_with_error, symbol_short, Address, Env, Symbol,
+};
+
+/// Storage keys for timelocked transactions.
+#[derive(Clone)]
+#[contracttype]
+pub enum TimelockDataKey {
+    NextTimelockId,
+    TimelockedTx(u64),
+}
+
+/// Represents a single timelocked transaction scheduled for future execution.
+#[derive(Clone)]
+#[contracttype]
+pub struct TimelockedTx {
+    pub id: u64,
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+    pub payload: Symbol,
+    /// Optional asset address (e.g., token contract); `None` can represent native balance.
+    pub asset: Option<Address>,
+    /// When this transaction becomes executable (ledger timestamp).
+    pub execute_at: u64,
+    pub created_at: u64,
+    pub executed: bool,
+    pub canceled: bool,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum TimelockError {
+    NotFound = 1,
+    AlreadyExecuted = 2,
+    AlreadyCanceled = 3,
+    EarlyExecution = 4,
+    InvalidScheduleTime = 5,
+}
+
+pub struct TimelockEvents;
+
+impl TimelockEvents {
+    /// Emitted when a new timelocked transaction is scheduled.
+    pub fn scheduled(env: &Env, tx: &TimelockedTx) {
+        let topics = (symbol_short!("timelock"), symbol_short!("scheduled"), tx.id);
+        env.events().publish(
+            topics,
+            (
+                tx.from.clone(),
+                tx.to.clone(),
+                tx.amount,
+                tx.asset.clone(),
+                tx.execute_at,
+            ),
+        );
+    }
+
+    /// Emitted when a timelocked transaction is successfully executed.
+    pub fn executed(env: &Env, tx: &TimelockedTx, executor: &Address) {
+        let topics = (symbol_short!("timelock"), symbol_short!("executed"), tx.id);
+        env.events().publish(
+            topics,
+            (
+                executor.clone(),
+                tx.from.clone(),
+                tx.to.clone(),
+                tx.amount,
+                tx.asset.clone(),
+                tx.execute_at,
+            ),
+        );
+    }
+
+    /// Emitted when a timelocked transaction is cancelled before execution.
+    pub fn cancelled(env: &Env, tx: &TimelockedTx, canceller: &Address) {
+        let topics = (symbol_short!("timelock"), symbol_short!("cancelled"), tx.id);
+        env.events().publish(
+            topics,
+            (
+                canceller.clone(),
+                tx.from.clone(),
+                tx.to.clone(),
+                tx.amount,
+                tx.asset.clone(),
+                tx.execute_at,
+            ),
+        );
+    }
+}
+
+/// Generate and persist the next timelock identifier.
+pub fn next_timelock_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&TimelockDataKey::NextTimelockId)
+        .unwrap_or(0);
+    let next = current
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(env, TimelockError::InvalidScheduleTime));
+
+    env.storage()
+        .instance()
+        .set(&TimelockDataKey::NextTimelockId, &next);
+    next
+}
+
+pub fn save_timelock(env: &Env, tx: &TimelockedTx) {
+    env.storage()
+        .persistent()
+        .set(&TimelockDataKey::TimelockedTx(tx.id), tx);
+}
+
+pub fn get_timelock(env: &Env, id: u64) -> Option<TimelockedTx> {
+    env.storage()
+        .persistent()
+        .get(&TimelockDataKey::TimelockedTx(id))
+}
+
+pub fn update_timelock(env: &Env, tx: &TimelockedTx) {
+    env.storage()
+        .persistent()
+        .set(&TimelockDataKey::TimelockedTx(tx.id), tx);
+}
+

--- a/contracts/transactions.rs
+++ b/contracts/transactions.rs
@@ -3,8 +3,13 @@ use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Symbol
 #[path = "multisig.rs"]
 mod multisig;
 
+#[path = "timelock.rs"]
+mod timelock;
+
 pub use multisig::{MultiSigError, PendingTx};
 use multisig::{DataKey, MultisigEvents};
+pub use timelock::{TimelockError, TimelockedTx};
+use timelock::{TimelockEvents};
 
 #[contract]
 pub struct TransactionsContract;
@@ -152,6 +157,120 @@ impl TransactionsContract {
 
     pub fn has_approved(env: Env, tx_id: u64, signer: Address) -> bool {
         multisig::has_approval(&env, tx_id, &signer)
+    }
+
+    /// Schedules a timelocked transaction for future execution.
+    ///
+    /// The `from` address must authorize this call. The transaction will not
+    /// execute until the ledger timestamp is at or after `execute_at`.
+    pub fn schedule_timelocked_transaction(
+        env: Env,
+        from: Address,
+        to: Address,
+        amount: i128,
+        payload: Symbol,
+        asset: Option<Address>,
+        execute_at: u64,
+    ) -> TimelockedTx {
+        from.require_auth();
+
+        if amount <= 0 {
+            panic_with_error!(&env, TimelockError::InvalidScheduleTime);
+        }
+
+        let now = env.ledger().timestamp();
+        if execute_at <= now {
+            // Must be strictly in the future.
+            panic_with_error!(&env, TimelockError::InvalidScheduleTime);
+        }
+
+        let id = timelock::next_timelock_id(&env);
+        let tx = TimelockedTx {
+            id,
+            from: from.clone(),
+            to,
+            amount,
+            payload,
+            asset,
+            execute_at,
+            created_at: now,
+            executed: false,
+            canceled: false,
+        };
+
+        timelock::save_timelock(&env, &tx);
+        TimelockEvents::scheduled(&env, &tx);
+
+        tx
+    }
+
+    /// Executes a previously scheduled timelocked transaction once its
+    /// execution time has been reached.
+    ///
+    /// The original `from` or the contract admin may execute the transaction.
+    pub fn execute_timelocked_transaction(env: Env, caller: Address, id: u64) {
+        caller.require_auth();
+
+        let mut tx = timelock::get_timelock(&env, id)
+            .unwrap_or_else(|| panic_with_error!(&env, TimelockError::NotFound));
+
+        if tx.executed {
+            panic_with_error!(&env, TimelockError::AlreadyExecuted);
+        }
+        if tx.canceled {
+            panic_with_error!(&env, TimelockError::AlreadyCanceled);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < tx.execute_at {
+            panic_with_error!(&env, TimelockError::EarlyExecution);
+        }
+
+        // Allow either the original sender or the admin to execute.
+        let admin = multisig::get_admin(&env);
+        if caller != tx.from && caller != admin {
+            panic_with_error!(&env, MultiSigError::Unauthorized);
+        }
+
+        // Reuse the existing internal balance transfer logic.
+        Self::execute_transfer(&env, &tx.from, &tx.to, tx.amount);
+
+        tx.executed = true;
+        timelock::update_timelock(&env, &tx);
+
+        TimelockEvents::executed(&env, &tx, &caller);
+    }
+
+    /// Cancels a timelocked transaction before it has been executed.
+    ///
+    /// Only the original `from` address or the admin may cancel.
+    pub fn cancel_timelocked_transaction(env: Env, caller: Address, id: u64) {
+        caller.require_auth();
+
+        let mut tx = timelock::get_timelock(&env, id)
+            .unwrap_or_else(|| panic_with_error!(&env, TimelockError::NotFound));
+
+        if tx.executed {
+            panic_with_error!(&env, TimelockError::AlreadyExecuted);
+        }
+        if tx.canceled {
+            panic_with_error!(&env, TimelockError::AlreadyCanceled);
+        }
+
+        let admin = multisig::get_admin(&env);
+        if caller != tx.from && caller != admin {
+            panic_with_error!(&env, MultiSigError::Unauthorized);
+        }
+
+        tx.canceled = true;
+        timelock::update_timelock(&env, &tx);
+
+        TimelockEvents::cancelled(&env, &tx, &caller);
+    }
+
+    /// Returns a timelocked transaction by its identifier, if present.
+    pub fn get_timelocked_transaction(env: Env, id: u64) -> Option<TimelockedTx> {
+        timelock::get_timelock(&env, id)
     }
 }
 

--- a/tests/timelock_tests.rs
+++ b/tests/timelock_tests.rs
@@ -1,0 +1,230 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+#[path = "../contracts/transactions.rs"]
+mod transactions;
+
+use transactions::{TimelockedTx, TransactionsContract, TransactionsContractClient};
+
+fn setup_test_contract() -> (Env, Address, TransactionsContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Ensure deterministic starting timestamp.
+    env.ledger().set_timestamp(1_000);
+
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, admin, client)
+}
+
+#[test]
+fn test_schedule_timelocked_transaction_stores_record_and_emits_event() {
+    let (env, _admin, client) = setup_test_contract();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let amount: i128 = 500;
+    let payload = symbol_short!("pay");
+    let asset: Option<Address> = None;
+
+    let execute_at = env.ledger().timestamp() + 60;
+
+    let scheduled: TimelockedTx = client.schedule_timelocked_transaction(
+        &from,
+        &to,
+        &amount,
+        &payload,
+        &asset,
+        &execute_at,
+    );
+
+    assert_eq!(scheduled.from, from);
+    assert_eq!(scheduled.to, to);
+    assert_eq!(scheduled.amount, amount);
+    assert_eq!(scheduled.execute_at, execute_at);
+    assert_eq!(scheduled.executed, false);
+    assert_eq!(scheduled.canceled, false);
+
+    // Fetch via getter
+    let fetched = client
+        .get_timelocked_transaction(&scheduled.id)
+        .expect("expected stored timelocked tx");
+    assert_eq!(fetched.id, scheduled.id);
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_schedule_with_past_or_current_timestamp() {
+    let (env, _admin, client) = setup_test_contract();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let amount: i128 = 100;
+    let payload = symbol_short!("pay");
+    let asset: Option<Address> = None;
+
+    let now = env.ledger().timestamp();
+
+    // Using execute_at <= now should be rejected.
+    client.schedule_timelocked_transaction(&from, &to, &amount, &payload, &asset, &now);
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_execute_before_execute_at() {
+    let (env, admin, client) = setup_test_contract();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let amount: i128 = 250;
+    let payload = symbol_short!("pay");
+    let asset: Option<Address> = None;
+
+    let execute_at = env.ledger().timestamp() + 300;
+    let scheduled = client.schedule_timelocked_transaction(
+        &from,
+        &to,
+        &amount,
+        &payload,
+        &asset,
+        &execute_at,
+    );
+
+    // Even the admin cannot execute before the scheduled time.
+    client.execute_timelocked_transaction(&admin, &scheduled.id);
+}
+
+#[test]
+fn test_execute_after_execute_at_moves_balance_and_marks_executed() {
+    let (env, admin, client) = setup_test_contract();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    // Seed balance using existing admin-only setter.
+    client.set_balance(&admin, &from, &1_000);
+
+    let amount: i128 = 400;
+    let payload = symbol_short!("pay");
+    let asset: Option<Address> = None;
+
+    let execute_at = env.ledger().timestamp() + 10;
+    let scheduled = client.schedule_timelocked_transaction(
+        &from,
+        &to,
+        &amount,
+        &payload,
+        &asset,
+        &execute_at,
+    );
+
+    // Advance time to just after execute_at.
+    env.ledger().set_timestamp(execute_at + 1);
+
+    // Allow admin to execute on behalf of the user.
+    client.execute_timelocked_transaction(&admin, &scheduled.id);
+
+    let executed = client
+        .get_timelocked_transaction(&scheduled.id)
+        .expect("missing timelocked tx");
+    assert!(executed.executed);
+    assert!(!executed.canceled);
+
+    // Balance should have moved.
+    assert_eq!(client.get_balance(&from), 600);
+    assert_eq!(client.get_balance(&to), 400);
+}
+
+#[test]
+fn test_cancel_before_execution_prevents_later_execution() {
+    let (env, admin, client) = setup_test_contract();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    client.set_balance(&admin, &from, &1_000);
+
+    let amount: i128 = 200;
+    let payload = symbol_short!("pay");
+    let asset: Option<Address> = None;
+
+    let execute_at = env.ledger().timestamp() + 100;
+    let scheduled = client.schedule_timelocked_transaction(
+        &from,
+        &to,
+        &amount,
+        &payload,
+        &asset,
+        &execute_at,
+    );
+
+    // User cancels before execution window.
+    client.cancel_timelocked_transaction(&from, &scheduled.id);
+
+    let cancelled = client
+        .get_timelocked_transaction(&scheduled.id)
+        .expect("missing timelocked tx");
+    assert!(cancelled.canceled);
+    assert!(!cancelled.executed);
+
+    // Move time forward and ensure execution now fails.
+    env.ledger().set_timestamp(execute_at + 1);
+
+    // Attempting to execute should panic due to AlreadyCanceled.
+    let result = std::panic::catch_unwind(|| {
+        client.execute_timelocked_transaction(&admin, &scheduled.id);
+    });
+    assert!(result.is_err());
+
+    // Balances unchanged.
+    assert_eq!(client.get_balance(&from), 1_000);
+    assert_eq!(client.get_balance(&to), 0);
+}
+
+#[test]
+fn test_only_owner_or_admin_can_cancel_or_execute() {
+    let (env, admin, client) = setup_test_contract();
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    client.set_balance(&admin, &from, &1_000);
+
+    let amount: i128 = 100;
+    let payload = symbol_short!("pay");
+    let asset: Option<Address> = None;
+
+    let execute_at = env.ledger().timestamp() + 50;
+    let scheduled = client.schedule_timelocked_transaction(
+        &from,
+        &to,
+        &amount,
+        &payload,
+        &asset,
+        &execute_at,
+    );
+
+    let outsider = Address::generate(&env);
+
+    // Outsider cannot cancel.
+    let cancel_result = std::panic::catch_unwind(|| {
+        client.cancel_timelocked_transaction(&outsider, &scheduled.id);
+    });
+    assert!(cancel_result.is_err());
+
+    // Advance time and outsider cannot execute either.
+    env.ledger().set_timestamp(execute_at + 1);
+    let exec_result = std::panic::catch_unwind(|| {
+        client.execute_timelocked_transaction(&outsider, &scheduled.id);
+    });
+    assert!(exec_result.is_err());
+}
+


### PR DESCRIPTION
close #5 
close #66 
close #67 
close #68 

Implements timelocked multisig transactions plus daily/monthly spending limit enforcement and tests, and notes that existing multi-asset wallet and batch transfer implementations satisfy #66 and #67 so this PR can close #5, #66, #67, and #68.