### PR TITLE
feat(fee): implement max fee admin function and config improvements

### DIFF
--- a/contracts/fee/src/events.rs
+++ b/contracts/fee/src/events.rs
@@ -2,6 +2,8 @@ use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
 pub struct TierEvents;
 
+pub struct FeeConfigEvents;
+
 impl TierEvents {
     /// Emitted when an admin assigns a tier to a user.
     pub fn tier_set(env: &Env, admin: &Address, user: &Address, tier: &Symbol) {
@@ -20,5 +22,27 @@ impl TierEvents {
     pub fn fee_config_reset(env: &Env, admin: &Address) {
         let topics = (symbol_short!("fee"), symbol_short!("reset"));
         env.events().publish(topics, admin.clone());
+    }
+}
+
+impl FeeConfigEvents {
+    /// Emitted when fee configuration is updated.
+    pub fn fee_config_updated(
+        env: &Env,
+        admin: &Address,
+        fee_bps: Option<u32>,
+        min_fee: Option<i128>,
+        max_fee: Option<i128>,
+    ) {
+        let topics = (symbol_short!("fee"), symbol_short!("config_up"));
+        env.events().publish(
+            topics,
+            (
+                admin.clone(),
+                fee_bps.unwrap_or(0),
+                min_fee.unwrap_or(0),
+                max_fee.unwrap_or(0),
+            ),
+        );
     }
 }

--- a/contracts/fee/src/lib.rs
+++ b/contracts/fee/src/lib.rs
@@ -19,17 +19,17 @@ use crate::escrow::{
 };
 use crate::reconciliation::reconcile;
 pub use crate::reconciliation::ReconciliationResult;
-use crate::events::TierEvents;
+use crate::events::{TierEvents, FeeConfigEvents};
 use crate::storage::{
     has_admin, read_admin, read_current_cycle, read_escrow_balance, read_fee_bps, read_last_active,
-    read_locked, read_min_fee, read_pending_fees, read_token, read_total_batch_calls,
+    read_locked, read_min_fee, read_max_fee, read_pending_fees, read_token, read_total_batch_calls,
     read_total_collected, read_total_released, read_treasury, write_admin, write_current_cycle,
-    write_fee_bps, write_last_active, write_locked, write_min_fee, write_token, write_treasury,
-    is_valid_tier, read_user_tier, remove_user_tier, write_user_tier,
-    DEFAULT_FEE_BPS, DEFAULT_MIN_FEE,
+    write_fee_bps, write_last_active, write_locked, write_min_fee, write_max_fee, write_token, write_treasury,
+    is_valid_tier, read_user_tier, remove_user_tier, write_user_tier, has_fee_config,
+    DEFAULT_FEE_BPS, DEFAULT_MIN_FEE, DEFAULT_MAX_FEE,
 };
 pub use crate::storage::{BatchFeeResult, DataKey, MAX_BATCH_SIZE, MAX_FEE_BPS};
-use crate::validation::{validate_fee_bps_or_panic, validate_min_fee_or_panic};
+use crate::validation::{validate_fee_bps_or_panic, validate_min_fee_or_panic, validate_max_fee_or_panic};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
@@ -262,6 +262,7 @@ impl FeeContract {
 
         write_fee_bps(&env, fee_bps);
         FeeEvents::fee_bps_updated(&env, fee_bps);
+        FeeConfigEvents::fee_config_updated(&env, &admin, Some(fee_bps), None, None);
     }
 
     pub fn set_treasury(env: Env, admin: Address, treasury: Address) {
@@ -282,12 +283,26 @@ impl FeeContract {
 
         write_min_fee(&env, min_fee);
         FeeEvents::min_fee_updated(&env, min_fee);
+        FeeConfigEvents::fee_config_updated(&env, &admin, None, Some(min_fee), None);
+    }
+
+    pub fn set_max_fee(env: Env, admin: Address, max_fee: i128) {
+        admin.require_auth();
+        Self::require_admin(&env, &admin);
+        Self::require_unlocked(&env);
+
+        let min_fee = read_min_fee(&env);
+        validate_max_fee_or_panic(&env, max_fee, min_fee);
+
+        write_max_fee(&env, max_fee);
+        FeeConfigEvents::fee_config_updated(&env, &admin, None, None, Some(max_fee));
     }
 
     /// Resets fee configuration to default values. Admin-only.
     /// Restores:
     /// - fee_bps to DEFAULT_FEE_BPS (500 = 5%)
     /// - min_fee to DEFAULT_MIN_FEE (0)
+    /// - max_fee to DEFAULT_MAX_FEE (1,000,000)
     /// Emits a fee_config_reset event.
     pub fn reset_fee_config(env: Env, admin: Address) {
         admin.require_auth();
@@ -296,8 +311,10 @@ impl FeeContract {
 
         write_fee_bps(&env, DEFAULT_FEE_BPS);
         write_min_fee(&env, DEFAULT_MIN_FEE);
+        write_max_fee(&env, DEFAULT_MAX_FEE);
         
         TierEvents::fee_config_reset(&env, &admin);
+        FeeConfigEvents::fee_config_updated(&env, &admin, Some(DEFAULT_FEE_BPS), Some(DEFAULT_MIN_FEE), Some(DEFAULT_MAX_FEE));
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -318,6 +335,10 @@ impl FeeContract {
 
     pub fn get_min_fee(env: Env) -> i128 {
         read_min_fee(&env)
+    }
+
+    pub fn get_max_fee(env: Env) -> i128 {
+        read_max_fee(&env)
     }
 
     pub fn is_locked(env: Env) -> bool {
@@ -458,6 +479,10 @@ impl FeeContract {
     /// Returns the tier assigned to a user, or `None` if no tier is set.
     pub fn get_user_tier(env: Env, user: Address) -> Option<Symbol> {
         read_user_tier(&env, &user)
+    }
+
+    pub fn has_fee_config(env: Env) -> bool {
+        has_fee_config(&env)
     }
 
     fn require_admin(env: &Env, caller: &Address) {

--- a/contracts/fee/src/storage.rs
+++ b/contracts/fee/src/storage.rs
@@ -9,6 +9,9 @@ pub const DEFAULT_FEE_BPS: u32 = 500;
 /// Default minimum fee (0)
 pub const DEFAULT_MIN_FEE: i128 = 0;
 
+/// Default maximum fee (1,000,000)
+pub const DEFAULT_MAX_FEE: i128 = 1_000_000;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct BatchFeeResult {
@@ -26,6 +29,7 @@ pub enum DataKey {
     Treasury,
     FeeBps,
     MinFee,
+    MaxFee,
     IsLocked,
     CurrentCycle,
     EscrowBalance,
@@ -91,6 +95,14 @@ pub fn write_min_fee(env: &Env, min_fee: i128) {
 
 pub fn read_min_fee(env: &Env) -> i128 {
     env.storage().instance().get(&DataKey::MinFee).unwrap_or(0)
+}
+
+pub fn write_max_fee(env: &Env, max_fee: i128) {
+    env.storage().instance().set(&DataKey::MaxFee, &max_fee);
+}
+
+pub fn read_max_fee(env: &Env) -> i128 {
+    env.storage().instance().get(&DataKey::MaxFee).unwrap_or(DEFAULT_MAX_FEE)
 }
 
 pub fn write_locked(env: &Env, is_locked: bool) {
@@ -254,4 +266,9 @@ pub fn remove_user_tier(env: &Env, user: &Address) {
     env.storage()
         .persistent()
         .remove(&DataKey::UserTier(user.clone()));
+}
+
+/// Check if fee configuration exists (has admin and fee_bps set)
+pub fn has_fee_config(env: &Env) -> bool {
+    has_admin(env) && env.storage().instance().has(&DataKey::FeeBps)
 }

--- a/contracts/fee/src/test.rs
+++ b/contracts/fee/src/test.rs
@@ -187,3 +187,122 @@ fn test_validate_min_fee_invalid() {
     assert_eq!(validate_min_fee(-1), Err(FeeContractError::InvalidConfig));
     assert_eq!(validate_min_fee(-1000), Err(FeeContractError::InvalidConfig));
 }
+
+#[test]
+fn test_set_max_fee_valid() {
+    let (env, admin, client) = setup();
+    
+    // Set a valid max fee
+    client.set_max_fee(&admin, &1000000i128);
+    assert_eq!(client.get_max_fee(), 1000000);
+}
+
+#[test]
+#[should_panic]
+fn test_set_max_fee_unauthorized_panics() {
+    let (env, _admin, client) = setup();
+    let non_admin = Address::generate(&env);
+    client.set_max_fee(&non_admin, &1000000i128);
+}
+
+#[test]
+#[should_panic]
+fn test_set_max_fee_negative_panics() {
+    let (env, admin, client) = setup();
+    client.set_max_fee(&admin, &-100i128);
+}
+
+#[test]
+#[should_panic]
+fn test_set_max_fee_less_than_min_fee_panics() {
+    let (env, admin, client) = setup();
+    
+    // Set min fee first
+    client.set_min_fee(&admin, &1000i128);
+    
+    // Try to set max fee less than min fee
+    client.set_max_fee(&admin, &500i128);
+}
+
+#[test]
+fn test_set_max_fee_greater_than_min_fee() {
+    let (env, admin, client) = setup();
+    
+    // Set min fee first
+    client.set_min_fee(&admin, &1000i128);
+    
+    // Set max fee greater than min fee
+    client.set_max_fee(&admin, &5000i128);
+    assert_eq!(client.get_max_fee(), 5000);
+}
+
+#[test]
+fn test_get_max_fee_default() {
+    let (_env, _admin, client) = setup();
+    
+    // Should return default max fee (1,000,000)
+    assert_eq!(client.get_max_fee(), 1000000);
+}
+
+#[test]
+fn test_reset_fee_config_includes_max_fee() {
+    let (env, admin, client) = setup();
+    
+    // Change all fee configs
+    client.set_fee_bps(&admin, &1000u32);
+    client.set_min_fee(&admin, &100i128);
+    client.set_max_fee(&admin, &2000000i128);
+    
+    // Verify changes
+    assert_eq!(client.get_fee_bps(), 1000);
+    assert_eq!(client.get_min_fee(), 100);
+    assert_eq!(client.get_max_fee(), 2000000);
+    
+    // Reset config
+    client.reset_fee_config(&admin);
+    
+    // Verify all defaults restored
+    assert_eq!(client.get_fee_bps(), 500);
+    assert_eq!(client.get_min_fee(), 0);
+    assert_eq!(client.get_max_fee(), 1000000);
+}
+
+#[test]
+fn test_has_fee_config_after_initialization() {
+    let (_env, _admin, client) = setup();
+    
+    // Should have fee config after initialization
+    assert!(client.has_fee_config());
+}
+
+#[test]
+fn test_has_fee_config_false_before_initialization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(FeeContract, ());
+    let client = FeeContractClient::new(&env, &contract_id);
+    
+    // Should not have fee config before initialization
+    assert!(!client.has_fee_config());
+}
+
+#[test]
+fn test_validate_max_fee_valid() {
+    use crate::validation::validate_max_fee;
+    
+    // Valid values
+    assert!(validate_max_fee(1000, 0).is_ok());
+    assert!(validate_max_fee(1000, 500).is_ok());
+    assert!(validate_max_fee(1000000, 999999).is_ok());
+}
+
+#[test]
+fn test_validate_max_fee_invalid() {
+    use crate::validation::validate_max_fee;
+    use crate::FeeContractError;
+    
+    // Invalid values
+    assert_eq!(validate_max_fee(-1, 0), Err(FeeContractError::InvalidConfig));
+    assert_eq!(validate_max_fee(500, 1000), Err(FeeContractError::InvalidConfig)); // max < min
+    assert_eq!(validate_max_fee(0, 100), Err(FeeContractError::InvalidConfig)); // max < min
+}

--- a/contracts/fee/src/validation.rs
+++ b/contracts/fee/src/validation.rs
@@ -55,3 +55,27 @@ pub fn validate_min_fee(min_fee: i128) -> Result<(), FeeContractError> {
         Ok(())
     }
 }
+
+/// Validate maximum fee is non-negative and greater than or equal to min fee.
+/// Panics with InvalidConfig on failure. Returns true on success.
+pub fn validate_max_fee_or_panic(env: &Env, max_fee: i128, min_fee: i128) -> bool {
+    if max_fee < 0 {
+        panic_with_error!(env, FeeContractError::InvalidConfig);
+    }
+    if max_fee < min_fee {
+        panic_with_error!(env, FeeContractError::InvalidConfig);
+    }
+    true
+}
+
+/// Validate maximum fee without panicking.
+/// Returns Ok(()) if valid, or Err(FeeContractError::InvalidConfig) if invalid.
+pub fn validate_max_fee(max_fee: i128, min_fee: i128) -> Result<(), FeeContractError> {
+    if max_fee < 0 {
+        Err(FeeContractError::InvalidConfig)
+    } else if max_fee < min_fee {
+        Err(FeeContractError::InvalidConfig)
+    } else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Add set_max_fee admin function (#279)
- Add FeeConfigUpdated event emitted on config changes (#282)
- Implement has_fee_config() function to check fee configuration existence (#285)
- Add default max fee fallback logic (#286)
- Update reset_fee_config to include max_fee
- Add comprehensive tests for all new functionality
- Add max fee validation functions

closes #279
closes #282
closes #285
closes #286