### PR TITLE
Validate and store structured memos for transactions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,19 @@ members = [
     "contracts/category-analytics",
 ]
 
+[package]
+name = "stellarspend-contracts-tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[test]]
+name = "memo_tests"
+path = "tests/memo_tests.rs"
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"

--- a/contracts/memo.rs
+++ b/contracts/memo.rs
@@ -1,0 +1,176 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, contracterror, panic_with_error, symbol_short,
+    Address, Bytes, Env, Symbol, String,
+};
+
+const MAX_MEMO_TYPE_LEN: u32 = 32;
+const MAX_REFERENCE_LEN: u32 = 64;
+const MAX_TEXT_LEN: u32 = 256;
+const MAX_TOTAL_MEMO_BYTES: u32 = 320;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum MemoError {
+    NotInitialized = 1,
+    Unauthorized = 2,
+    InvalidMemoType = 3,
+    InvalidReference = 4,
+    InvalidText = 5,
+    MemoTooLarge = 6,
+    MalformedMetadata = 7,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Memo {
+    pub memo_type: Symbol,
+    pub reference: String,
+    pub text: String,
+    pub created_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    Admin,
+    MaxMemoTypeLen,
+    MaxReferenceLen,
+    MaxTextLen,
+    Memo(Bytes),
+}
+
+#[contract]
+pub struct MemoContract;
+
+#[contractimpl]
+impl MemoContract {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        max_memo_type_len: u32,
+        max_reference_len: u32,
+        max_text_len: u32,
+    ) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, MemoError::MalformedMetadata);
+        }
+        admin.require_auth();
+        if max_memo_type_len == 0 || max_text_len == 0 {
+            panic_with_error!(&env, MemoError::MalformedMetadata);
+        }
+        if max_memo_type_len > 64 || max_reference_len > 128 || max_text_len > 1024 {
+            panic_with_error!(&env, MemoError::MemoTooLarge);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::MaxMemoTypeLen, &max_memo_type_len);
+        env.storage().instance().set(&DataKey::MaxReferenceLen, &max_reference_len);
+        env.storage().instance().set(&DataKey::MaxTextLen, &max_text_len);
+        env.events().publish(
+            (symbol_short!("memo"), symbol_short!("init")),
+            (admin, max_memo_type_len, max_reference_len, max_text_len),
+        );
+    }
+
+    pub fn set_memo(
+        env: Env,
+        caller: Address,
+        transaction_id: Bytes,
+        memo_type: Symbol,
+        reference: String,
+        text: String,
+    ) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+        Self::validate_memo(&env, &memo_type, &reference, &text);
+        let created_at = env.ledger().timestamp();
+        let memo = Memo {
+            memo_type: memo_type.clone(),
+            reference: reference.clone(),
+            text: text.clone(),
+            created_at,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Memo(transaction_id.clone()), &memo);
+        env.events().publish(
+            (symbol_short!("memo"), symbol_short!("stored")),
+            (transaction_id, memo_type, created_at),
+        );
+    }
+
+    pub fn get_memo(env: Env, transaction_id: Bytes) -> Option<Memo> {
+        env.storage().persistent().get(&DataKey::Memo(transaction_id))
+    }
+
+    pub fn get_admin(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::Admin)
+    }
+
+    pub fn get_limits(
+        env: Env,
+    ) -> Option<(u32, u32, u32)> {
+        let a = env.storage().instance().get(&DataKey::MaxMemoTypeLen)?;
+        let b = env.storage().instance().get(&DataKey::MaxReferenceLen)?;
+        let c = env.storage().instance().get(&DataKey::MaxTextLen)?;
+        Some((a, b, c))
+    }
+
+    fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, MemoError::NotInitialized));
+        if caller != &admin {
+            panic_with_error!(env, MemoError::Unauthorized);
+        }
+    }
+
+    fn validate_memo(
+        env: &Env,
+        memo_type: &Symbol,
+        reference: &String,
+        text: &String,
+    ) {
+        let max_type: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxMemoTypeLen)
+            .unwrap_or(MAX_MEMO_TYPE_LEN);
+        let max_ref: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxReferenceLen)
+            .unwrap_or(MAX_REFERENCE_LEN);
+        let max_text: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxTextLen)
+            .unwrap_or(MAX_TEXT_LEN);
+
+        let type_str = memo_type.to_string();
+        if type_str.len() == 0 {
+            panic_with_error!(env, MemoError::InvalidMemoType);
+        }
+        if type_str.len() as u32 > max_type {
+            panic_with_error!(env, MemoError::MemoTooLarge);
+        }
+        if reference.len() as u32 > max_ref {
+            panic_with_error!(env, MemoError::InvalidReference);
+        }
+        if text.len() == 0 {
+            panic_with_error!(env, MemoError::InvalidText);
+        }
+        if text.len() as u32 > max_text {
+            panic_with_error!(env, MemoError::MemoTooLarge);
+        }
+
+        let total: u32 = type_str.len() as u32 + reference.len() as u32 + text.len() as u32;
+        if total > MAX_TOTAL_MEMO_BYTES {
+            panic_with_error!(env, MemoError::MemoTooLarge);
+        }
+    }
+}

