### PR TITLE
Implemented per-user fee overrides in the fee contract

### DIFF
--- a/contracts/contract-upgrade/new_contract/Cargo.toml
+++ b/contracts/contract-upgrade/new_contract/Cargo.toml
@@ -8,12 +8,12 @@ rust-version = "1.89.0"
 [lib]
 crate-type = ["cdylib", "rlib"]
 doctest = false
-// handle hash
+
 [dependencies]
-soroban-sdk = { version = "23.0.1" }
+soroban-sdk = { version = "22.0.0" }
 
 [dev-dependencies]
-soroban-sdk = { version = "23.0.1", features = ["testutils"] }
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Batch escrow reversal contract for StellarSpend"
-handle hash
+
 [lib]
 crate-type = ["cdylib"]
 doctest = false

--- a/contracts/fee/src/decay.rs
+++ b/contracts/fee/src/decay.rs
@@ -13,7 +13,7 @@ pub fn calculate_fee_decay(
     if current_time <= last_active {
         return base_fee;
     }
-handle hash
+
     let time_elapsed = (current_time - last_active) as i128;
     
     // decay = time_elapsed * decay_rate

--- a/contracts/fee/src/lib.rs
+++ b/contracts/fee/src/lib.rs
@@ -12,15 +12,11 @@ use crate::escrow::{
     collect_batch_to_escrow, collect_to_escrow, release_cycle_fees, rollover_cycle_fees,
 };
 use crate::storage::{
-    has_admin, read_admin, read_current_cycle, read_escrow_balance, read_fee_bps, read_locked,
-    read_min_fee, read_pending_fees, read_token, read_total_batch_calls, read_total_collected,
-    read_total_released, read_treasury, write_admin, write_current_cycle, write_fee_bps,
-    write_locked, write_min_fee, write_token, write_treasury,
     has_admin, read_admin, read_current_cycle, read_escrow_balance, read_fee_bps, read_last_active,
-		read_locked, read_min_fee, read_pending_fees, read_token, read_total_batch_calls,
-		read_total_collected, read_total_released, read_treasury, write_admin,
-		write_current_cycle, write_fee_bps, write_last_active, write_locked, write_min_fee,
-		write_token, write_treasury,
+    read_locked, read_min_fee, read_pending_fees, read_token, read_total_batch_calls,
+    read_total_collected, read_total_released, read_treasury, read_user_fee_override,
+    remove_user_fee_override, write_admin, write_current_cycle, write_fee_bps, write_last_active,
+    write_locked, write_min_fee, write_token, write_treasury, write_user_fee_override,
 };
 pub use crate::storage::{BatchFeeResult, DataKey, MAX_BATCH_SIZE, MAX_FEE_BPS};
 use crate::validation::{validate_fee_bps_or_panic, validate_min_fee_or_panic};
@@ -104,6 +100,18 @@ impl FeeEvents {
         let topics = (symbol_short!("fee"), symbol_short!("config"));
         env.events()
             .publish(topics, (symbol_short!("min_fee"), min_fee));
+    }
+
+    pub fn user_fee_override_set(env: &Env, user: &Address, fee_bps: u32) {
+        let topics = (symbol_short!("fee"), symbol_short!("override"));
+        env.events()
+            .publish(topics, (symbol_short!("set"), user.clone(), fee_bps));
+    }
+
+    pub fn user_fee_override_removed(env: &Env, user: &Address) {
+        let topics = (symbol_short!("fee"), symbol_short!("override"));
+        env.events()
+            .publish(topics, (symbol_short!("remove"), user.clone()));
     }
 }
 
@@ -349,6 +357,56 @@ impl FeeContract {
                 .unwrap_or_else(|| panic_with_error!(&env, FeeContractError::Overflow));
         }
         total
+    }
+
+    /// Calculate the fee for a given amount, checking user-specific overrides first.
+    /// If a user has an override, it takes precedence over the global fee_bps.
+    pub fn calculate_fee(env: Env, user: Address, amount: i128) -> i128 {
+        if amount <= 0 {
+            panic_with_error!(&env, FeeContractError::InvalidAmount);
+        }
+
+        let fee_bps = read_user_fee_override(&env, &user).unwrap_or_else(|| read_fee_bps(&env));
+
+        let min_fee = read_min_fee(&env);
+        let raw_fee = amount
+            .checked_mul(fee_bps as i128)
+            .unwrap_or_else(|| panic_with_error!(&env, FeeContractError::Overflow))
+            .checked_div(10_000)
+            .unwrap_or_else(|| panic_with_error!(&env, FeeContractError::Overflow));
+
+        if raw_fee < min_fee {
+            min_fee
+        } else {
+            raw_fee
+        }
+    }
+
+    /// Set a user-specific fee override. Only admin can call.
+    pub fn set_user_fee_override(env: Env, admin: Address, user: Address, fee_bps: u32) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        Self::require_unlocked(&env);
+
+        validate_fee_bps_or_panic(&env, fee_bps);
+
+        write_user_fee_override(&env, &user, fee_bps);
+        FeeEvents::user_fee_override_set(&env, &user, fee_bps);
+    }
+
+    /// Remove a user-specific fee override. Only admin can call.
+    pub fn remove_user_fee_override(env: Env, admin: Address, user: Address) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        Self::require_unlocked(&env);
+
+        remove_user_fee_override(&env, &user);
+        FeeEvents::user_fee_override_removed(&env, &user);
+    }
+
+    /// Get the effective fee rate for a user (override if exists, otherwise global).
+    pub fn get_user_fee_bps(env: Env, user: Address) -> u32 {
+        read_user_fee_override(&env, &user).unwrap_or_else(|| read_fee_bps(&env))
     }
 
     /// Validate a configuration tuple. Returns true or panics on invalid inputs.

