### PR TITLE
feat(contract): add admin module with get_admin function

### DIFF
--- a/contracts/admin/admin_contract.rs
+++ b/contracts/admin/admin_contract.rs
@@ -1,0 +1,21 @@
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+use crate::{ContractUtils, DataKey};
+
+#[contract]
+pub struct AdminContract;
+
+#[contractimpl]
+impl AdminContract {
+    /// Initialize contract with admin
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Retrieve the stored admin address
+    ///
+    /// This function does not require authentication.
+    pub fn get_admin(env: Env) -> Address {
+        ContractUtils::get_admin(&env)
+    }
+}

--- a/contracts/admin/mod.rs
+++ b/contracts/admin/mod.rs
@@ -1,0 +1,11 @@
+use soroban_sdk::{Address, Env};
+
+mod storage;
+
+pub fn initialize_admin(env: &Env, admin: &Address) {
+    storage::set_admin(env, admin);
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    storage::get_admin(env)
+}

--- a/contracts/admin/storage.rs
+++ b/contracts/admin/storage.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+const ADMIN_KEY: Symbol = Symbol::short("ADMIN");
+
+pub fn set_admin(env: &Env, admin: &Address) {
+    env.storage().instance().set(&ADMIN_KEY, admin);
+}
+
+pub fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .instance()
+        .get(&ADMIN_KEY)
+        .expect("Admin not initialized")
+}


### PR DESCRIPTION
- Create admin module for admin-related contract logic
- Implement initialize() to store admin address
- Implement get_admin() to retrieve stored admin
- Reuse ContractUtils storage helper

closes #172 