### PR TITLE
feat(transactions): add export-filtered transaction retrieval

### DIFF
--- a/contracts/transact/src/lib.rs
+++ b/contracts/transact/src/lib.rs
@@ -1,0 +1,47 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Env, Symbol, Vec, Map};
+
+#[derive(Clone)]
+pub struct Transaction {
+    pub id: u64,
+    pub amount: i128,
+    pub sender: Symbol,
+    pub receiver: Symbol,
+    pub export: bool, // <-- flag used for filtering
+}
+
+const STORAGE_KEY: Symbol = Symbol::short("TXS");
+
+#[contract]
+pub struct TransactionContract;
+
+#[contractimpl]
+impl TransactionContract {
+    /// Store a transaction (helper for completeness)
+    pub fn add_transaction(env: Env, tx: Transaction) {
+        let mut storage: Map<u64, Transaction> =
+            env.storage().instance().get(&STORAGE_KEY).unwrap_or(Map::new(&env));
+
+        storage.set(tx.id, tx);
+
+        env.storage().instance().set(&STORAGE_KEY, &storage);
+    }
+
+    /// ✅ Core Requirement:
+    /// Fetch transactions marked for export
+    pub fn get_export_transactions(env: Env) -> Vec<Transaction> {
+        let storage: Map<u64, Transaction> =
+            env.storage().instance().get(&STORAGE_KEY).unwrap_or(Map::new(&env));
+
+        let mut result: Vec<Transaction> = Vec::new(&env);
+
+        for (_, tx) in storage.iter() {
+            if tx.export {
+                result.push_back(tx);
+            }
+        }
+
+        result
+    }
+}


### PR DESCRIPTION
feat(transactions): add export-filtered transaction retrieval

- Implement get_export_transactions to filter by export flag
- Store transactions in instance storage map
- Ensure only export-marked transactions are returned
- Maintain deterministic contract state access

closes #410