### PR TITLE
feat: add transaction memo length validation (#498)

### DIFF
--- a/contracts/transaction-memo/Cargo.toml
+++ b/contracts/transaction-memo/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "transaction-memo"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+default = []
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/transaction-memo/src/lib.rs
+++ b/contracts/transaction-memo/src/lib.rs
@@ -1,0 +1,220 @@
+//! # Transaction Memo Contract
+//!
+//! A Soroban smart contract for managing transaction memos with
+//! length validation to prevent oversized payloads and manage storage costs.
+//!
+//! ## Features
+//!
+//! - **Memo Storage**: Store and retrieve transaction memos
+//! - **Length Validation**: Reject oversized memo text, references, and total payload
+//! - **Boundary Checks**: Validates memo type, reference, and text lengths
+//! - **Event Emission**: Emits events for memo operations
+
+#![no_std]
+
+mod validation;
+
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, symbol_short, Address, Bytes, Env, String, Symbol};
+
+use crate::validation::{validate_memo_text_length, validate_memo_reference_length, validate_total_memo_size};
+
+/// Error codes for the transaction memo contract.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum MemoError {
+    /// Contract not initialized
+    NotInitialized = 1,
+    /// Caller is not authorized
+    Unauthorized = 2,
+    /// Memo text is empty
+    EmptyMemoText = 3,
+    /// Memo text exceeds maximum length
+    MemoTextTooLarge = 4,
+    /// Memo reference exceeds maximum length
+    MemoReferenceTooLarge = 5,
+    /// Total memo payload exceeds maximum size
+    MemoTooLarge = 6,
+    /// Invalid memo type
+    InvalidMemoType = 7,
+}
+
+impl From<MemoError> for soroban_sdk::Error {
+    fn from(e: MemoError) -> Self {
+        soroban_sdk::Error::from_contract_error(e as u32)
+    }
+}
+
+/// Represents a transaction memo.
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct TransactionMemo {
+    /// The transaction ID this memo belongs to
+    pub transaction_id: Bytes,
+    /// The memo type (e.g., "payment", "refund", "note")
+    pub memo_type: Symbol,
+    /// Optional reference string
+    pub reference: String,
+    /// The memo text content
+    pub text: String,
+    /// When the memo was created (ledger timestamp)
+    pub created_at: u64,
+}
+
+/// Storage keys for the contract.
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Memo(Bytes),
+    TotalMemos,
+}
+
+/// Events emitted by the contract.
+pub struct MemoEvents;
+
+impl MemoEvents {
+    pub fn memo_stored(env: &Env, transaction_id: &Bytes, memo_type: &Symbol, created_at: u64) {
+        let topics = (symbol_short!("memo"), symbol_short!("stored"));
+        env.events().publish(topics, (transaction_id.clone(), memo_type.clone(), created_at));
+    }
+}
+
+#[contract]
+pub struct TransactionMemoContract;
+
+#[contractimpl]
+impl TransactionMemoContract {
+    /// Initializes the contract with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Contract already initialized");
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TotalMemos, &0u64);
+    }
+
+    /// Stores a transaction memo with length validation.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `caller` - The admin address
+    /// * `transaction_id` - Unique transaction identifier
+    /// * `memo_type` - Type of memo
+    /// * `reference` - Optional reference string
+    /// * `text` - Memo text content
+    pub fn set_memo(
+        env: Env,
+        caller: Address,
+        transaction_id: Bytes,
+        memo_type: Symbol,
+        reference: String,
+        text: String,
+    ) {
+        caller.require_auth();
+        Self::require_admin(&env, &caller);
+
+        // Validate memo type (must not be empty)
+        if memo_type.len() == 0 {
+            panic_with_error!(&env, MemoError::InvalidMemoType);
+        }
+
+        // Validate text length
+        if let Err(_) = validate_memo_text_length(&text) {
+            if text.len() == 0 {
+                panic_with_error!(&env, MemoError::EmptyMemoText);
+            } else {
+                panic_with_error!(&env, MemoError::MemoTextTooLarge);
+            }
+        }
+
+        // Validate reference length
+        if let Err(_) = validate_memo_reference_length(&reference) {
+            panic_with_error!(&env, MemoError::MemoReferenceTooLarge);
+        }
+
+        // Validate total memo size
+        if let Err(_) = validate_total_memo_size(
+            text.len() as u32,
+            reference.len() as u32,
+            memo_type.len() as u32,
+        ) {
+            panic_with_error!(&env, MemoError::MemoTooLarge);
+        }
+
+        let created_at = env.ledger().timestamp();
+
+        let memo = TransactionMemo {
+            transaction_id: transaction_id.clone(),
+            memo_type: memo_type.clone(),
+            reference: reference.clone(),
+            text: text.clone(),
+            created_at,
+        };
+
+        // Store the memo
+        env.storage()
+            .persistent()
+            .set(&DataKey::Memo(transaction_id.clone()), &memo);
+
+        // Update total count
+        let total: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalMemos)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalMemos, &(total + 1));
+
+        // Emit event
+        MemoEvents::memo_stored(&env, &transaction_id, &memo_type, created_at);
+    }
+
+    /// Retrieves a transaction memo by transaction ID.
+    pub fn get_memo(env: Env, transaction_id: Bytes) -> Option<TransactionMemo> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Memo(transaction_id))
+    }
+
+    /// Returns the admin address.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized")
+    }
+
+    /// Updates the admin address.
+    pub fn set_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        Self::require_admin(&env, &current_admin);
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+    }
+
+    /// Returns the total number of memos stored.
+    pub fn get_total_memos(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalMemos)
+            .unwrap_or(0)
+    }
+
+    // Internal helper to verify admin
+    fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Contract not initialized");
+
+        if *caller != admin {
+            panic_with_error!(env, MemoError::Unauthorized);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/transaction-memo/src/test.rs
+++ b/contracts/transaction-memo/src/test.rs
@@ -1,0 +1,177 @@
+//! Comprehensive unit tests for the transaction memo contract.
+
+#![cfg(test)]
+
+use crate::{TransactionMemoContract, TransactionMemoContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, String, Symbol};
+
+/// Helper function to create a test environment with initialized contract.
+fn setup_test_contract() -> (Env, Address, TransactionMemoContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TransactionMemoContract, ());
+    let client = TransactionMemoContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    (env, admin, client)
+}
+
+fn tx_id(env: &Env, s: &str) -> Bytes {
+    let mut b = Bytes::new(env);
+    b.extend_from_slice(s.as_bytes());
+    b
+}
+
+#[test]
+fn test_initialize() {
+    let (_, admin, client) = setup_test_contract();
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_total_memos(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_initialize_twice_fails() {
+    let (env, _, client) = setup_test_contract();
+    let new_admin = Address::generate(&env);
+    client.initialize(&new_admin);
+}
+
+#[test]
+fn test_set_and_get_memo() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-1");
+    let memo_type = Symbol::new(&env, "payment");
+    let reference = String::from_str(&env, "ref-123");
+    let text = String::from_str(&env, "Payment for services");
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+
+    let memo = client.get_memo(&id).unwrap();
+    assert_eq!(memo.memo_type, memo_type);
+    assert_eq!(memo.reference, reference);
+    assert_eq!(memo.text, text);
+    assert_eq!(client.get_total_memos(), 1);
+}
+
+#[test]
+#[should_panic]
+fn test_memo_text_too_large() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-oversized");
+    let memo_type = Symbol::new(&env, "note");
+    let reference = String::from_str(&env, "");
+    // Create text exceeding 256 bytes
+    let long_text = "a".repeat(300);
+    let text = String::from_str(&env, &long_text);
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+#[should_panic]
+fn test_memo_empty_text() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-empty");
+    let memo_type = Symbol::new(&env, "note");
+    let reference = String::from_str(&env, "");
+    let text = String::from_str(&env, "");
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+#[should_panic]
+fn test_memo_reference_too_large() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-longref");
+    let memo_type = Symbol::new(&env, "note");
+    let reference = String::from_str(&env, &"r".repeat(100));
+    let text = String::from_str(&env, "Valid text");
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+fn test_memo_text_at_max_length() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-max");
+    let memo_type = Symbol::new(&env, "note");
+    let reference = String::from_str(&env, "");
+    // Exactly 256 bytes
+    let text = String::from_str(&env, &"a".repeat(256));
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+
+    let memo = client.get_memo(&id).unwrap();
+    assert_eq!(memo.text.len(), 256);
+}
+
+#[test]
+fn test_memo_reference_at_max_length() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-refmax");
+    let memo_type = Symbol::new(&env, "x");
+    let reference = String::from_str(&env, &"r".repeat(64));
+    let text = String::from_str(&env, "Short");
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+
+    let memo = client.get_memo(&id).unwrap();
+    assert_eq!(memo.reference.len(), 64);
+}
+
+#[test]
+#[should_panic]
+fn test_total_memo_too_large() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-total");
+    let memo_type = Symbol::new(&env, &"t".repeat(32));
+    let reference = String::from_str(&env, &"r".repeat(64));
+    let text = String::from_str(&env, &"a".repeat(256));
+    // Total: 32 + 64 + 256 = 352 > 320 MAX
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}
+
+#[test]
+fn test_get_nonexistent_memo() {
+    let (env, _, client) = setup_test_contract();
+
+    let id = tx_id(&env, "nonexistent");
+    let result = client.get_memo(&id);
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_set_admin() {
+    let (env, admin, client) = setup_test_contract();
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+#[should_panic]
+fn test_empty_memo_type() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-notype");
+    let memo_type = Symbol::new(&env, "");
+    let reference = String::from_str(&env, "");
+    let text = String::from_str(&env, "Valid text");
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+}

--- a/contracts/transaction-memo/src/validation.rs
+++ b/contracts/transaction-memo/src/validation.rs
@@ -1,0 +1,121 @@
+//! Validation logic for transaction memo length.
+
+use soroban_sdk::String;
+
+/// Maximum memo text length in bytes (256 bytes to prevent oversized payloads).
+pub const MAX_MEMO_TEXT_LENGTH: u32 = 256;
+
+/// Maximum memo reference length in bytes.
+pub const MAX_MEMO_REFERENCE_LENGTH: u32 = 64;
+
+/// Maximum total memo size in bytes.
+pub const MAX_TOTAL_MEMO_SIZE: u32 = 320;
+
+/// Validates that a memo text string is within length bounds.
+///
+/// # Returns
+/// * `Ok(())` if valid
+/// * `Err(())` if empty or exceeds maximum length
+pub fn validate_memo_text_length(text: &String) -> Result<(), ()> {
+    let len = text.len() as u32;
+    if len == 0 || len > MAX_MEMO_TEXT_LENGTH {
+        return Err(());
+    }
+    Ok(())
+}
+
+/// Validates that a memo reference string is within length bounds.
+///
+/// # Returns
+/// * `Ok(())` if valid
+/// * `Err(())` if exceeds maximum reference length
+pub fn validate_memo_reference_length(reference: &String) -> Result<(), ()> {
+    let len = reference.len() as u32;
+    if len > MAX_MEMO_REFERENCE_LENGTH {
+        return Err(());
+    }
+    Ok(())
+}
+
+/// Validates total memo payload size (text + reference + type name).
+///
+/// # Returns
+/// * `Ok(())` if total size is within bounds
+/// * `Err(())` if exceeds maximum total size
+pub fn validate_total_memo_size(text_len: u32, reference_len: u32, type_len: u32) -> Result<(), ()> {
+    let total = text_len + reference_len + type_len;
+    if total > MAX_TOTAL_MEMO_SIZE {
+        return Err(());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Env, String};
+
+    #[test]
+    fn test_valid_memo_text_length() {
+        let env = Env::default();
+        let text = String::from_str(&env, "Payment for services");
+        assert!(validate_memo_text_length(&text).is_ok());
+    }
+
+    #[test]
+    fn test_memo_text_at_max_length() {
+        let env = Env::default();
+        let text = String::from_str(&env, &"a".repeat(MAX_MEMO_TEXT_LENGTH as usize));
+        assert!(validate_memo_text_length(&text).is_ok());
+    }
+
+    #[test]
+    fn test_memo_text_over_max_length() {
+        let env = Env::default();
+        let text = String::from_str(&env, &"a".repeat((MAX_MEMO_TEXT_LENGTH + 1) as usize));
+        assert!(validate_memo_text_length(&text).is_err());
+    }
+
+    #[test]
+    fn test_empty_memo_text_rejected() {
+        let env = Env::default();
+        let text = String::from_str(&env, "");
+        assert!(validate_memo_text_length(&text).is_err());
+    }
+
+    #[test]
+    fn test_valid_reference_length() {
+        let env = Env::default();
+        let reference = String::from_str(&env, "REF-12345");
+        assert!(validate_memo_reference_length(&reference).is_ok());
+    }
+
+    #[test]
+    fn test_reference_over_max_length() {
+        let env = Env::default();
+        let reference = String::from_str(&env, &"r".repeat((MAX_MEMO_REFERENCE_LENGTH + 1) as usize));
+        assert!(validate_memo_reference_length(&reference).is_err());
+    }
+
+    #[test]
+    fn test_reference_at_max_length() {
+        let env = Env::default();
+        let reference = String::from_str(&env, &"r".repeat(MAX_MEMO_REFERENCE_LENGTH as usize));
+        assert!(validate_memo_reference_length(&reference).is_ok());
+    }
+
+    #[test]
+    fn test_total_memo_size_within_bounds() {
+        assert!(validate_total_memo_size(200, 50, 20).is_ok());
+    }
+
+    #[test]
+    fn test_total_memo_size_at_boundary() {
+        assert!(validate_total_memo_size(256, 64, 0).is_ok());
+    }
+
+    #[test]
+    fn test_total_memo_size_exceeds_maximum() {
+        assert!(validate_total_memo_size(300, 50, 20).is_err());
+    }
+}


### PR DESCRIPTION
Closes #498

## Summary

Implements transaction memo length validation to prevent oversized payloads and manage storage costs.

### Changes
- Added validation constants: MAX_MEMO_TEXT_LENGTH (256), MAX_MEMO_REFERENCE_LENGTH (64), MAX_TOTAL_MEMO_SIZE (320)
- Implemented `validate_memo_text_length()`, `validate_memo_reference_length()`, and `validate_total_memo_size()` in `validation.rs`
- Updated `set_memo()` in `lib.rs` to enforce all three validations before storage
- Added comprehensive unit tests for boundary conditions (at max, over max, empty, total size)
- Added proper error codes: EmptyMemoText, MemoTextTooLarge, MemoReferenceTooLarge, MemoTooLarge