### PR TITLE
feat(budget): initialize default budget on user registration

### DIFF
--- a/contracts/budget/src/libs.rs
+++ b/contracts/budget/src/libs.rs
@@ -1,0 +1,41 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Map};
+
+// Storage key
+const BUDGETS_KEY: &str = "BUDGETS";
+
+// Default budget value (adjust as needed)
+const DEFAULT_BUDGET: i128 = 1_000;
+
+#[contract]
+pub struct BudgetContract;
+
+#[contractimpl]
+impl BudgetContract {
+    /// Register a user with a default budget
+    pub fn register_user(env: Env, user: Address) {
+        user.require_auth();
+
+        let mut budgets: Map<Address, i128> =
+            env.storage().persistent().get(&BUDGETS_KEY).unwrap_or(Map::new(&env));
+
+        // Prevent overwriting existing user budget
+        if budgets.contains_key(user.clone()) {
+            panic!("User already initialized");
+        }
+
+        // ✅ Set default budget
+        budgets.set(user, DEFAULT_BUDGET);
+
+        env.storage().persistent().set(&BUDGETS_KEY, &budgets);
+    }
+
+    /// Get user budget
+    pub fn get_budget(env: Env, user: Address) -> i128 {
+        let budgets: Map<Address, i128> =
+            env.storage().persistent().get(&BUDGETS_KEY).unwrap_or(Map::new(&env));
+
+        budgets.get(user).unwrap_or(0)
+    }
+}

--- a/contracts/user/src/lib.rs
+++ b/contracts/user/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Map};
+
+// Storage key for users map
+const USERS_KEY: &str = "USERS";
+
+#[contract]
+pub struct UsersContract;
+
+#[contractimpl]
+impl UsersContract {
+    /// Register a user (helper for testing / completeness)
+    pub fn register_user(env: Env, user: Address) {
+        user.require_auth();
+
+        let mut users: Map<Address, bool> =
+            env.storage().persistent().get(&USERS_KEY).unwrap_or(Map::new(&env));
+
+        // Prevent duplicate registration
+        if users.contains_key(user.clone()) {
+            panic!("User already registered");
+        }
+
+        users.set(user, true);
+        env.storage().persistent().set(&USERS_KEY, &users);
+    }
+
+    /// 🔍 Check if a user is already registered
+    pub fn user_exists(env: Env, user: Address) -> bool {
+        let users: Map<Address, bool> =
+            env.storage().persistent().get(&USERS_KEY).unwrap_or(Map::new(&env));
+
+        users.contains_key(user)
+    }
+}


### PR DESCRIPTION
feat(budget): initialize default budget on user registration

- Added register_user to assign default budget
- Introduced DEFAULT_BUDGET constant
- Prevents re-initialization of existing users
- Added get_budget with safe fallback
- Uses persistent storage for budget tracking

closes #394 