### PR TITLE
feat(contract): add get_total_expense

### DIFF
--- a/contracts/transactions/src/lib.rs
+++ b/contracts/transactions/src/lib.rs
@@ -172,6 +172,11 @@ impl TransactionsContract {
     pub fn get_total_income(env: Env) -> i128 {
         storage::get_total_income(&env)
     }
+
+    /// Get the total expense from all transactions
+    pub fn get_total_expense(env: Env) -> i128 {
+        storage::get_total_expense(&env)
+    }
     
     /// Get a paginated subset of all transactions.
     ///

--- a/contracts/transactions/src/storage.rs
+++ b/contracts/transactions/src/storage.rs
@@ -398,6 +398,21 @@ pub fn get_total_income(env: &Env) -> i128 {
     total
 }
 
+/// Get the total expense from all transactions
+pub fn get_total_expense(env: &Env) -> i128 {
+    let all_txs = get_all_transactions(env);
+    let mut total: i128 = 0;
+    let expense_symbol = Symbol::new(env, "expense");
+
+    for tx in all_txs.iter() {
+        if tx.tx_type == expense_symbol {
+            total += tx.amount;
+        }
+    }
+
+    total
+}
+
 /// Get a paginated subset of all transactions.
 ///
 /// - `offset`: number of transactions to skip (0-based)

--- a/contracts/transactions/src/test.rs
+++ b/contracts/transactions/src/test.rs
@@ -588,3 +588,31 @@ fn test_get_user_transactions_filtered_by_tx_type() {
     assert_eq!(expense_txs.len(), 1);
     assert_eq!(expense_txs.get(0).unwrap().id, expense_tx);
 }
+
+#[test]
+fn test_get_total_expense() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let user = Address::generate(&env);
+    let to = Address::generate(&env);
+    let note = String::from_str(&env, "note");
+    let memo = String::from_str(&env, "memo");
+    let tags = Vec::new(&env);
+    let income = Symbol::new(&env, "income");
+    let expense = Symbol::new(&env, "expense");
+
+    // No transactions yet
+    assert_eq!(client.get_total_expense(), 0);
+
+    client.create_transaction(&user, &to, &200, &note, &memo, &tags, &income);
+    client.create_transaction(&user, &to, &50, &note, &memo, &tags, &expense);
+    client.create_transaction(&user, &to, &30, &note, &memo, &tags, &expense);
+
+    // Only expense amounts should be summed
+    assert_eq!(client.get_total_expense(), 80);
+}


### PR DESCRIPTION
Closes #405

## Summary
Add `get_total_expense` function to calculate the total of all expense transactions.

## Changes
- `storage.rs`: added `get_total_expense` — filters all transactions by `tx_type == "expense"` and sums amounts
- `lib.rs`: exposed `get_total_expense` as a public contract method
- `test.rs`: added `test_get_total_expense` covering zero state, income exclusion, and correct sum