### PR TITLE
feat:Feat(contract): add check if transaction list is empty

### DIFF
--- a/contracts/transaction/src/lib.rs
+++ b/contracts/transaction/src/lib.rs
@@ -1,54 +1,315 @@
-use soroban_sdk::{contractimpl, Env, Address, Symbol};
+#![no_std]
 
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short,
+    Address, Env, Vec,
+};
+
+// ── Error types ───────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum TxError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    InvalidAmount = 4,
+}
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Stores the contract admin address.
+    Admin,
+    /// Stores the global ordered list of transaction IDs (Vec<u64>).
+    TxList,
+    /// Stores the next auto-increment transaction ID counter.
+    TxCounter,
+    /// Stores the Transaction record for a given ID.
+    Tx(u64),
+    /// Stores the transaction count for a given user (sender).
+    UserTxCount(Address),
+}
+
+// ── Data types ────────────────────────────────────────────────────────────────
+
+/// A single on-chain transaction record.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transaction {
+    pub id: u64,
+    pub from: Address,
+    pub to: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
 pub struct TransactionContract;
 
 #[contractimpl]
 impl TransactionContract {
-    /// Create a transaction and emit an event
-    pub fn create_transaction(env: Env, from: Address, to: Address, amount: i128) {
-        // Store transaction data (simplified example)
-        let tx_key = format!("tx:{}:{}", from, to);
-        env.storage().set(&tx_key, &amount);
+    /// Initialize the contract with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, TxError::AlreadyInitialized);
+        }
 
-        // Emit event for off-chain listeners
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TxCounter, &0u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::TxList, &Vec::<u64>::new(&env));
+
         env.events().publish(
-            (Symbol::short("transaction_created"),),
-            (from, to, amount),
+            (symbol_short!("txs"), symbol_short!("init")),
+            admin,
         );
+    }
+
+    /// Record a new transaction between two parties.
+    ///
+    /// Emits a `("txs", "created")` event carrying the full Transaction
+    /// struct so off-chain indexers can track every transfer without
+    /// polling on-chain storage.
+    ///
+    /// Returns the assigned transaction ID.
+    pub fn create_transaction(
+        env: Env,
+        from: Address,
+        to: Address,
+        amount: i128,
+    ) -> u64 {
+        from.require_auth();
+
+        if amount <= 0 {
+            panic_with_error!(&env, TxError::InvalidAmount);
+        }
+
+        // Assign an auto-incrementing ID.
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TxCounter)
+            .unwrap_or(0u64);
+
+        let tx = Transaction {
+            id,
+            from: from.clone(),
+            to: to.clone(),
+            amount,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        // Persist the transaction record.
+        env.storage().instance().set(&DataKey::Tx(id), &tx);
+
+        // Append the ID to the global ordered list.
+        let mut tx_list: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::TxList)
+            .unwrap_or_else(|| Vec::new(&env));
+        tx_list.push_back(id);
+        env.storage().instance().set(&DataKey::TxList, &tx_list);
+
+        // Advance the counter.
+        env.storage()
+            .instance()
+            .set(&DataKey::TxCounter, &(id + 1));
+
+        // Increment per-user transaction count for the sender.
+        let user_count: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::UserTxCount(from.clone()))
+            .unwrap_or(0i128);
+        env.storage()
+            .instance()
+            .set(&DataKey::UserTxCount(from.clone()), &(user_count + 1));
+
+        // Emit event.
+        env.events().publish(
+            (symbol_short!("txs"), symbol_short!("created")),
+            tx.clone(),
+        );
+
+        id
+    }
+
+    // ── Issue: Fetch most recent transactions ─────────────────────────────────
+    //
+    // Returns up to `limit` of the most recently recorded transactions,
+    // ordered newest-first. If fewer than `limit` transactions exist, all
+    // available records are returned.
+    //
+    // Acceptance criteria: returns latest N transactions.
+    pub fn get_recent_transactions(env: Env, limit: u32) -> Vec<Transaction> {
+        let tx_list: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::TxList)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let total = tx_list.len();
+        // How many records we will actually return (capped at total available).
+        let count = if limit as u32 > total { total } else { limit as u32 };
+
+        let mut result: Vec<Transaction> = Vec::new(&env);
+
+        // Iterate from the tail of the list to get newest-first order.
+        let start = total - count;
+        let mut i = total;
+        while i > start {
+            i -= 1;
+            let tx_id = tx_list.get(i).unwrap();
+            if let Some(tx) = env.storage().instance().get(&DataKey::Tx(tx_id)) {
+                result.push_back(tx);
+            }
+        }
+
+        result
+    }
+
+    // ── Issue: Quick check for user activity ──────────────────────────────────
+    //
+    // Returns `true` if the given user has sent at least one transaction,
+    // `false` otherwise. This is a cheap O(1) read against the per-user
+    // counter maintained by `create_transaction`.
+    //
+    // Acceptance criteria: returns correct boolean state.
+    pub fn has_user_transacted(env: Env, user: Address) -> bool {
+        let count: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::UserTxCount(user))
+            .unwrap_or(0i128);
+        count > 0
+    }
+
+    /// Return the total number of transactions sent by a user.
+    pub fn get_user_transaction_count(env: Env, user: Address) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::UserTxCount(user))
+            .unwrap_or(0i128)
+    }
+
+    /// Return the transaction record for a given ID, if it exists.
+    pub fn get_transaction(env: Env, id: u64) -> Option<Transaction> {
+        env.storage().instance().get(&DataKey::Tx(id))
+    }
+
+    /// Return the total number of recorded transactions.
+    pub fn get_transaction_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TxCounter)
+            .unwrap_or(0u64)
     }
 }
 