--- a/contracts/fee/src/storage.rs
+++ b/contracts/fee/src/storage.rs
@@ -28,6 +28,7 @@ pub enum DataKey {
     TotalBatchCalls,
     PendingFees(u64),
     UserActivity(Address),
+    UserFeeOverride(Address),
 }
 
 pub fn has_admin(env: &Env) -> bool {
@@ -210,4 +211,22 @@ pub fn write_last_active(env: &Env, user: &Address, timestamp: u64) {
     env.storage()
         .persistent()
         .set(&DataKey::UserActivity(user.clone()), &timestamp);
+}
+
+pub fn read_user_fee_override(env: &Env, user: &Address) -> Option<u32> {
+    env.storage()
+        .instance()
+        .get(&DataKey::UserFeeOverride(user.clone()))
+}
+
+pub fn write_user_fee_override(env: &Env, user: &Address, fee_bps: u32) {
+    env.storage()
+        .instance()
+        .set(&DataKey::UserFeeOverride(user.clone()), &fee_bps);
+}
+
+pub fn remove_user_fee_override(env: &Env, user: &Address) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::UserFeeOverride(user.clone()));
 }

--- a/contracts/fee/src/validation.rs
+++ b/contracts/fee/src/validation.rs
@@ -12,7 +12,7 @@ pub fn validate_fee_bps_or_panic(env: &Env, fee_bps: u32) -> bool {
     }
     true
 }
-handle hash
+
 /// Validate minimum fee is non-negative.
 /// Panics with InvalidConfig on failure. Returns true on success.
 pub fn validate_min_fee_or_panic(env: &Env, min_fee: i128) -> bool {

--- a/contracts/fee/test_snapshots/batch_collection_aggregates_fee_inputs_with_one_state_update.1.json
+++ b/contracts/fee/test_snapshots/batch_collection_aggregates_fee_inputs_with_one_state_update.1.json
@@ -284,6 +284,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "UserActivity"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "UserActivity"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/contracts/fee/test_snapshots/fees_are_held_then_released_from_escrow.1.json
+++ b/contracts/fee/test_snapshots/fees_are_held_then_released_from_escrow.1.json
@@ -291,6 +291,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "UserActivity"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "UserActivity"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/contracts/fee/test_snapshots/pending_fees_roll_over_between_cycles_without_duplication.1.json
+++ b/contracts/fee/test_snapshots/pending_fees_roll_over_between_cycles_without_duplication.1.json
@@ -485,6 +485,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "UserActivity"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "UserActivity"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": 0
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/contracts/fee/tests/decay.rs
+++ b/contracts/fee/tests/decay.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use soroban_sdk::testutils::Ledger;
 use support::setup;
 
 #[test]

--- a/contracts/fee/tests/escrow.rs
+++ b/contracts/fee/tests/escrow.rs
@@ -8,7 +8,7 @@ fn fees_are_held_then_released_from_escrow() {
 
     assert_eq!(ctx.client.get_escrow_balance(), 0);
     assert_eq!(ctx.client.get_pending_fees(&1), 0);
-handle hash
+
     let pending = ctx.client.collect_fee(&ctx.payer, &150i128);
     assert_eq!(pending, 150);
     assert_eq!(ctx.client.get_escrow_balance(), 150);

--- a/contracts/fee/tests/get_fee_config.rs
+++ b/contracts/fee/tests/get_fee_config.rs
@@ -1,18 +1,25 @@
 #[cfg(test)]
 mod test {
-    use soroban_sdk::{Env};
+    use soroban_sdk::{Env, Address, testutils::*};
+    use soroban_sdk::testutils::Address as _;
 
-    use crate::FeeContract;
+    use fee::{FeeContract, FeeContractClient};
 
     #[test]
     fn test_get_fee_config_default() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, FeeContract);
+        let contract_id = env.register(FeeContract, ());
         let client = FeeContractClient::new(&env, &contract_id);
 
-        let (base_fee, max_fee) = client.get_fee_config();
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        client.initialize(&admin, &token, &treasury, &100u32, &1u64);
+
+        let base_fee = client.get_fee_bps();
+        let min_fee = client.get_min_fee();
 
         assert_eq!(base_fee, 100);
-        assert_eq!(max_fee, 1_000_000);
+        assert_eq!(min_fee, 0);
     }
 }

