### PR TITLE
Add category analytics batch aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "contracts/batch-token-mint",
     "contracts/asset_control",
     "contracts/access-control",
+    "contracts/category-analytics",
     "contracts/users",
     "contracts/transactions",
 ]

--- a/contracts/category-analytics/Cargo.toml
+++ b/contracts/category-analytics/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "On-chain budget category analytics contract for StellarSpend"
+autotests = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/category-analytics/src/events.rs
+++ b/contracts/category-analytics/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Symbol, Env};
+use soroban_sdk::{contracttype, Address, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,5 +16,6 @@ pub fn emit_spending_updated(env: &Env, user: Address, category: Symbol, amount:
         amount,
         timestamp: env.ledger().timestamp(),
     };
-    env.events().publish((Symbol::new(env, "spending_updated"),), event);
+    env.events()
+        .publish((Symbol::new(env, "spending_updated"),), event);
 }

--- a/contracts/category-analytics/src/lib.rs
+++ b/contracts/category-analytics/src/lib.rs
@@ -1,13 +1,16 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, log};
+use soroban_sdk::{contract, contractimpl, log, Address, Env, Symbol, Vec};
 
-pub mod types;
 pub mod events;
 #[cfg(test)]
+#[path = "../tests/integration.rs"]
+mod integration;
+#[cfg(test)]
 mod test;
+pub mod types;
 
-use crate::types::{CategorySpending, DataKey, MonthlyAnalytics};
 use crate::events::emit_spending_updated;
+use crate::types::{CategorySpend, CategorySpending, DataKey, MonthlyAnalytics};
 
 #[contract]
 pub struct CategoryAnalytics;