-use soroban_sdk::{contractimpl, Env, Address, Symbol};
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
-pub struct TransactionContract;
+#[cfg(test)]
+mod tests {
+    use super::{TransactionContract, TransactionContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env};
 
-#[contractimpl]
-impl TransactionContract {
-    /// Create a transaction, emit event, and increment user transaction count
-    pub fn create_transaction(env: Env, from: Address, to: Address, amount: i128) {
-        // Store transaction data (simplified example)
-        let tx_key = format!("tx:{}:{}", from, to);
-        env.storage().set(&tx_key, &amount);
-
-        // Increment transaction count for sender
-        let count_key = format!("count:{}", from);
-        let current_count: i128 = env.storage().get(&count_key).unwrap_or(0);
-        env.storage().set(&count_key, &(current_count + 1));
-
-        // Emit event for off-chain listeners
-        env.events().publish(
-            (Symbol::short("transaction_created"),),
-            (from, to, amount),
-        );
+    fn setup<'a>() -> (Env, Address, TransactionContractClient<'a>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(TransactionContract, ());
+        let client = TransactionContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, client)
     }
 
-    /// Get the transaction count for a given user
-    pub fn get_user_transaction_count(env: Env, user: Address) -> i128 {
-        let count_key = format!("count:{}", user);
-        env.storage().get(&count_key).unwrap_or(0)
+    // ── get_recent_transactions ───────────────────────────────────────────────
+
+    #[test]
+    fn returns_empty_when_no_transactions() {
+        let (_env, _admin, client) = setup();
+        let recent = client.get_recent_transactions(&5);
+        assert_eq!(recent.len(), 0);
     }
-} /// Get transactions count by user
-pub fn get_transactions_count_by_user(env: Env, user: Address) -> i128 {
-    let count_key = format!("count:{}", user);
-    env.storage().get(&count_key).unwrap_or(0)
+
+    #[test]
+    fn returns_latest_n_transactions_newest_first() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        // Create 5 transactions.
+        for amount in 1i128..=5 {
+            client.create_transaction(&alice, &bob, &amount);
+        }
+
+        // Ask for the latest 3.
+        let recent = client.get_recent_transactions(&3);
+        assert_eq!(recent.len(), 3);
+
+        // Should be newest-first: amounts 5, 4, 3.
+        assert_eq!(recent.get(0).unwrap().amount, 5);
+        assert_eq!(recent.get(1).unwrap().amount, 4);
+        assert_eq!(recent.get(2).unwrap().amount, 3);
+    }
+
+    #[test]
+    fn clamps_limit_to_available_count() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.create_transaction(&alice, &bob, &100);
+        client.create_transaction(&alice, &bob, &200);
+
+        // Requesting more than available should return all 2.
+        let recent = client.get_recent_transactions(&50);
+        assert_eq!(recent.len(), 2);
+    }
+
+    // ── has_user_transacted ───────────────────────────────────────────────────
+
+    #[test]
+    fn returns_false_for_user_with_no_transactions() {
+        let (env, _admin, client) = setup();
+        let stranger = Address::generate(&env);
+        assert!(!client.has_user_transacted(&stranger));
+    }
+
+    #[test]
+    fn returns_true_after_first_transaction() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        assert!(!client.has_user_transacted(&alice));
+
+        client.create_transaction(&alice, &bob, &42);
+
+        assert!(client.has_user_transacted(&alice));
+        // Recipient has no outgoing transactions — still false.
+        assert!(!client.has_user_transacted(&bob));
+    }
+
+    #[test]
+    fn transaction_count_increments_correctly() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.create_transaction(&alice, &bob, &10);
+        client.create_transaction(&alice, &bob, &20);
+
+        assert_eq!(client.get_user_transaction_count(&alice), 2);
+        assert_eq!(client.get_user_transaction_count(&bob), 0);
+    }
 }

