### PR TITLE
fix: add duplicate savings goal name validation

### DIFF
--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::types::{
     ErrorCode, GoalEvents, GoalResult, MilestoneAchievement, MilestoneAchievementRequest,
     MilestoneResult, SavingsGoal, SavingsGoalProgress, SavingsGoalRequest, MAX_BATCH_SIZE,
 };
-use crate::validation::{validate_goal_request, validate_milestone_request};
+use crate::validation::{validate_goal_name_unique, validate_goal_request, validate_milestone_request};
 
 /// Error codes for the savings goals contract.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -315,6 +315,14 @@ impl SavingsGoalsContract {
             // Validate the request
             match validate_goal_request(&env, &request) {
                 Ok(()) => {
+                    // Check for duplicate goal name for this user
+                    if let Err(error_code) = validate_goal_name_unique(&env, &request.user, &request.goal_name) {
+                        failed_count += 1;
+                        GoalEvents::goal_creation_failed(&env, batch_id, &request.user, error_code);
+                        results.push_back(GoalResult::Failure(request.user.clone(), error_code));
+                        continue;
+                    }
+
                     // Validation succeeded - create the goal
                     goal_id_counter += 1;
 
@@ -344,6 +352,10 @@ impl SavingsGoalsContract {
                     env.storage()
                         .persistent()
                         .set(&DataKey::Goal(goal_id_counter), &goal);
+                    // Store name-to-id mapping for duplicate detection
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::GoalByName(request.user.clone(), request.goal_name.clone()), &goal_id_counter);
                     // Emit milestone events for initial contribution
                     Self::check_and_emit_milestones(&env, goal_id_counter);
 

--- a/contracts/savings-goals/src/test.rs
+++ b/contracts/savings-goals/src/test.rs
@@ -475,6 +475,82 @@ fn test_zero_initial_contribution() {
 }
 
 #[test]
+fn test_duplicate_goal_name_same_user() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    let mut requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests.push_back(create_valid_request(&env, &user, "vacation", 100_000_000));
+    requests.push_back(create_valid_request(&env, &user, "vacation", 200_000_000)); // Duplicate name
+
+    let result = client.batch_set_savings_goals(&admin, &requests);
+
+    assert_eq!(result.total_requests, 2);
+    assert_eq!(result.successful, 1); // First one succeeds
+    assert_eq!(result.failed, 1); // Second one fails (duplicate name)
+
+    // Verify first succeeded
+    match &result.results.get(0).unwrap() {
+        GoalResult::Success(_) => {}
+        GoalResult::Failure(_, _) => panic!("Expected first request to succeed"),
+    }
+
+    // Verify second failed with duplicate error
+    match &result.results.get(1).unwrap() {
+        GoalResult::Success(_) => panic!("Expected second request to fail"),
+        GoalResult::Failure(_, error_code) => {
+            assert_eq!(*error_code, ErrorCode::DUPLICATE_GOAL_NAME);
+        }
+    }
+
+    assert_eq!(client.get_total_goals_created(), 1);
+}
+
+#[test]
+fn test_same_goal_name_different_users() {
+    let (env, admin, client) = setup_test_contract();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    let mut requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests.push_back(create_valid_request(&env, &user1, "vacation", 100_000_000));
+    requests.push_back(create_valid_request(&env, &user2, "vacation", 200_000_000)); // Same name, different user
+
+    let result = client.batch_set_savings_goals(&admin, &requests);
+
+    assert_eq!(result.total_requests, 2);
+    assert_eq!(result.successful, 2); // Both should succeed
+    assert_eq!(result.failed, 0);
+    assert_eq!(client.get_total_goals_created(), 2);
+}
+
+#[test]
+fn test_duplicate_goal_name_across_batches() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    // First batch creates "vacation"
+    let mut requests1: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests1.push_back(create_valid_request(&env, &user, "vacation", 100_000_000));
+    let result1 = client.batch_set_savings_goals(&admin, &requests1);
+    assert_eq!(result1.successful, 1);
+
+    // Second batch tries to create "vacation" again for same user
+    let mut requests2: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests2.push_back(create_valid_request(&env, &user, "vacation", 200_000_000));
+    let result2 = client.batch_set_savings_goals(&admin, &requests2);
+    assert_eq!(result2.successful, 0);
+    assert_eq!(result2.failed, 1);
+
+    match &result2.results.get(0).unwrap() {
+        GoalResult::Failure(_, error_code) => {
+            assert_eq!(*error_code, ErrorCode::DUPLICATE_GOAL_NAME);
+        }
+        GoalResult::Success(_) => panic!("Expected duplicate to fail"),
+    }
+}
+
+#[test]
 fn test_full_initial_contribution() {
     let (env, admin, client) = setup_test_contract();
     let user = Address::generate(&env);

--- a/contracts/savings-goals/src/types.rs
+++ b/contracts/savings-goals/src/types.rs
@@ -217,6 +217,8 @@ pub enum DataKey {
     GoalMilestonesPercent(u64),
     /// Total milestones achieved lifetime
     TotalMilestonesAchieved,
+    /// Maps (user, goal_name) -> goal_id for duplicate detection
+    GoalByName(Address, Symbol),
 }
 
 /// Error codes for goal validation and creation.
@@ -243,6 +245,8 @@ pub mod ErrorCode {
     pub const UNAUTHORIZED_USER: u32 = 8;
     /// Goal has already achieved this milestone
     pub const MILESTONE_ALREADY_ACHIEVED: u32 = 9;
+    /// Duplicate goal name for the same user
+    pub const DUPLICATE_GOAL_NAME: u32 = 11;
 }
 
 /// Events emitted by the savings goals contract.

--- a/contracts/savings-goals/src/validation.rs
+++ b/contracts/savings-goals/src/validation.rs
@@ -1,11 +1,20 @@
 //! Validation logic for savings goal requests.
 
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Symbol};
 
 use crate::types::{
     DataKey, ErrorCode, MilestoneAchievementRequest, SavingsGoal, SavingsGoalRequest,
     MAX_GOAL_AMOUNT, MIN_GOAL_AMOUNT,
 };
