### PR TITLE
feat(contracts): resolve #353 #350 #366 #368

### DIFF
--- a/contracts/shared/src/utils.rs
+++ b/contracts/shared/src/utils.rs
@@ -2,6 +2,7 @@
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ValidationError {
     NegativeAmount,
+    InvalidAddress,
 }
 
 /// Validates that an amount is not negative.
@@ -13,9 +14,36 @@ pub fn validate_amount(amount: i128) -> Result<(), ValidationError> {
     }
 }
 
+/// Validates a user address string format.
+///
+/// Accepts classic Stellar-style prefixes (`G` account, `C` contract)
+/// and only base32 characters (`A-Z`, `2-7`).
+pub fn validate_user_address(address: &soroban_sdk::String) -> Result<(), ValidationError> {
+    if address.len() == 0 {
+        return Err(ValidationError::InvalidAddress);
+    }
+
+    let bytes = address.to_bytes();
+    let prefix = bytes.get(0).unwrap_or(0);
+    if prefix != b'G' && prefix != b'C' {
+        return Err(ValidationError::InvalidAddress);
+    }
+
+    for b in bytes.iter() {
+        let is_upper_alpha = b >= b'A' && b <= b'Z';
+        let is_base32_digit = b >= b'2' && b <= b'7';
+        if !is_upper_alpha && !is_base32_digit {
+            return Err(ValidationError::InvalidAddress);
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{validate_amount, ValidationError};
+    use super::{validate_amount, validate_user_address, ValidationError};
+    use soroban_sdk::{Env, String};
 
     #[test]
     fn accepts_zero_and_positive_amounts() {
@@ -28,5 +56,26 @@ mod tests {
     fn rejects_negative_amounts() {
         assert_eq!(validate_amount(-1), Err(ValidationError::NegativeAmount));
         assert_eq!(validate_amount(-99), Err(ValidationError::NegativeAmount));
+    }
+
+    #[test]
+    fn accepts_valid_user_address() {
+        let env = Env::default();
+        let address = String::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assert_eq!(validate_user_address(&address), Ok(()));
+    }
+
+    #[test]
+    fn rejects_invalid_user_address() {
+        let env = Env::default();
+
+        let empty = String::from_str(&env, "");
+        assert_eq!(validate_user_address(&empty), Err(ValidationError::InvalidAddress));
+
+        let bad_prefix = String::from_str(&env, "XAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+        assert_eq!(validate_user_address(&bad_prefix), Err(ValidationError::InvalidAddress));
+
+        let bad_chars = String::from_str(&env, "GINVALID!ADDRESS");
+        assert_eq!(validate_user_address(&bad_chars), Err(ValidationError::InvalidAddress));
     }
 }

--- a/contracts/transactions/src/lib.rs
+++ b/contracts/transactions/src/lib.rs
@@ -73,7 +73,13 @@ impl TransactionsContract {
         
         env.events().publish(
             (symbol_short!("tx"), symbol_short!("created")),
-            (transaction.id.clone(), transaction.from.clone(), transaction.to.clone(), transaction.amount),
+            (
+                transaction.id.clone(),
+                transaction.from.clone(),
+                transaction.to.clone(),
+                transaction.amount,
+                transaction.timestamp,
+            ),
         );
         
         transaction.id

--- a/contracts/transactions/src/test.rs
+++ b/contracts/transactions/src/test.rs
@@ -1,5 +1,6 @@
 ﻿use soroban_sdk::{
-    testutils::Address as _, Address, Env, Symbol, String, Vec,
+    testutils::{Address as _, Ledger},
+    Address, Env, Symbol, String, Vec,
 };
 use crate::{TransactionsContract, TransactionsContractClient, TransactionError, Transaction};
 
@@ -297,4 +298,30 @@ fn test_transaction_exists() {
 
     let fake_id = Symbol::new(&env, "not_here");
     assert!(!client.transaction_exists(&fake_id));
+}
+
+#[test]
+fn test_create_transaction_stores_creation_timestamp() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(1_700_000_123);
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let tx_id = client.create_transaction(
+        &from,
+        &to,
+        &500,
+        &String::from_str(&env, "timestamped"),
+        &Vec::new(&env),
+    );
+
+    let tx = client.get_transaction(&tx_id).unwrap();
+    assert_eq!(tx.timestamp, 1_700_000_123);
+    assert_eq!(client.get_transaction_timestamp(&tx_id), Some(1_700_000_123));
 }

--- a/contracts/users/src/lib.rs
+++ b/contracts/users/src/lib.rs
@@ -2,12 +2,15 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Env, Vec,
+    Env, String, Vec,
 };
 
 mod storage;
 
-pub use storage::{add_user, get_user_count, user_exists, get_all_users, reset_user_data};
+pub use storage::{
+    add_user, deactivate_user as storage_deactivate_user, get_all_users, get_default_currency,
+    get_user_count, is_user_active, reset_user_data, set_default_currency, user_exists,
+};
 
 #[cfg(test)]
 mod test;
@@ -103,6 +106,48 @@ impl UsersContract {
         }
 
         success
+    }
+
+    /// Set default currency preference for a registered user.
+    pub fn set_default_currency(env: Env, user: Address, currency: String) {
+        user.require_auth();
+
+        if !user_exists(&env, user.clone()) {
+            panic_with_error!(&env, UserError::UserNotFound);
+        }
+
+        set_default_currency(&env, user.clone(), currency.clone());
+
+        env.events().publish(
+            (symbol_short!("users"), symbol_short!("def_curr")),
+            (user, currency),
+        );
+    }
+
+    /// Get default currency preference for a user.
+    pub fn get_default_currency(env: Env, user: Address) -> Option<String> {
+        get_default_currency(&env, user)
+    }
+
+    /// Deactivate a registered user account (only the user may call).
+    pub fn deactivate_user(env: Env, user: Address) -> bool {
+        user.require_auth();
+
+        let success = storage_deactivate_user(&env, user.clone());
+
+        if success {
+            env.events().publish(
+                (symbol_short!("users"), symbol_short!("deact")),
+                user,
+            );
+        }
+
+        success
+    }
+
+    /// Return whether the given user account is active.
+    pub fn is_user_active(env: Env, user: Address) -> bool {
+        is_user_active(&env, user)
     }
 
     /// Get the admin address

--- a/contracts/users/src/storage.rs
+++ b/contracts/users/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Env, Map, Vec};
+use soroban_sdk::{contracttype, Address, Env, Map, String, Vec};
 
 #[derive(Clone)]
 #[contracttype]
@@ -7,6 +7,10 @@ pub enum DataKey {
     Users,
     /// Count of unique users
     UserCount,
+    /// Default currency preference for a user
+    DefaultCurrency(Address),
+    /// Active status for a user
+    UserActive(Address),
 }
 
 /// Add a user to the set of unique users if not already present
@@ -40,6 +44,11 @@ pub fn add_user(env: &Env, user: Address) -> bool {
     env.storage()
         .persistent()
         .set(&DataKey::UserCount, &count);
+
+    // Newly registered users are active by default.
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserActive(user), &true);
     
     true
 }
@@ -92,6 +101,13 @@ pub fn reset_user_data(env: &Env, user: Address) -> bool {
         .persistent()
         .set(&DataKey::UserCount, &count);
 
+    env.storage()
+        .persistent()
+        .remove(&DataKey::DefaultCurrency(user.clone()));
+    env.storage()
+        .persistent()
+        .remove(&DataKey::UserActive(user));
+
     true
 }
 
@@ -108,4 +124,38 @@ pub fn get_all_users(env: &Env) -> Vec<Address> {
         result.push_back(user);
     }
     result
+}
+
+/// Set default currency preference for a user.
+pub fn set_default_currency(env: &Env, user: Address, currency: String) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DefaultCurrency(user), &currency);
+}
+
+/// Get default currency preference for a user.
+pub fn get_default_currency(env: &Env, user: Address) -> Option<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DefaultCurrency(user))
+}
+
+/// Mark a user account as inactive.
+pub fn deactivate_user(env: &Env, user: Address) -> bool {
+    if !user_exists(env, user.clone()) {
+        return false;
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::UserActive(user), &false);
+    true
+}
+
+/// Returns whether the user account is active.
+pub fn is_user_active(env: &Env, user: Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserActive(user))
+        .unwrap_or(false)
 }