--- a/tests/memo_tests.rs
+++ b/tests/memo_tests.rs
@@ -1,0 +1,170 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Bytes, Env, Symbol, String,
+};
+
+#[path = "../contracts/memo.rs"]
+mod memo;
+
+use memo::{MemoContract, MemoContractClient};
+
+fn setup_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: 1_700_000_000,
+        protocol_version: 22,
+        sequence_number: 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 4096,
+        max_entry_ttl: 6_312_000,
+    });
+    env
+}
+
+fn deploy(env: &Env) -> (MemoContractClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let contract_id = env.register(MemoContract, ());
+    let client = MemoContractClient::new(env, &contract_id);
+    (client, admin)
+}
+
+fn tx_id(env: &Env, s: &str) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(s.as_bytes());
+    b
+}
+
+#[test]
+fn test_initialize() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+    let limits = client.get_limits().unwrap();
+    assert_eq!(limits.0, 32);
+    assert_eq!(limits.1, 64);
+    assert_eq!(limits.2, 256);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_double_initialize_fails() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    client.initialize(&admin, &16_u32, &32_u32, &128_u32);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_initialize_zero_memo_type_len_fails() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &0_u32, &64_u32, &256_u32);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_initialize_excessive_limits_fail() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &100_u32, &64_u32, &256_u32);
+}
+
+#[test]
+fn test_set_and_get_memo() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    let id = tx_id(&env, "tx-1");
+    let memo_type = Symbol::new(&env, "payment");
+    let reference = String::from_str(&env, "ref-123");
+    let text = String::from_str(&env, "Payment for services");
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+    let memo = client.get_memo(&id).unwrap();
+    assert_eq!(memo.memo_type, memo_type);
+    assert_eq!(memo.reference, reference);
+    assert_eq!(memo.text, text);
+    assert_eq!(memo.created_at, 1_700_000_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_set_memo_empty_type_fails() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    let id = tx_id(&env, "tx-2");
+    let memo_type = Symbol::new(&env, "");
+    let reference = String::from_str(&env, "");
+    let text = String::from_str(&env, "Some text");
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_set_memo_empty_text_fails() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    let id = tx_id(&env, "tx-3");
+    let memo_type = Symbol::new(&env, "note");
+    let reference = String::from_str(&env, "");
+    let text = String::from_str(&env, "");
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_set_memo_unauthorized() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    let other = Address::generate(&env);
+    let id = tx_id(&env, "tx-4");
+    let memo_type = Symbol::new(&env, "payment");
+    let reference = String::from_str(&env, "");
+    let text = String::from_str(&env, "Text");
+    client.set_memo(&other, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+fn test_get_memo_none_for_unknown_tx() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &256_u32);
+    let id = tx_id(&env, "nonexistent");
+    assert!(client.get_memo(&id).is_none());
+}
+
+#[test]
+fn test_memo_respects_configured_limits() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &8_u32, &4_u32, &16_u32);
+    let id = tx_id(&env, "tx-5");
+    let memo_type = Symbol::new(&env, "refund");
+    let reference = String::from_str(&env, "r1");
+    let text = String::from_str(&env, "Refund issued");
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+    let memo = client.get_memo(&id).unwrap();
+    assert_eq!(memo.text, String::from_str(&env, "Refund issued"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_memo_text_over_limit_fails() {
+    let env = setup_env();
+    let (client, admin) = deploy(&env);
+    client.initialize(&admin, &32_u32, &64_u32, &10_u32);
+    let id = tx_id(&env, "tx-6");
+    let memo_type = Symbol::new(&env, "x");
+    let reference = String::from_str(&env, "");
+    let text = String::from_str(&env, "way too long text");
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}


### PR DESCRIPTION
# Validate and store structured memos for transactions

## Description

Adds validation and storage for structured transaction memos with a defined schema, size limits, and validation to prevent malformed metadata.

## Requirements addressed

- **Define memo schema** — `Memo` struct: `memo_type` (Symbol), `reference` (String), `text` (String), `created_at` (u64). Stored by `transaction_id` (Bytes).
- **Limit memo size** — Configurable max lengths for type, reference, and text at init; default caps (32 / 64 / 256 bytes) and a total memo cap (320 bytes). Init rejects limits above 64 / 128 / 1024.
- **Prevent malformed metadata** — Non-empty `memo_type` and `text`; all lengths checked against configured limits; invalid init config (e.g. zero type/text limit, excessive limits) rejected with `MemoError`.
- **Emit memo events** — `(memo, init)` on initialize with admin and limits; `(memo, stored)` on `set_memo` with `(transaction_id, memo_type, created_at)`.
- **Add validation tests** — 11 tests in `tests/memo_tests.rs` covering init, set/get, and validation failures.

## Files changed

| File | Change |
|------|--------|
| `contracts/memo.rs` | New contract: `initialize`, `set_memo`, `get_memo`, `get_admin`, `get_limits`; memo schema, size limits, validation, events. |
| `tests/memo_tests.rs` | New test suite: init (incl. double-init and invalid config), set/get memo, empty type/text, unauthorized, unknown tx, configured limits, text over limit. |
| `Cargo.toml` | Root package and `[[test]]` for `memo_tests` so integration tests can be run. |

## How to test

cargo test --test memo_tests


closes #155 