+
+/// Checks whether the user already has a goal with the same name.
+/// Returns an error code if a duplicate is found.
+pub fn validate_goal_name_unique(env: &Env, user: &Address, goal_name: &Symbol) -> Result<(), u32> {
+    if env.storage().persistent().has(&DataKey::GoalByName(user.clone(), goal_name.clone())) {
+        return Err(ErrorCode::DUPLICATE_GOAL_NAME);
+    }
+    Ok(())
+}
 
 /// Validates a savings goal request.
 ///
@@ -307,5 +316,47 @@ mod tests {
         assert!(is_valid_initial_contribution(100_000_000, 100_000_000));
         assert!(!is_valid_initial_contribution(-1, 100_000_000));
         assert!(!is_valid_initial_contribution(100_000_001, 100_000_000));
+    }
+
+    #[test]
+    fn test_validate_goal_name_unique_no_duplicate() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let name = symbol_short!("vacation");
+        // No goal exists yet, so should be OK
+        assert!(validate_goal_name_unique(&env, &user, &name).is_ok());
+    }
+
+    #[test]
+    fn test_validate_goal_name_unique_detects_duplicate() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let name = symbol_short!("vacation");
+
+        // Simulate an existing goal with this name
+        env.storage()
+            .persistent()
+            .set(&DataKey::GoalByName(user.clone(), name.clone()), &1u64);
+
+        assert_eq!(
+            validate_goal_name_unique(&env, &user, &name),
+            Err(ErrorCode::DUPLICATE_GOAL_NAME)
+        );
+    }
+
+    #[test]
+    fn test_validate_goal_name_unique_allows_same_name_different_user() {
+        let env = Env::default();
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        let name = symbol_short!("vacation");
+
+        // User1 has the name
+        env.storage()
+            .persistent()
+            .set(&DataKey::GoalByName(user1.clone(), name.clone()), &1u64);
+
+        // User2 should still be able to use the same name
+        assert!(validate_goal_name_unique(&env, &user2, &name).is_ok());
     }
 }


### PR DESCRIPTION
Closes #500

- Add GoalByName storage key for efficient duplicate detection
- Add validate_goal_name_unique function in validation.rs
- Enforce duplicate name check in batch_set_savings_goals
- Same names allowed for different users
- Add comprehensive unit and integration tests