--- a/contracts/users/src/test.rs
+++ b/contracts/users/src/test.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
 use crate::{UsersContract, UsersContractClient, UserError};
 
 #[test]
@@ -244,6 +244,58 @@ fn test_multiple_unique_users() {
         let user = users.get(i).unwrap();
         assert!(client.is_user_registered(&user));
     }
+}
+
+#[test]
+fn test_set_and_get_default_currency() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(UsersContract, ());
+    let client = UsersContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    client.register_user(&user);
+
+    let currency = String::from_str(&env, "USD");
+    client.set_default_currency(&user, &currency);
+
+    assert_eq!(client.get_default_currency(&user), Some(currency));
+}
+
+#[test]
+#[should_panic]
+fn test_set_default_currency_fails_for_unregistered_user() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(UsersContract, ());
+    let client = UsersContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let currency = String::from_str(&env, "USD");
+
+    client.set_default_currency(&user, &currency);
+}
+
+#[test]
+fn test_deactivate_user_marks_user_inactive() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(UsersContract, ());
+    let client = UsersContractClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    client.register_user(&user);
+    assert!(client.is_user_active(&user));
+
+    let success = client.deactivate_user(&user);
+    assert!(success);
+    assert!(!client.is_user_active(&user));
 }
 
 


### PR DESCRIPTION

feat(contracts): implement user currency preference, user deactivation, address validation, and transaction creation timestamp

## Summary
This PR resolves issues #353, #350, #366, and #368 by adding:
- User default currency storage and retrieval
- User deactivation support
- Shared user address validation helper
- Transaction creation timestamp coverage and event payload timestamp

## Closes
Closes #353  
Closes #350  
Closes #366  
Closes #368

## What Changed

### Users contract
- Added set_default_currency(user, currency)
- Added get_default_currency(user)
- Added deactivate_user(user)
- Added is_user_active(user)
- Added persistent keys for:
  - DefaultCurrency(Address)
  - UserActive(Address)
- New users are marked active on registration
- Resetting user data now also clears default currency and active flag
- Added tests for:
  - Setting and getting default currency
  - Rejecting currency set for unregistered users
  - Deactivating user and verifying inactive state

### Shared utils
- Added ValidationError::InvalidAddress
- Added validate_user_address(address) helper
- Validation rejects:
  - Empty address
  - Invalid prefix
  - Non base32 characters outside A-Z and 2-7
- Added tests for valid and invalid addresses

### Transactions contract
- Transaction create event now includes timestamp
- Added test to verify transaction timestamp equals ledger timestamp at creation