--- a/contracts/users/src/lib.rs
+++ b/contracts/users/src/lib.rs
@@ -7,7 +7,12 @@ use soroban_sdk::{
 
 mod storage;
 
-pub use storage::{add_user, get_user_count, user_exists, get_all_users, reset_user_data, get_user_active_status, set_user_active_status, get_user_currency, set_user_currency, get_user_last_login, set_user_last_login};
+pub use storage::{
+    add_user, get_user_count, user_exists, get_all_users, reset_user_data,
+    get_user_active_status, set_user_active_status,
+    get_user_currency, set_user_currency,
+    get_user_last_login, set_user_last_login,
+};
 
 #[cfg(test)]
 mod test;
@@ -34,70 +39,82 @@ pub struct UsersContract;
 
 #[contractimpl]
 impl UsersContract {
-    /// Initialize the users contract with an admin address
+    /// Initialize the users contract with an admin address.
     pub fn initialize(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic_with_error!(&env, UserError::AlreadyInitialized);
         }
-        
+
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
-        
+
         env.events().publish(
             (symbol_short!("users"), symbol_short!("init")),
             admin,
         );
     }
-    
-    /// Register a user (adds them to the unique user set)
-    /// Can be called by anyone to register themselves or others
+
+    /// Register a new user.
+    ///
+    /// Issue: "Track when user joined" — the current ledger timestamp is
+    /// recorded via `set_user_last_login` immediately on registration and
+    /// can be read back with `get_user_last_login`.
+    ///
+    /// Issue: "Emit event when user registers" — a `("users", "reg")` event
+    /// carrying the registrant's address is published on every successful
+    /// registration.
+    ///
+    /// Returns `true` when the user was newly registered, `false` if they
+    /// were already present (idempotent, no event emitted for duplicates).
     pub fn register_user(env: Env, user: Address) -> bool {
         if user_exists(&env, user.clone()) {
-            return false; // Reject duplicate users
+            return false;
         }
-        
+
         let is_new = add_user(&env, user.clone());
-        
+
         if is_new {
-            // Set last login timestamp on registration
+            // ── Issue: Track when user joined ────────────────────────────
+            // Capture the ledger timestamp at the moment of registration so
+            // callers can query it later via `get_user_last_login`.
             set_user_last_login(&env, user.clone(), env.ledger().timestamp());
-            
+
+            // ── Issue: Emit event when user registers ────────────────────
+            // Publish a structured event so off-chain indexers and other
+            // contracts can react to new registrations.
             env.events().publish(
                 (symbol_short!("users"), symbol_short!("reg")),
                 user,
             );
         }
-        
+
         is_new
     }
-    
-    /// Get the total count of unique users who have interacted with the contract
+
+    /// Return the total count of registered users.
     pub fn get_all_users_count(env: Env) -> u64 {
         get_user_count(&env)
     }
-    
-    /// Check if a specific user is registered
+
+    /// Return `true` if the given address has been registered.
     pub fn is_user_registered(env: Env, user: Address) -> bool {
         user_exists(&env, user)
     }
 
-    /// Verify user existence — returns `true` if the user has been registered,
-    /// `false` otherwise. Functionally identical to `is_user_registered`;
-    /// exposed under this name to satisfy the `check_user_exists` API surface
-    /// requested in issue #336.
+    /// Alias for `is_user_registered`; satisfies the `check_user_exists` API
+    /// surface requested in issue #336.
     pub fn check_user_exists(env: Env, user: Address) -> bool {
         user_exists(&env, user)
     }
-    
-    /// Get all registered users (admin only)
+
+    /// Return all registered user addresses (admin only).
     pub fn get_all_users(env: Env, caller: Address) -> Vec<Address> {
         caller.require_auth();
         Self::require_admin(&env, &caller);
-        
         get_all_users(&env)
     }
-    
-    /// Reset the user's profile data (only the user may call)
+
+    /// Reset the calling user's profile data.
     pub fn reset_user_data(env: Env, user: Address) -> bool {
         user.require_auth();
 
@@ -113,59 +130,67 @@ impl UsersContract {
         success
     }
 
-    /// Get the admin address
+    /// Return the stored admin address, if the contract has been initialized.
     pub fn get_admin(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::Admin)
     }
 
-    /// Get user activity status
+    /// Return the activity status for the given user.
     pub fn get_user_active_status(env: Env, user: Address) -> bool {
         get_user_active_status(&env, user)
     }
 
-    /// Set user activity status (only admin can set)
-    pub fn set_user_active_status(env: Env, caller: Address, user: Address, is_active: bool) -> bool {
+    /// Set the activity status for a user (admin only).
+    pub fn set_user_active_status(
+        env: Env,
+        caller: Address,
+        user: Address,
+        is_active: bool,
+    ) -> bool {
         caller.require_auth();
         Self::require_admin(&env, &caller);
-        
+
         let success = set_user_active_status(&env, user.clone(), is_active);
-        
+
         if success {
             env.events().publish(
-                (symbol_short!("users"), symbol_short!("active_upd")),
+                (symbol_short!("users"), symbol_short!("actv_upd")),
                 (user, is_active),
             );
         }
-        
+
         success
     }
 
-    /// Get user's preferred currency
+    /// Return the user's preferred currency string.
     pub fn get_user_currency(env: Env, user: Address) -> String {
         get_user_currency(&env, user)
     }
 
-    /// Set user's preferred currency (only the user can set their own currency)
+    /// Set the calling user's preferred currency.
     pub fn set_user_currency(env: Env, user: Address, currency: String) -> bool {
         user.require_auth();
-        
+
         let success = set_user_currency(&env, user.clone(), currency.clone());
-        
+
         if success {
             env.events().publish(
-                (symbol_short!("users"), symbol_short!("currency_upd")),
+                (symbol_short!("users"), symbol_short!("curr_upd")),
                 (user, currency),
             );
         }
-        
+
         success
     }
-    
-    /// Get user's last login timestamp
+
+    /// Return the ledger timestamp recorded when the user last logged in (or
+    /// registered, whichever is more recent).
     pub fn get_user_last_login(env: Env, user: Address) -> Option<u64> {
         get_user_last_login(&env, user)
     }
-    
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
+
     fn require_admin(env: &Env, caller: &Address) {
         let admin: Address = env
             .storage()
@@ -178,15 +203,12 @@ impl UsersContract {
     }
 }
 
-// ── Issue #336: check_user_exists ────────────────────────────────────────────
+// ── Issue #336: check_user_exists ─────────────────────────────────────────────
 //
-// Tests are inline here (rather than in the sibling `test.rs` file) because
-// `test.rs` is currently not wired as a module from `lib.rs`. Wiring it up
-// surfaces several pre-existing compile errors in tests that have never run
-// (missing `Vec` import, `Option<Address>` vs `Address` mismatches, and
-// `std::panic::catch_unwind` calls that don't compile in this `no_std`
-// crate). Repairing those is out of scope for issue #336; tracking that as
-// a separate concern keeps this PR focused.
+// Tests live here (not in test.rs) to avoid surfacing pre-existing compile
+// errors in that file (missing Vec import, Option<Address> mismatches, and
+// std::panic::catch_unwind calls incompatible with no_std). Fixing those is
+// tracked separately.
 #[cfg(test)]
 mod check_user_exists_tests {
     use super::{UsersContract, UsersContractClient};
@@ -213,19 +235,13 @@ mod check_user_exists_tests {
     fn returns_true_after_registration() {
         let (env, _admin, client) = setup();
         let user = Address::generate(&env);
-
-        // Before registration → false
         assert!(!client.check_user_exists(&user));
-
-        // After registration → true
         client.register_user(&user);
         assert!(client.check_user_exists(&user));
     }
 
     #[test]
     fn matches_is_user_registered_for_parity() {
-        // check_user_exists is a deliberate alias for is_user_registered.
-        // This test guards against future divergence between the two.
         let (env, _admin, client) = setup();
         let registered = Address::generate(&env);
         let unregistered = Address::generate(&env);
@@ -239,5 +255,20 @@ mod check_user_exists_tests {
             client.check_user_exists(&unregistered),
             client.is_user_registered(&unregistered),
         );
+    }
+
+    /// Verifies that the join timestamp is populated on registration.
+    #[test]
+    fn registration_records_join_timestamp() {
+        let (env, _admin, client) = setup();
+        let user = Address::generate(&env);
+
+        // No timestamp before registration
+        assert!(client.get_user_last_login(&user).is_none());
+
+        client.register_user(&user);
+
+        // Timestamp present after registration
+        assert!(client.get_user_last_login(&user).is_some());
     }
 }


### PR DESCRIPTION
feat(users, transactions): join timestamp, registration event, recent txs, activity check

Users contract
- register_user: records ledger timestamp on first registration (get_user_last_login)
- register_user: emits ("users", "reg") event on every new registration
- New test: registration_records_join_timestamp

Transactions contract (new file)
- get_recent_transactions(limit): returns latest N transactions, newest-first, clamped to available count
- has_user_transacted(user): O(1) boolean — true if user has sent ≥1 transaction
- create_transaction: persists Transaction structs, maintains global TxList and per-user counters, emits ("txs", "created") event
- Full test coverage for both new query methods

Closes #374
Closes #382
Closes #381
Closes #377