### PR TITLE
chore(ci): Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![CI Status](https://github.com/stellarspend/stellarspend-contracts/actions/workflows/contract-ci.yml/badge.svg)](https://github.com/stellarspend/stellarspend-contracts/actions/workflows/contract-ci.yml)
 # stellarspend-contracts
 Soroban smart contracts for automated budgets, savings goals, and spending limits on Stellar
 Smart contracts powering StellarSpend financial logic on the Stellar blockchain using Soroban.


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions status badge to the top of the `README.md` file to provide an immediate visual indicator of build health for contributors and external reviewers. 

Fixes #168 

## Changes Made
* Added the standard markdown status badge for the `contract-ci.yml` workflow to the README.
* Configured the badge URL to dynamically reflect the latest workflow status (passing/failing).

## How to Test
1. Navigate to the main repository page on this branch.
2. Observe the new CI badge at the top of the README.
3. Trigger the `contract-ci.yml` workflow and confirm the badge updates automatically upon completion.