### PR TITLE
Fix #506: Add Asset Symbol Normalization Utility

### DIFF
--- a/contracts/multi-currency-wallet/Cargo.toml
+++ b/contracts/multi-currency-wallet/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk.workspace = true
+shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/multi-currency-wallet/src/lib.rs
+++ b/contracts/multi-currency-wallet/src/lib.rs
@@ -147,6 +147,9 @@ impl MultiCurrencyWalletContract {
 
         // Process each request
         for request in requests.iter() {
+            let mut request = request;
+            request.currency = shared::assets::normalize_asset_symbol(&env, &request.currency);
+
             // Validate the request
             match validate_balance_request(&request) {
                 Ok(()) => {
@@ -298,9 +301,10 @@ impl MultiCurrencyWalletContract {
     /// # Returns
     /// * `i128` - The balance (0 if not found)
     pub fn get_balance(env: Env, user: Address, currency: Symbol) -> i128 {
+        let normalized_currency = shared::assets::normalize_asset_symbol(&env, &currency);
         env.storage()
             .persistent()
-            .get(&DataKey::Balance(user, currency))
+            .get(&DataKey::Balance(user, normalized_currency))
             .map(|b: CurrencyBalance| b.balance)
             .unwrap_or(0)
     }
@@ -319,9 +323,10 @@ impl MultiCurrencyWalletContract {
         user: Address,
         currency: Symbol,
     ) -> Option<CurrencyBalance> {
+        let normalized_currency = shared::assets::normalize_asset_symbol(&env, &currency);
         env.storage()
             .persistent()
-            .get(&DataKey::Balance(user, currency))
+            .get(&DataKey::Balance(user, normalized_currency))
     }
 
     /// Returns the admin address.

--- a/contracts/shared/src/assets.rs
+++ b/contracts/shared/src/assets.rs
@@ -1,0 +1,9 @@
+use alloc::string::ToString;
+use soroban_sdk::{Env, Symbol};
+
+/// Normalizes an asset symbol by converting it to uppercase
+pub fn normalize_asset_symbol(env: &Env, symbol: &Symbol) -> Symbol {
+    let sym_string = symbol.to_string();
+    let upper = sym_string.to_uppercase();
+    Symbol::new(env, &upper)
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,10 +1,14 @@
 #![no_std]
 
+extern crate alloc;
+
 use soroban_sdk::{Env, String, Address, contracttype};
 
 pub mod utils;
 pub mod errors;
 pub mod auth;
+pub mod assets;
+pub mod sanitizer;
 
 pub use errors::SharedError;
 
@@ -40,6 +44,9 @@ pub fn update_contract_owner(env: &Env, new_owner: Address) {
     current_owner.require_auth();
     env.storage().instance().set(&SharedDataKey::Admin, &new_owner);
 }
+
+#[cfg(test)]
+mod test;
 
 #[cfg(test)]
 mod tests {

--- a/contracts/shared/src/test.rs
+++ b/contracts/shared/src/test.rs
@@ -1,0 +1,21 @@
+#![cfg(test)]
+
+use crate::assets::normalize_asset_symbol;
+use soroban_sdk::{Env, Symbol};
+
+#[test]
+fn test_normalize_asset_symbol() {
+    let env = Env::default();
+
+    // Already normalized
+    let sym1 = Symbol::new(&env, "USDC");
+    assert_eq!(normalize_asset_symbol(&env, &sym1), Symbol::new(&env, "USDC"));
+
+    // Lowercase
+    let sym2 = Symbol::new(&env, "usdc");
+    assert_eq!(normalize_asset_symbol(&env, &sym2), Symbol::new(&env, "USDC"));
+
+    // Mixed case
+    let sym3 = Symbol::new(&env, "UsDc");
+    assert_eq!(normalize_asset_symbol(&env, &sym3), Symbol::new(&env, "USDC"));
+}


### PR DESCRIPTION
 Description
This PR resolves issue #506 by introducing a robust Asset Symbol Normalization utility to ensure that all asset symbols are consistently upper-cased. This completely eliminates lookup mismatches caused by inconsistent casing (e.g. `USDC` vs `usdc`).

 Changes Proposed
- **Created `contracts/shared/src/assets.rs`**: Implemented `normalize_asset_symbol` using `alloc::string::ToString` and `to_uppercase` to safely normalize any incoming Soroban `Symbol`.
- **Linked `shared` to Wallet**: Updated `contracts/multi-currency-wallet/Cargo.toml` to depend on the local `shared` crate.
- **Updated Wallet Lookups (`contracts/multi-currency-wallet/src/lib.rs`)**:
  - Automatically normalizes the `currency` for every item in `batch_update_balances`.
  - Normalizes the `currency` prior to lookup in `get_balance`.
  - Normalizes the `currency` prior to lookup in `get_balance_details`.
- **Added Comprehensive Tests**: Covered all scenarios (uppercase, lowercase, mixed case) in `contracts/shared/src/test.rs` to guarantee that inputs like `usdc`, `USDC`, and `UsDc` strictly evaluate to the same normalized `USDC` symbol.

 Related Issues
Fixes #506

 Checklist
- [x] Implemented uppercase normalization utility.
- [x] Applied normalization across all wallet lookup/update logic.
- [x] Added unit tests for case-insensitive behavior.
- [x] Verified existing tests pass successfully.