--- a/contracts/fee/tests/user_override.rs
+++ b/contracts/fee/tests/user_override.rs
@@ -1,0 +1,150 @@
+mod support;
+
+use soroban_sdk::Address;
+use soroban_sdk::testutils::Address as _;
+use support::setup;
+
+#[test]
+fn test_calculate_fee_uses_global_config() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+
+    // Global fee_bps is 250 (set in setup)
+    let amount = 10000i128;
+    let expected_fee = (amount * 250) / 10000; // 250
+
+    let fee = ctx.client.calculate_fee(&user, &amount);
+    assert_eq!(fee, expected_fee);
+}
+
+#[test]
+fn test_calculate_fee_uses_user_override() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let admin = ctx.admin.clone();
+
+    // Set user override to 500 bps
+    ctx.client.set_user_fee_override(&admin, &user, &500u32);
+
+    let amount = 10000i128;
+    let expected_fee = (amount * 500) / 10000; // 500
+
+    let fee = ctx.client.calculate_fee(&user, &amount);
+    assert_eq!(fee, expected_fee);
+}
+
+#[test]
+fn test_calculate_fee_override_takes_precedence() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let admin = ctx.admin.clone();
+
+    // First calculate with global (250)
+    let amount = 10000i128;
+    let global_fee = ctx.client.calculate_fee(&user, &amount);
+    assert_eq!(global_fee, 250);
+
+    // Set override to 100 bps
+    ctx.client.set_user_fee_override(&admin, &user, &100u32);
+
+    // Now should use override
+    let override_fee = ctx.client.calculate_fee(&user, &amount);
+    assert_eq!(override_fee, 100);
+}
+
+#[test]
+fn test_calculate_fee_respects_min_fee() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let admin = ctx.admin.clone();
+
+    // Set min_fee to 50
+    ctx.client.set_min_fee(&admin, &50i128);
+
+    // Set user override to very low rate
+    ctx.client.set_user_fee_override(&admin, &user, &1u32); // 0.01%
+
+    let amount = 10000i128;
+    let fee = ctx.client.calculate_fee(&user, &amount);
+    // Calculated fee would be 0.1, but min_fee is 50
+    assert_eq!(fee, 50);
+}
+
+#[test]
+#[should_panic]
+fn test_set_user_fee_override_requires_admin() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let non_admin = Address::generate(&ctx.env);
+
+    // Should panic when non-admin tries to set override
+    ctx.client.set_user_fee_override(&non_admin, &user, &500u32);
+}
+
+#[test]
+fn test_remove_user_fee_override() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let admin = ctx.admin.clone();
+
+    // Set override
+    ctx.client.set_user_fee_override(&admin, &user, &500u32);
+    let fee_with_override = ctx.client.calculate_fee(&user, &10000i128);
+    assert_eq!(fee_with_override, 500);
+
+    // Remove override
+    ctx.client.remove_user_fee_override(&admin, &user);
+
+    // Should fall back to global
+    let fee_global = ctx.client.calculate_fee(&user, &10000i128);
+    assert_eq!(fee_global, 250);
+}
+
+#[test]
+fn test_get_user_fee_bps_with_override() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let admin = ctx.admin.clone();
+
+    // Initially should return global
+    assert_eq!(ctx.client.get_user_fee_bps(&user), 250);
+
+    // Set override
+    ctx.client.set_user_fee_override(&admin, &user, &300u32);
+    assert_eq!(ctx.client.get_user_fee_bps(&user), 300);
+
+    // Remove override
+    ctx.client.remove_user_fee_override(&admin, &user);
+    assert_eq!(ctx.client.get_user_fee_bps(&user), 250);
+}
+
+#[test]
+#[should_panic]
+fn test_calculate_fee_invalid_amount() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+
+    // Should panic with invalid amount
+    ctx.client.calculate_fee(&user, &0i128);
+}
+
+#[test]
+#[should_panic]
+fn test_calculate_fee_invalid_amount_negative() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+
+    // Should panic with invalid amount
+    ctx.client.calculate_fee(&user, &-100i128);
+}
+
+#[test]
+#[should_panic]
+fn test_set_user_fee_override_invalid_bps() {
+    let ctx = setup();
+    let user = ctx.payer.clone();
+    let admin = ctx.admin.clone();
+
+    // Should panic with invalid fee_bps (> MAX_FEE_BPS = 10000)
+    ctx.client.set_user_fee_override(&admin, &user, &15000u32);
+}


### PR DESCRIPTION
CLOSES #241 Feat(contract): implement user-specific fee overrides Summary:
Implemented per-user fee overrides in the fee contract so permitted users can have custom fee-bps while preserving global/default fee behavior. Overrides are admin-managed and guarantee user override precedence over global settings while respecting minimum fee constraints.