@@ -26,30 +29,124 @@ impl CategoryAnalytics {
     /// Updates both current spending aggregations and monthly history.
     pub fn record_spending(env: Env, user: Address, category: Symbol, amount: i128) {
         user.require_auth();
+        record_category_spending(&env, &user, category.clone(), amount);
 
-        if amount <= 0 {
-            panic!("amount must be positive");
+        log!(
+            &env,
+            "recorded spending: user={}, category={}, amount={}",
+            user,
+            category,
+            amount
+        );
+    }
+
+    /// Records a batch of spending entries for a user across one or more categories.
+    pub fn record_spending_batch(env: Env, user: Address, spendings: Vec<CategorySpend>) {
+        user.require_auth();
+
+        if spendings.len() == 0 {
+            panic!("batch must not be empty");
         }
 
-        // 1. Update Current Spending (Instance Storage for performance)
-        let current_key = DataKey::CurrentSpending(user.clone(), category.clone());
-        let mut current = env.storage().instance().get(&current_key).unwrap_or(CategorySpending {
+        for spending in spendings.iter() {
+            record_category_spending(&env, &user, spending.category, spending.amount);
+        }
+    }
+
+    /// Retrieves current aggregate spending for a user and category.
+    pub fn get_current_spending(env: Env, user: Address, category: Symbol) -> CategorySpending {
+        let key = DataKey::CurrentSpending(user, category);
+        env.storage()
+            .instance()
+            .get(&key)
+            .unwrap_or(CategorySpending {
+                count: 0,
+                volume: 0,
+            })
+    }
+
+    /// Retrieves analytics for a user and category in a specific month
+    pub fn get_category_metrics(
+        env: Env,
+        user: Address,
+        category: Symbol,
+        year: u32,
+        month: u32,
+    ) -> MonthlyAnalytics {
+        let key = DataKey::MonthlyAnalytics(year, month, user.clone(), category.clone());
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(MonthlyAnalytics {
+                user,
+                category,
+                year,
+                month,
+                volume: 0,
+                count: 0,
+                last_updated: 0,
+            })
+    }
+
+    /// Aggregates yearly trend for a user and category
+    pub fn get_yearly_trend(
+        env: Env,
+        user: Address,
+        category: Symbol,
+        year: u32,
+    ) -> CategorySpending {
+        let mut total_volume: i128 = 0;
+        let mut total_count: u32 = 0;
+
+        for month in 1..=12 {
+            let analytics = Self::get_category_metrics(
+                env.clone(),
+                user.clone(),
+                category.clone(),
+                year,
+                month,
+            );
+            total_volume = total_volume
+                .checked_add(analytics.volume)
+                .expect("volume overflow");
+            total_count += analytics.count;
+        }
+
+        CategorySpending {
+            count: total_count,
+            volume: total_volume,
+        }
+    }
+}
+
+fn record_category_spending(env: &Env, user: &Address, category: Symbol, amount: i128) {
+    if amount <= 0 {
+        panic!("amount must be positive");
+    }
+
+    let current_key = DataKey::CurrentSpending(user.clone(), category.clone());
+    let mut current = env
+        .storage()
+        .instance()
+        .get(&current_key)
+        .unwrap_or(CategorySpending {
             count: 0,
             volume: 0,
         });
 
-        current.count += 1;
-        current.volume = current.volume.checked_add(amount).expect("volume overflow");
-        env.storage().instance().set(&current_key, &current);
+    current.count += 1;
+    current.volume = current.volume.checked_add(amount).expect("volume overflow");
+    env.storage().instance().set(&current_key, &current);
 
-        // 2. Update Monthly Analytics (Persistent Storage for history)
-        let ledger_timestamp = env.ledger().timestamp();
-        // Simplified date calculation for demo (Soroban doesn't have a full date lib yet)
-        // In a real app, we'd use a more robust way to get year/month
-        let (year, month) = get_year_month(ledger_timestamp);
+    let ledger_timestamp = env.ledger().timestamp();
+    let (year, month) = get_year_month(ledger_timestamp);
 
-        let monthly_key = DataKey::MonthlyAnalytics(year, month, user.clone(), category.clone());
-        let mut monthly = env.storage().persistent().get(&monthly_key).unwrap_or(MonthlyAnalytics {
+    let monthly_key = DataKey::MonthlyAnalytics(year, month, user.clone(), category.clone());
+    let mut monthly = env
+        .storage()
+        .persistent()
+        .get(&monthly_key)
+        .unwrap_or(MonthlyAnalytics {
             user: user.clone(),
             category: category.clone(),
             year,
@@ -59,48 +156,13 @@ impl CategoryAnalytics {
             last_updated: ledger_timestamp,
         });
 
-        monthly.volume = monthly.volume.checked_add(amount).expect("volume overflow");
-        monthly.count += 1;
-        monthly.last_updated = ledger_timestamp;
+    monthly.volume = monthly.volume.checked_add(amount).expect("volume overflow");
+    monthly.count += 1;
+    monthly.last_updated = ledger_timestamp;
 
-        env.storage().persistent().set(&monthly_key, &monthly);
+    env.storage().persistent().set(&monthly_key, &monthly);
 
-        // 3. Emit event
-        emit_spending_updated(&env, user.clone(), category.clone(), amount);
-        
-        log!(&env, "recorded spending: user={}, category={}, amount={}", user, category, amount);
-    }
-
-    /// Retrieves analytics for a user and category in a specific month
-    pub fn get_category_metrics(env: Env, user: Address, category: Symbol, year: u32, month: u32) -> MonthlyAnalytics {
-        let key = DataKey::MonthlyAnalytics(year, month, user.clone(), category.clone());
-        env.storage().persistent().get(&key).unwrap_or(MonthlyAnalytics {
-            user,
-            category,
-            year,
-            month,
-            volume: 0,
-            count: 0,
-            last_updated: 0,
-        })
-    }
-
-    /// Aggregates yearly trend for a user and category
-    pub fn get_yearly_trend(env: Env, user: Address, category: Symbol, year: u32) -> CategorySpending {
-        let mut total_volume: i128 = 0;
-        let mut total_count: u32 = 0;
-
-        for month in 1..=12 {
-            let analytics = Self::get_category_metrics(env.clone(), user.clone(), category.clone(), year, month);
-            total_volume = total_volume.checked_add(analytics.volume).expect("volume overflow");
-            total_count += analytics.count;
-        }
-
-        CategorySpending {
-            count: total_count,
-            volume: total_volume,
-        }
-    }
+    emit_spending_updated(env, user.clone(), category, amount);
 }
 
 /// Helper function to estimate year and month from timestamp

--- a/contracts/category-analytics/src/test.rs
+++ b/contracts/category-analytics/src/test.rs
@@ -19,8 +19,8 @@ fn test_record_spending() {
     client.record_spending(&user, &category, &1000);
 
     let _metrics = client.get_category_metrics(&user, &category, &2026, &2); // Assuming current date in test env
-    // Note: get_year_month(0) gives 1970, 1. But Env::default().ledger().timestamp() is typically higher or configurable.
-    // Let's check what the default timestamp is.
+                                                                             // Note: get_year_month(0) gives 1970, 1. But Env::default().ledger().timestamp() is typically higher or configurable.
+                                                                             // Let's check what the default timestamp is.
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn test_yearly_trend() {
 
     // Record spending in different "months" by advancing ledger time
     // Default ledger time starts at 0 or a small number.
-    
+
     client.record_spending(&user, &category, &500);
     client.record_spending(&user, &category, &500);
 

--- a/contracts/category-analytics/src/types.rs
+++ b/contracts/category-analytics/src/types.rs
@@ -8,6 +8,14 @@ pub struct CategorySpending {
     pub volume: i128,
 }
 
+/// Spending entry used for multi-category batch aggregation
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CategorySpend {
+    pub category: Symbol,
+    pub amount: i128,
+}
+
 /// Historical analytics record for a user, category, and month
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/category-analytics/tests/integration.rs
+++ b/contracts/category-analytics/tests/integration.rs
@@ -1,11 +1,10 @@
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
-    Address, Env, Symbol,
+    vec, Address, Env, Symbol,
 };
 
-use category_analytics::{
-    CategoryAnalytics, CategoryAnalyticsClient,
-};
+use crate::types::CategorySpend;
+use crate::{CategoryAnalytics, CategoryAnalyticsClient};
 // handle hash
 fn setup_analytics_contract() -> (Env, Address, CategoryAnalyticsClient<'static>) {
     let env = Env::default();
@@ -47,4 +46,57 @@ fn test_integration_spending_trends() {
     let yearly = client.get_yearly_trend(&user, &category, &2026);
     assert_eq!(yearly.volume, 10000);
     assert_eq!(yearly.count, 3);
+}
+
+#[test]
+fn test_multi_category_batch_aggregation() {
+    let (env, _admin, client) = setup_analytics_contract();
+    let user = Address::generate(&env);
+    let shopping = Symbol::new(&env, "shopping");
+    let groceries = Symbol::new(&env, "groceries");
+    let transport = Symbol::new(&env, "transport");
+
+    env.ledger().set_timestamp(1768608000);
+
+    let spendings = vec![
+        &env,
+        CategorySpend {
+            category: shopping.clone(),
+            amount: 5000,
+        },
+        CategorySpend {
+            category: groceries.clone(),
+            amount: 2500,
+        },
+        CategorySpend {
+            category: shopping.clone(),
+            amount: 1500,
+        },
+        CategorySpend {
+            category: transport.clone(),
+            amount: 900,
+        },
+    ];
+
+    client.record_spending_batch(&user, &spendings);
+
+    let shopping_metrics = client.get_category_metrics(&user, &shopping, &2026, &2);
+    assert_eq!(shopping_metrics.volume, 6500);
+    assert_eq!(shopping_metrics.count, 2);
+
+    let groceries_metrics = client.get_category_metrics(&user, &groceries, &2026, &2);
+    assert_eq!(groceries_metrics.volume, 2500);
+    assert_eq!(groceries_metrics.count, 1);
+
+    let transport_metrics = client.get_category_metrics(&user, &transport, &2026, &2);
+    assert_eq!(transport_metrics.volume, 900);
+    assert_eq!(transport_metrics.count, 1);
+
+    let shopping_current = client.get_current_spending(&user, &shopping);
+    assert_eq!(shopping_current.volume, 6500);
+    assert_eq!(shopping_current.count, 2);
+
+    let shopping_yearly = client.get_yearly_trend(&user, &shopping, &2026);
+    assert_eq!(shopping_yearly.volume, 6500);
+    assert_eq!(shopping_yearly.count, 2);
 }


### PR DESCRIPTION
This PR adds multi-category batch aggregation support to the category analytics contract by introducing a CategorySpend batch item type, adding record_spending_batch, and routing both single-entry and batch recording through shared aggregation logic so monthly, current, and yearly category metrics remain consistent. It also adds integration coverage for mixed-category batches with repeated category entries, registers category-analytics as a workspace member, and keeps the contract-standard cdylib/rlib crate type while configuring tests to avoid host cdylib linking issues. Verified with cargo fmt -p category-analytics -- --check, cargo test -p category-analytics, and cargo build -p category-analytics --target wasm32-unknown-unknown --release.
closes #454 