### PR TITLE
feat: add spending category rename support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "contracts/asset_control",
     "contracts/access-control",
     "contracts/category-analytics",
+    "contracts/spending-categories",
     "contracts/users",
     "contracts/transactions",
 ]

--- a/contracts/spending-categories/Cargo.toml
+++ b/contracts/spending-categories/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "spending-categories"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+default = []
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/spending-categories/src/lib.rs
+++ b/contracts/spending-categories/src/lib.rs
@@ -1,0 +1,315 @@
+//! # Spending Categories Contract
+//!
+//! A Soroban smart contract for managing spending categories with
+//! rename support, duplicate prevention, and event emission.
+//!
+//! ## Features
+//!
+//! - **Category Management**: Create and rename spending categories
+//! - **Duplicate Prevention**: Ensures category names are unique per wallet
+//! - **Event Emission**: Emits events for category creation and renames
+//! - **Admin Control**: Only admin can manage categories
+
+#![no_std]
+
+mod validation;
+
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Env, Symbol, Vec};
+
+use crate::validation::validate_category_name;
+
+/// Error codes for the spending categories contract.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum CategoryError {
+    /// Contract not initialized
+    NotInitialized = 1,
+    /// Caller is not authorized
+    Unauthorized = 2,
+    /// Category name is empty or invalid
+    InvalidName = 3,
+    /// Category name already exists for this wallet
+    DuplicateName = 4,
+    /// Category not found
+    CategoryNotFound = 5,
+}
+
+impl From<CategoryError> for soroban_sdk::Error {
+    fn from(e: CategoryError) -> Self {
+        soroban_sdk::Error::from_contract_error(e as u32)
+    }
+}
+
+/// Represents a spending category entry.
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct SpendingCategory {
+    /// Unique category identifier
+    pub category_id: u64,
+    /// The wallet owner of this category
+    pub user: Address,
+    /// The category name
+    pub name: Symbol,
+    /// When the category was created (ledger sequence)
+    pub created_at: u64,
+    /// When the category was last updated
+    pub updated_at: u64,
+}
+
+/// Storage keys for the contract.
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    LastCategoryId,
+    TotalCategories,
+    Category(u64),
+    /// Maps (user, name) -> category_id for duplicate detection
+    CategoryByName(Address, Symbol),
+    /// Maps user -> list of category IDs
+    UserCategories(Address),
+}
+
+/// Events emitted by the contract.
+pub struct CategoryEvents;
+
+impl CategoryEvents {
+    pub fn category_created(env: &Env, category: &SpendingCategory) {
+        let topics = (symbol_short!("category"), symbol_short!("created"));
+        env.events().publish(topics, (category.category_id, category.user.clone(), category.name.clone()));
+    }
+
+    pub fn category_renamed(env: &Env, category_id: u64, old_name: Symbol, new_name: Symbol) {
+        let topics = (symbol_short!("category"), symbol_short!("renamed"));
+        env.events().publish(topics, (category_id, old_name, new_name));
+    }
+}
+
+#[contract]
+pub struct SpendingCategoriesContract;
+
+#[contractimpl]
+impl SpendingCategoriesContract {
+    /// Initializes the contract with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Contract already initialized");
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::LastCategoryId, &0u64);
+        env.storage().instance().set(&DataKey::TotalCategories, &0u64);
+    }
+
+    /// Creates a new spending category for a user.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `caller` - The admin address
+    /// * `user` - The wallet owner
+    /// * `name` - The category name
+    ///
+    /// # Returns
+    /// * `SpendingCategory` - The created category
+    pub fn create_category(
+        env: Env,
+        caller: Address,
+        user: Address,
+        name: Symbol,
+    ) -> SpendingCategory {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+
+        // Validate category name
+        if validate_category_name(&name).is_err() {
+            panic_with_error!(&env, CategoryError::InvalidName);
+        }
+
+        // Check for duplicate name for this user
+        if env.storage().persistent().has(&DataKey::CategoryByName(user.clone(), name.clone())) {
+            panic_with_error!(&env, CategoryError::DuplicateName);
+        }
+
+        let category_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LastCategoryId)
+            .unwrap_or(0)
+            + 1;
+
+        let current_ledger = env.ledger().sequence() as u64;
+
+        let category = SpendingCategory {
+            category_id,
+            user: user.clone(),
+            name: name.clone(),
+            created_at: current_ledger,
+            updated_at: current_ledger,
+        };
+
+        // Store category
+        env.storage()
+            .persistent()
+            .set(&DataKey::Category(category_id), &category);
+
+        // Store name-to-id mapping for duplicate detection
+        env.storage()
+            .persistent()
+            .set(&DataKey::CategoryByName(user.clone(), name), &category_id);
+
+        // Update user's category list
+        let mut user_categories: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserCategories(user.clone()))
+            .unwrap_or(Vec::new(&env));
+        user_categories.push_back(category_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::UserCategories(user.clone()), &user_categories);
+
+        // Update counters
+        env.storage()
+            .instance()
+            .set(&DataKey::LastCategoryId, &category_id);
+
+        let total: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalCategories)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalCategories, &(total + 1));
+
+        // Emit event
+        CategoryEvents::category_created(&env, &category);
+
+        category
+    }
+
+    /// Renames an existing spending category.
+    ///
+    /// This preserves the category_id so that existing transactions
+    /// and spending limits remain linked to the category.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `caller` - The admin address
+    /// * `category_id` - The ID of the category to rename
+    /// * `new_name` - The new name for the category
+    ///
+    /// # Returns
+    /// * `SpendingCategory` - The updated category
+    pub fn rename_category(
+        env: Env,
+        caller: Address,
+        category_id: u64,
+        new_name: Symbol,
+    ) -> SpendingCategory {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+
+        // Validate new name
+        if validate_category_name(&new_name).is_err() {
+            panic_with_error!(&env, CategoryError::InvalidName);
+        }
+
+        // Fetch existing category
+        let mut category: SpendingCategory = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Category(category_id))
+            .unwrap_or_else(|| panic_with_error!(&env, CategoryError::CategoryNotFound));
+
+        let old_name = category.name.clone();
+
+        // Check for duplicate name (excluding self)
+        if old_name != new_name {
+            if env
+                .storage()
+                .persistent()
+                .has(&DataKey::CategoryByName(category.user.clone(), new_name.clone()))
+            {
+                panic_with_error!(&env, CategoryError::DuplicateName);
+            }
+
+            // Remove old name mapping
+            env.storage()
+                .persistent()
+                .remove(&DataKey::CategoryByName(category.user.clone(), old_name.clone()));
+
+            // Add new name mapping
+            env.storage().persistent().set(
+                &DataKey::CategoryByName(category.user.clone(), new_name.clone()),
+                &category_id,
+            );
+        }
+
+        // Update category
+        category.name = new_name.clone();
+        category.updated_at = env.ledger().sequence() as u64;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Category(category_id), &category);
+
+        // Emit rename event
+        CategoryEvents::category_renamed(&env, category_id, old_name, new_name);
+
+        category
+    }
+
+    /// Retrieves a category by ID.
+    pub fn get_category(env: Env, category_id: u64) -> Option<SpendingCategory> {
+        env.storage().persistent().get(&DataKey::Category(category_id))
+    }
+
+    /// Retrieves all category IDs for a user.
+    pub fn get_user_categories(env: Env, user: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::UserCategories(user))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns the admin address.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized")
+    }
+
+    /// Updates the admin address.
+    pub fn set_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        Self::require_admin(&env, &current_admin);
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+    }
+
+    /// Returns the total number of categories created.
+    pub fn get_total_categories(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalCategories)
+            .unwrap_or(0)
+    }
+
+    // Internal helper to verify admin
+    fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
+
+        if *caller != admin {
+            panic_with_error!(env, CategoryError::Unauthorized);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/spending-categories/src/test.rs
+++ b/contracts/spending-categories/src/test.rs
@@ -1,0 +1,171 @@
+//! Comprehensive unit tests for the spending categories contract.
+
+#![cfg(test)]
+
+use crate::{SpendingCategoriesContract, SpendingCategoriesContractClient};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+/// Helper function to create a test environment with initialized contract.
+fn setup_test_contract() -> (Env, Address, SpendingCategoriesContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SpendingCategoriesContract, ());
+    let client = SpendingCategoriesContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, admin, client)
+}
+
+#[test]
+fn test_initialize() {
+    let (_, admin, client) = setup_test_contract();
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_total_categories(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_initialize_twice_fails() {
+    let (env, _, client) = setup_test_contract();
+    let new_admin = Address::generate(&env);
+    client.initialize(&new_admin);
+}
+
+#[test]
+fn test_create_category() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    let category = client.create_category(&admin, &user, &symbol_short!("Food"));
+
+    assert_eq!(category.category_id, 1);
+    assert_eq!(category.user, user);
+    assert_eq!(category.name, symbol_short!("Food"));
+    assert_eq!(client.get_total_categories(), 1);
+
+    // Verify retrieval
+    let fetched = client.get_category(&1).unwrap();
+    assert_eq!(fetched.name, symbol_short!("Food"));
+}
+
+#[test]
+fn test_create_multiple_categories_for_same_user() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    let cat1 = client.create_category(&admin, &user, &symbol_short!("Food"));
+    let cat2 = client.create_category(&admin, &user, &symbol_short!("Transport"));
+
+    assert_eq!(cat1.category_id, 1);
+    assert_eq!(cat2.category_id, 2);
+    assert_eq!(client.get_total_categories(), 2);
+
+    let user_cats = client.get_user_categories(&user);
+    assert_eq!(user_cats.len(), 2);
+}
+
+#[test]
+fn test_create_categories_for_different_users() {
+    let (env, admin, client) = setup_test_contract();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    client.create_category(&admin, &user1, &symbol_short!("Food"));
+    client.create_category(&admin, &user2, &symbol_short!("Food")); // Same name, different user - allowed
+
+    assert_eq!(client.get_total_categories(), 2);
+}
+
+#[test]
+#[should_panic]
+fn test_create_duplicate_category_same_user() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    client.create_category(&admin, &user, &symbol_short!("Food"));
+    // Should panic on duplicate
+    client.create_category(&admin, &user, &symbol_short!("Food"));
+}
+
+#[test]
+fn test_rename_category() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    client.create_category(&admin, &user, &symbol_short!("Food"));
+
+    let renamed = client.rename_category(&admin, &1, &symbol_short!("Groceries"));
+
+    assert_eq!(renamed.category_id, 1);
+    assert_eq!(renamed.name, symbol_short!("Groceries"));
+
+    // Verify stored correctly
+    let fetched = client.get_category(&1).unwrap();
+    assert_eq!(fetched.name, symbol_short!("Groceries"));
+}
+
+#[test]
+fn test_rename_to_same_name() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    client.create_category(&admin, &user, &symbol_short!("Food"));
+
+    // Renaming to the same name should succeed (no-op)
+    let renamed = client.rename_category(&admin, &1, &symbol_short!("Food"));
+    assert_eq!(renamed.name, symbol_short!("Food"));
+}
+
+#[test]
+#[should_panic]
+fn test_rename_to_duplicate_name() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    client.create_category(&admin, &user, &symbol_short!("Food"));
+    client.create_category(&admin, &user, &symbol_short!("Transport"));
+
+    // Try to rename "Transport" to "Food" (duplicate)
+    client.rename_category(&admin, &2, &symbol_short!("Food"));
+}
+
+#[test]
+#[should_panic]
+fn test_rename_nonexistent_category() {
+    let (env, admin, client) = setup_test_contract();
+
+    client.rename_category(&admin, &999, &symbol_short!("Test"));
+}
+
+#[test]
+fn test_rename_preserves_category_id() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    client.create_category(&admin, &user, &symbol_short!("Food"));
+
+    let renamed = client.rename_category(&admin, &1, &symbol_short!("Groceries"));
+    assert_eq!(renamed.category_id, 1);
+}
+
+#[test]
+fn test_get_nonexistent_category() {
+    let (_, _, client) = setup_test_contract();
+
+    let result = client.get_category(&999);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_set_admin() {
+    let (env, admin, client) = setup_test_contract();
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+}

--- a/contracts/spending-categories/src/validation.rs
+++ b/contracts/spending-categories/src/validation.rs
@@ -1,0 +1,48 @@
+//! Validation logic for spending category names.
+
+use soroban_sdk::Symbol;
+
+/// Validates that a category name is not empty and has reasonable length.
+///
+/// # Returns
+/// * `Ok(())` if valid
+/// * `Err(())` if invalid
+pub fn validate_category_name(name: &Symbol) -> Result<(), ()> {
+    // In Soroban, Symbols are always valid by construction,
+    // but we verify the name is non-empty and within bounds.
+    // A Symbol's length is the number of characters.
+    // We check that it's not an empty symbol and within a reasonable max length.
+    let len = name.len();
+    if len == 0 || len > 32 {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, Env};
+
+    #[test]
+    fn test_valid_category_name() {
+        let env = Env::default();
+        let name = symbol_short!("Food");
+        assert!(validate_category_name(&name).is_ok());
+    }
+
+    #[test]
+    fn test_valid_short_name() {
+        let env = Env::default();
+        let name = symbol_short!("A");
+        assert!(validate_category_name(&name).is_ok());
+    }
+
+    #[test]
+    fn test_valid_long_name() {
+        let env = Env::default();
+        // 32-char name
+        let name = Symbol::new(&env, "abcdefghijklmnopqrstuvwxyz012345");
+        assert!(validate_category_name(&name).is_ok());
+    }
+}


### PR DESCRIPTION
Closes #501

- Create spending-categories contract with create/rename functionality
- Add duplicate name prevention per wallet
- Emit events for category creation and renames
- Include comprehensive test suite