### PR TITLE
feat(contract): add contract-wide emergency pause mechanism

### DIFF
--- a/contracts/budget/src/pause.rs
+++ b/contracts/budget/src/pause.rs
@@ -1,0 +1,22 @@
+use soroban_sdk::{Env};
+
+use crate::storage::DataKey;
+
+pub fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+pub fn require_not_paused(env: &Env) {
+    if is_paused(env) {
+        panic!("Contract is paused");
+    }
+}
+
+pub fn set_paused(env: &Env, paused: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::Paused, &paused);
+}


### PR DESCRIPTION
## Summary

Implements a contract-wide emergency pause mechanism to allow authorized administrators to halt state-changing operations during incidents or maintenance windows.

## Changes

- Added global pause flag in contract storage
- Added admin-only `pause` and `unpause` functions
- Added pause status query endpoint
- Restricted state-mutating operations while paused
- Preserved read-only operations during pause state
- Added tests covering pause behavior

## Acceptance Criteria

- [x] Authorized admin can pause contract
- [x] Authorized admin can unpause contract
- [x] State-changing operations are blocked while paused
- [x] Read operations remain available
- [x] Tests added for pause/unpause behavior

## Rollback

Revert this change and redeploy the previous contract version if pause functionality causes unexpected behavior.

closes #567 