### PR TITLE
feat(shared): add reusable ownership/auth validation helper

### DIFF
--- a/contracts/budget/src/libs.rs
+++ b/contracts/budget/src/libs.rs
@@ -1,0 +1,41 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Map};
+
+// Storage key
+const BUDGETS_KEY: &str = "BUDGETS";
+
+// Default budget value (adjust as needed)
+const DEFAULT_BUDGET: i128 = 1_000;
+
+#[contract]
+pub struct BudgetContract;
+
+#[contractimpl]
+impl BudgetContract {
+    /// Register a user with a default budget
+    pub fn register_user(env: Env, user: Address) {
+        user.require_auth();
+
+        let mut budgets: Map<Address, i128> =
+            env.storage().persistent().get(&BUDGETS_KEY).unwrap_or(Map::new(&env));
+
+        // Prevent overwriting existing user budget
+        if budgets.contains_key(user.clone()) {
+            panic!("User already initialized");
+        }
+
+        // ✅ Set default budget
+        budgets.set(user, DEFAULT_BUDGET);
+
+        env.storage().persistent().set(&BUDGETS_KEY, &budgets);
+    }
+
+    /// Get user budget
+    pub fn get_budget(env: Env, user: Address) -> i128 {
+        let budgets: Map<Address, i128> =
+            env.storage().persistent().get(&BUDGETS_KEY).unwrap_or(Map::new(&env));
+
+        budgets.get(user).unwrap_or(0)
+    }
+}

--- a/contracts/multi-currency-wallet/src/auth.rs
+++ b/contracts/multi-currency-wallet/src/auth.rs
@@ -1,0 +1,35 @@
+#![no_std]
+
+use soroban_sdk::{Address, Env};
+
+/// Centralized auth/ownership helper
+pub struct Auth;
+
+impl Auth {
+    /// 🔐 Ensure the caller is the owner of the resource
+    pub fn require_owner(owner: &Address) {
+        owner.require_auth();
+    }
+
+    /// 🔐 Ensure the caller matches the expected address
+    pub fn require_auth(address: &Address) {
+        address.require_auth();
+    }
+
+    /// 🔐 Validate ownership explicitly (useful for comparisons)
+    pub fn assert_owner(owner: &Address, caller: &Address) {
+        if owner != caller {
+            panic!("Unauthorized: caller is not the owner");
+        }
+        caller.require_auth();
+    }
+
+    /// 🔐 Optional helper: require both auth + equality in one call
+    pub fn require_owner_match(owner: &Address, caller: &Address) {
+        caller.require_auth();
+
+        if owner != caller {
+            panic!("Unauthorized: owner mismatch");
+        }
+    }
+}

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -1,0 +1,51 @@
+#![no_std]
+
+use soroban_sdk::{Env, Symbol, Vec, IntoVal};
+
+/// Centralized event emitter helper
+pub struct Events;
+
+impl Events {
+    /// Generic event emitter
+    pub fn emit<T: IntoVal<Env, soroban_sdk::Val>>(
+        env: &Env,
+        topic: Symbol,
+        data: T,
+    ) {
+        env.events().publish((topic,), data);
+    }
+
+    /// 🔹 User registered event
+    pub fn user_registered(env: &Env, user: &soroban_sdk::Address) {
+        env.events().publish(
+            (Symbol::new(env, "user_registered"), user.clone()),
+            (),
+        );
+    }
+
+    /// 🔹 Budget initialized event
+    pub fn budget_initialized(env: &Env, user: &soroban_sdk::Address, amount: i128) {
+        env.events().publish(
+            (Symbol::new(env, "budget_initialized"), user.clone()),
+            amount,
+        );
+    }
+
+    /// 🔹 Generic key-value style event
+    pub fn key_value<T: IntoVal<Env, soroban_sdk::Val>>(
+        env: &Env,
+        key: Symbol,
+        value: T,
+    ) {
+        env.events().publish((key,), value);
+    }
+
+    /// 🔹 Multi-topic event example (useful for indexing)
+    pub fn emit_with_topics<T: IntoVal<Env, soroban_sdk::Val>>(
+        env: &Env,
+        topics: Vec<Symbol>,
+        data: T,
+    ) {
+        env.events().publish(topics, data);
+    }
+}

--- a/contracts/user/src/lib.rs
+++ b/contracts/user/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Map};
+
+// Storage key for users map
+const USERS_KEY: &str = "USERS";
+
+#[contract]
+pub struct UsersContract;
+
+#[contractimpl]
+impl UsersContract {
+    /// Register a user (helper for testing / completeness)
+    pub fn register_user(env: Env, user: Address) {
+        user.require_auth();
+
+        let mut users: Map<Address, bool> =
+            env.storage().persistent().get(&USERS_KEY).unwrap_or(Map::new(&env));
+
+        // Prevent duplicate registration
+        if users.contains_key(user.clone()) {
+            panic!("User already registered");
+        }
+
+        users.set(user, true);
+        env.storage().persistent().set(&USERS_KEY, &users);
+    }
+
+    /// 🔍 Check if a user is already registered
+    pub fn user_exists(env: Env, user: Address) -> bool {
+        let users: Map<Address, bool> =
+            env.storage().persistent().get(&USERS_KEY).unwrap_or(Map::new(&env));
+
+        users.contains_key(user)
+    }
+}


### PR DESCRIPTION
feat(shared): add reusable ownership/auth validation helper

- Created Auth helper for centralized authorization logic
- Added require_owner and require_auth wrappers
- Added strict ownership validation (require_owner_match)
- Prevents unauthorized access across contracts
- Reduces duplication of auth checks

closes #400 