### PR TITLE
feat(contracts): contribution memos, adaptive limits, ownership transfer, goal clone

### DIFF
--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -518,6 +518,105 @@ impl SavingsGoalsContract {
         goal.current_amount
     }
 
+    /// Clones an existing savings goal with a new name and zero balance.
+    pub fn clone_savings_goal(
+        env: Env,
+        caller: Address,
+        goal_id: u64,
+        new_goal_name: Symbol,
+    ) -> u64 {
+        caller.require_auth();
+
+        let existing_goal: SavingsGoal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Goal(goal_id))
+            .unwrap_or_else(|| panic_with_error!(&env, SavingsGoalError::GoalNotFound));
+
+        if existing_goal.user != caller {
+            panic_with_error!(&env, SavingsGoalError::Unauthorized);
+        }
+
+        // Check for duplicate goal name for this user
+        if validate_goal_name_unique(&env, &caller, &new_goal_name).is_err() {
+            panic_with_error!(&env, SavingsGoalError::InvalidGoalName);
+        }
+
+        let mut goal_id_counter: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LastGoalId)
+            .unwrap_or(0);
+        goal_id_counter += 1;
+
+        let created_at = env.ledger().timestamp();
+        // Inherit lock duration if it was originally set
+        let lock_duration = if existing_goal.unlock_at > existing_goal.created_at {
+            existing_goal.unlock_at - existing_goal.created_at
+        } else {
+            0
+        };
+        let unlock_at = if lock_duration > 0 {
+            created_at.saturating_add(lock_duration)
+        } else {
+            0
+        };
+
+        let new_goal = SavingsGoal {
+            goal_id: goal_id_counter,
+            user: caller.clone(),
+            goal_name: new_goal_name.clone(),
+            target_amount: existing_goal.target_amount,
+            current_amount: 0, // Reset balance
+            deadline: existing_goal.deadline,
+            created_at,
+            is_active: true,
+            is_complete: false,
+            unlock_at,
+        };
+
+        // Store the goal
+        env.storage()
+            .persistent()
+            .set(&DataKey::Goal(goal_id_counter), &new_goal);
+        // Store name-to-id mapping
+        env.storage().persistent().set(
+            &DataKey::GoalByName(caller.clone(), new_goal_name.clone()),
+            &goal_id_counter,
+        );
+
+        // Update user's goal list
+        let mut user_goals: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserGoals(caller.clone()))
+            .unwrap_or(Vec::new(&env));
+        user_goals.push_back(goal_id_counter);
+        env.storage()
+            .persistent()
+            .set(&DataKey::UserGoals(caller.clone()), &user_goals);
+
+        // Update global counter
+        env.storage()
+            .instance()
+            .set(&DataKey::LastGoalId, &goal_id_counter);
+
+        let total_goals: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalGoalsCreated)
+            .unwrap_or(0);
+        env.storage().instance().set(
+            &DataKey::TotalGoalsCreated,
+            &(total_goals + 1),
+        );
+
+        // Emit creation event (reusing batch 0 for manual creation)
+        GoalEvents::goal_created(&env, 0, &new_goal);
+
+        goal_id_counter
+    }
+
     /// Withdraws funds from a savings goal. Rejects withdrawals before unlock time when locked.
     pub fn withdraw_from_goal(env: Env, caller: Address, goal_id: u64, amount: i128) -> i128 {
         caller.require_auth();

--- a/contracts/savings-goals/src/test.rs
+++ b/contracts/savings-goals/src/test.rs
@@ -1042,3 +1042,48 @@ fn test_contribute_emits_milestone_events() {
     assert!(triggered.contains(&75));
     assert!(triggered.contains(&100));
 }
+
+#[test]
+fn test_clone_savings_goal() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    let mut requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests.push_back(SavingsGoalRequest {
+        user: user.clone(),
+        goal_name: Symbol::new(&env, "original"),
+        target_amount: 100_000_000,
+        deadline: env.ledger().sequence() as u64 + 1000,
+        initial_contribution: 50_000_000,
+        lock_duration_seconds: 3600,
+    });
+    client.batch_set_savings_goals(&admin, &requests);
+
+    let cloned_name = Symbol::new(&env, "cloned");
+    let cloned_id = client.clone_savings_goal(&user, &1, &cloned_name);
+
+    assert_eq!(cloned_id, 2);
+
+    let cloned_goal = client.get_goal(&cloned_id).unwrap();
+    assert_eq!(cloned_goal.goal_name, cloned_name);
+    assert_eq!(cloned_goal.target_amount, 100_000_000);
+    assert_eq!(cloned_goal.current_amount, 0); // Balance reset
+    assert_eq!(cloned_goal.user, user);
+    assert_eq!(cloned_goal.is_complete, false);
+    assert!(cloned_goal.unlock_at > cloned_goal.created_at); // Lock inherited
+}
+
+#[test]
+#[should_panic]
+fn test_clone_savings_goal_unauthorized() {
+    let (env, admin, client) = setup_test_contract();
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    let mut requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests.push_back(create_valid_request(&env, &user1, "original", 100_000_000));
+    client.batch_set_savings_goals(&admin, &requests);
+
+    let cloned_name = Symbol::new(&env, "cloned");
+    client.clone_savings_goal(&user2, &1, &cloned_name); // user2 tries to clone user1's goal
+}

--- a/contracts/shared-budgets/src/lib.rs
+++ b/contracts/shared-budgets/src/lib.rs
@@ -145,7 +145,13 @@ impl SharedBudgetContract {
     }
 
     /// Contributes to a shared budget.
-    pub fn contribute_to_budget(env: Env, contributor: Address, budget_id: u64, amount: i128) {
+    pub fn contribute_to_budget(
+        env: Env,
+        contributor: Address,
+        budget_id: u64,
+        amount: i128,
+        memo: Option<Symbol>,
+    ) {
         contributor.require_auth();
 
         // Validate amount
@@ -182,6 +188,7 @@ impl SharedBudgetContract {
             budget_id,
             contributor: contributor.clone(),
             amount,
+            memo: memo.clone(),
             timestamp: env.ledger().timestamp(),
         };
 
@@ -201,7 +208,7 @@ impl SharedBudgetContract {
             .set(&DataKey::TotalContributionsProcessed, &contribution_id);
 
         // Emit event
-        SharedBudgetEvents::contribution_added(&env, budget_id, &contributor, amount);
+        SharedBudgetEvents::contribution_added(&env, budget_id, &contributor, amount, memo);
     }
 
     /// Spend from a shared budget with spending rule enforcement.
@@ -263,6 +270,42 @@ impl SharedBudgetContract {
 
         // Emit event
         SharedBudgetEvents::expense_incurred(&env, budget_id, &spender, &recipient, amount);
+    }
+
+    /// Transfers budget ownership from the current owner to a new account.
+    ///
+    /// Both the current owner and the new owner must authorize the transfer.
+    /// After transfer, the previous owner loses owner-level control.
+    pub fn transfer_budget_ownership(
+        env: Env,
+        current_owner: Address,
+        budget_id: u64,
+        new_owner: Address,
+    ) {
+        current_owner.require_auth();
+        new_owner.require_auth();
+
+        let mut budget: Budget = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Budget(budget_id))
+            .unwrap_or_else(|| panic_with_error!(&env, SharedBudgetError::BudgetNotFound));
+
+        if current_owner != budget.creator {
+            panic_with_error!(&env, SharedBudgetError::Unauthorized);
+        }
+
+        if current_owner == new_owner {
+            return;
+        }
+
+        budget.creator = new_owner.clone();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Budget(budget_id), &budget);
+
+        SharedBudgetEvents::ownership_transferred(&env, budget_id, &current_owner, &new_owner);
     }
 
     /// Add a member to an existing budget.

--- a/contracts/shared-budgets/src/test.rs
+++ b/contracts/shared-budgets/src/test.rs
@@ -123,7 +123,7 @@ fn test_contribute_to_budget() {
 
     // Contribute to the budget
     let contribution_amount = 100_000_000; // 10 XLM
-    client.contribute_to_budget(&contributor, &budget_id, &contribution_amount);
+    client.contribute_to_budget(&contributor, &budget_id, &contribution_amount, &None);
 
     // Check that budget balance increased
     let budget_after = client.get_budget(&budget_id);
@@ -132,6 +132,27 @@ fn test_contribute_to_budget() {
 
     // Check that total contributions processed increased
     assert_eq!(client.get_total_contribs_processed(), 1);
+}
+
+#[test]
+fn test_contribution_with_memo() {
+    let (env, _admin, token, _token_client, client) = setup_test_env();
+
+    let creator = Address::generate(&env);
+    let contributor = Address::generate(&env);
+    let budget_name = Symbol::new(&env, "memo_budget");
+    let budget_id = client.create_budget(&creator, &budget_name, &Vec::new(&env), &token, &Vec::new(&env));
+
+    let amount = 100_000_000;
+    let memo = Some(Symbol::new(&env, "lunch_contribution"));
+    client.contribute_to_budget(&contributor, &budget_id, &amount, &memo);
+
+    let contribution_id = client.get_total_contribs_processed();
+    let contribution = client.get_contribution(&contribution_id);
+
+    assert_eq!(contribution.amount, amount);
+    assert_eq!(contribution.memo, memo);
+    assert_eq!(contribution.contributor, contributor);
 }
 
 #[test]
@@ -152,7 +173,7 @@ fn test_spend_from_budget() {
 
     // Contribute to budget first
     let contribution_amount = 100_000_000; // 10 XLM
-    client.contribute_to_budget(&member1, &budget_id, &contribution_amount);
+    client.contribute_to_budget(&member1, &budget_id, &contribution_amount, &None);
 
     // Spend from budget
     let expense_amount = 50_000_000; // 5 XLM
@@ -307,7 +328,7 @@ fn test_non_member_cannot_spend() {
 
     // Contribute to budget first
     let contribution_amount = 100_000_000; // 10 XLM
-    client.contribute_to_budget(&member1, &budget_id, &contribution_amount);
+    client.contribute_to_budget(&member1, &budget_id, &contribution_amount, &None);
 
     // Non-member tries to spend (should fail)
     let expense_amount = 50_000_000; // 5 XLM
@@ -323,4 +344,77 @@ fn test_unauthorized_admin_function() {
     let new_admin = Address::generate(&env);
 
     client.set_admin(&unauthorized_user, &new_admin);
+}
+
+#[test]
+fn test_transfer_budget_ownership() {
+    let (env, _admin, token, _token_client, client) = setup_test_env();
+
+    let creator = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let member = Address::generate(&env);
+
+    let mut members: Vec<Address> = Vec::new(&env);
+    members.push_back(member.clone());
+
+    let budget_name = Symbol::new(&env, "transfer_budget");
+    let spending_rules: Vec<BudgetSpendingRule> = Vec::new(&env);
+    let budget_id =
+        client.create_budget(&creator, &budget_name, &members, &token, &spending_rules);
+
+    client.transfer_budget_ownership(&creator, &budget_id, &new_owner);
+
+    let budget = client.get_budget(&budget_id);
+    assert_eq!(budget.creator, new_owner);
+
+    let owner_role = client.get_member_role(&budget_id, &new_owner);
+    assert_eq!(owner_role, Symbol::new(&env, "OWNER"));
+
+    let previous_owner_role = client.get_member_role(&budget_id, &creator);
+    assert_eq!(previous_owner_role, Symbol::new(&env, "NONE"));
+}
+
+#[test]
+#[should_panic]
+fn test_previous_owner_cannot_manage_budget_after_transfer() {
+    let (env, _admin, token, _token_client, client) = setup_test_env();
+
+    let creator = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let member = Address::generate(&env);
+    let added_member = Address::generate(&env);
+
+    let mut members: Vec<Address> = Vec::new(&env);
+    members.push_back(member.clone());
+
+    let budget_name = Symbol::new(&env, "post_transfer_budget");
+    let spending_rules: Vec<BudgetSpendingRule> = Vec::new(&env);
+    let budget_id =
+        client.create_budget(&creator, &budget_name, &members, &token, &spending_rules);
+
+    client.transfer_budget_ownership(&creator, &budget_id, &new_owner);
+
+    // Previous owner no longer has owner-level control.
+    client.add_member_to_budget(&creator, &budget_id, &added_member);
+}
+
+#[test]
+#[should_panic]
+fn test_unauthorized_budget_ownership_transfer() {
+    let (env, _admin, token, _token_client, client) = setup_test_env();
+
+    let creator = Address::generate(&env);
+    let impostor = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+
+    let budget_name = Symbol::new(&env, "secure_budget");
+    let budget_id = client.create_budget(
+        &creator,
+        &budget_name,
+        &Vec::new(&env),
+        &token,
+        &Vec::new(&env),
+    );
+
+    client.transfer_budget_ownership(&impostor, &budget_id, &new_owner);
 }

--- a/contracts/shared-budgets/src/types.rs
+++ b/contracts/shared-budgets/src/types.rs
@@ -44,6 +44,8 @@ pub struct BudgetContribution {
     pub contributor: Address,
     /// Amount contributed
     pub amount: i128,
+    /// Optional memo for the contribution
+    pub memo: Option<Symbol>,
     /// Timestamp of the contribution
     pub timestamp: u64,
 }
@@ -100,9 +102,15 @@ impl SharedBudgetEvents {
     }
 
     /// Event emitted when a contribution is added to a budget.
-    pub fn contribution_added(env: &Env, budget_id: u64, contributor: &Address, amount: i128) {
+    pub fn contribution_added(
+        env: &Env,
+        budget_id: u64,
+        contributor: &Address,
+        amount: i128,
+        memo: Option<Symbol>,
+    ) {
         let topics = (symbol_short!("budget"), symbol_short!("contrib"), budget_id);
-        env.events().publish(topics, (contributor.clone(), amount));
+        env.events().publish(topics, (contributor.clone(), amount, memo));
     }
 
     /// Event emitted when an allocation fails for a recipient.
@@ -155,5 +163,17 @@ impl SharedBudgetEvents {
                 rule.requires_approval,
             ),
         );
+    }
+
+    /// Event emitted when budget ownership is transferred to a new account.
+    pub fn ownership_transferred(
+        env: &Env,
+        budget_id: u64,
+        previous_owner: &Address,
+        new_owner: &Address,
+    ) {
+        let topics = (symbol_short!("budget"), symbol_short!("xfer_own"), budget_id);
+        env.events()
+            .publish(topics, (previous_owner.clone(), new_owner.clone()));
     }
 }

--- a/contracts/spending-limits/src/cross_contract.rs
+++ b/contracts/spending-limits/src/cross_contract.rs
@@ -1,0 +1,9 @@
+//! Whitelist storage keys shared with cross-contract spending authorization.
+
+use soroban_sdk::{contracttype, Address};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Whitelist(Address),
+}

--- a/contracts/spending-limits/src/lib.rs
+++ b/contracts/spending-limits/src/lib.rs
@@ -21,14 +21,16 @@
 
 #![no_std]
 
+mod cross_contract;
 mod types;
 mod validation;
 
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Vec};
 
 pub use crate::types::{
-    BatchLimitMetrics, BatchLimitResult, DataKey, ErrorCode, LimitEvents, LimitUpdateResult,
-    LimitsConfig, SpendingLimit, SpendingLimitRequest, MAX_BATCH_SIZE,
+    BatchLimitMetrics, BatchLimitResult, DataKey, ErrorCode, EscalationConfig, LimitEvents,
+    LimitStrategy, LimitUpdateResult, LimitsConfig, SpendingLimit, SpendingLimitRequest,
+    MAX_BATCH_SIZE,
 };
 use crate::validation::validate_limit_request;
 
@@ -170,6 +172,7 @@ impl SpendingLimitsContract {
                         category: request.category.clone(),
                         updated_at: current_ledger,
                         is_active: true,
+                        strategy: request.strategy.clone(),
                     };
 
                     // Accumulate metrics
@@ -443,6 +446,26 @@ impl SpendingLimitsContract {
                 panic_with_error!(&env, SpendingLimitError::DailyLimitExceeded);
             } else {
                 panic_with_error!(&env, SpendingLimitError::MonthlyLimitExceeded);
+            }
+        }
+
+        // If adaptive strategy is enabled and user is nearing their limit (>= 90%)
+        // automatically increase the limit by 10% for future transactions.
+        if limit.strategy == crate::types::LimitStrategy::Adaptive
+            && new_monthly >= (limit.monthly_limit * 9 / 10)
+        {
+            let old_limit = limit.monthly_limit;
+            let increment = limit.monthly_limit / 10;
+            let proposed_limit = old_limit.checked_add(increment).unwrap_or(crate::types::MAX_SPENDING_LIMIT);
+
+            limit.monthly_limit = if proposed_limit > crate::types::MAX_SPENDING_LIMIT {
+                crate::types::MAX_SPENDING_LIMIT
+            } else {
+                proposed_limit
+            };
+
+            if limit.monthly_limit != old_limit {
+                LimitEvents::limit_adjusted(&env, &user, old_limit, limit.monthly_limit);
             }
         }
 

--- a/contracts/spending-limits/src/test.rs
+++ b/contracts/spending-limits/src/test.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
     Address, Env, Vec,
 };
 
-use crate::types::{ErrorCode, LimitUpdateResult, SpendingLimitRequest};
+use crate::types::{ErrorCode, LimitStrategy, LimitUpdateResult, SpendingLimitRequest};
 
 /// Helper function to create a test environment with initialized contract.
 fn setup_test_contract() -> (Env, Address, SpendingLimitsContractClient<'static>) {
@@ -32,6 +32,7 @@ fn create_valid_request(env: &Env, user: &Address, limit: i128) -> SpendingLimit
         monthly_limit: limit,
         reset_window_seconds: 86_400,
         category: Some(symbol_short!("general")),
+        strategy: LimitStrategy::Static,
     }
 }
 
@@ -424,6 +425,7 @@ fn test_enforce_spending_limit_allows_within_daily_and_monthly() {
     let user = Address::generate(&env);
 
     // Configure a monthly limit of 300 units; derived daily limit is 10 units.
+    client.whitelist_destination(&admin, &user);
     let mut requests: Vec<SpendingLimitRequest> = Vec::new(&env);
     requests.push_back(create_valid_request(&env, &user, 300));
     client.batch_update_spending_limits(&admin, &requests);
@@ -442,6 +444,7 @@ fn test_enforce_spending_limit_resets_after_window() {
     let user = Address::generate(&env);
 
     // Configure a monthly limit with a 24-hour reset window.
+    client.whitelist_destination(&admin, &user);
     let mut requests: Vec<SpendingLimitRequest> = Vec::new(&env);
     let mut request = create_valid_request(&env, &user, 300);
     request.reset_window_seconds = 86_400;
@@ -464,6 +467,7 @@ fn test_enforce_spending_limit_daily_exceeded() {
     let user = Address::generate(&env);
 
     // Monthly 300 -> daily 10
+    client.whitelist_destination(&admin, &user);
     let mut requests: Vec<SpendingLimitRequest> = Vec::new(&env);
     requests.push_back(create_valid_request(&env, &user, 300));
     let result = client.batch_update_spending_limits(&admin, &requests);
@@ -490,6 +494,7 @@ fn test_enforce_spending_limit_monthly_exceeded_over_multiple_days() {
     let user = Address::generate(&env);
 
     // Monthly 30, daily 1 (30 / 30) => 1 unit per day max, 30 units per month.
+    client.whitelist_destination(&admin, &user);
     let mut requests: Vec<SpendingLimitRequest> = Vec::new(&env);
     requests.push_back(create_valid_request(&env, &user, 30));
     let result = client.batch_update_spending_limits(&admin, &requests);
@@ -516,10 +521,34 @@ fn test_enforce_without_limit_does_not_block() {
     let (env, _admin, client) = setup_test_contract();
     let user = Address::generate(&env);
 
+    client.whitelist_destination(&client.get_admin(), &user);
     env.ledger().set_timestamp(10 * 86_400);
 
     // No limit configured for this user; enforce should be a no-op and not panic.
     client.enforce_spending_limit(&user, &1_000_000);
+}
+
+#[test]
+fn test_adaptive_strategy_increases_limit_near_usage_threshold() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    client.whitelist_destination(&admin, &user);
+
+    let mut requests: Vec<SpendingLimitRequest> = Vec::new(&env);
+    let mut request = create_valid_request(&env, &user, 1_000_000_000);
+    request.strategy = LimitStrategy::Adaptive;
+    requests.push_back(request);
+    client.batch_update_spending_limits(&admin, &requests);
+
+    env.ledger().set_timestamp(86_400);
+
+    // Spend 900M (90% of 1B) — should trigger a deterministic 10% limit increase.
+    client.enforce_spending_limit(&user, &900_000_000);
+
+    let limit = client.get_spending_limit(&user).unwrap();
+    assert_eq!(limit.monthly_limit, 1_100_000_000);
+    assert_eq!(limit.strategy, LimitStrategy::Adaptive);
 }
 
 #[test]

--- a/contracts/spending-limits/src/types.rs
+++ b/contracts/spending-limits/src/types.rs
@@ -1,7 +1,3 @@
-use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
-
-// ─── Budget Types ───────────────────────────────────────────────────────────
-
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
 /// Maximum number of requests in a single batch for optimization.
@@ -31,6 +27,16 @@ pub enum EscalationLevel {
     Large,
 }
 
+/// Strategies for spending limit adjustment.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum LimitStrategy {
+    /// Fixed monthly limit
+    Static,
+    /// Limit increases automatically based on usage
+    Adaptive,
+}
+
 /// Configuration for spending escalation rules.
 #[derive(Clone, Debug)]
 #[contracttype]
@@ -54,7 +60,9 @@ pub struct SpendingLimitRequest {
     /// Reset window in seconds (e.g., 86400 for daily)
     pub reset_window_seconds: u64,
     /// Optional spending category
-    pub category: Option<BudgetCategory>,
+    pub category: Option<Symbol>,
+    /// Adjustment strategy
+    pub strategy: LimitStrategy,
 }
 
 /// Represents a configured spending limit for a user.
@@ -70,11 +78,23 @@ pub struct SpendingLimit {
     /// Current spending tracked in this period
     pub current_spending: i128,
     /// Optional category for the limit
-    pub category: Option<BudgetCategory>,
+    pub category: Option<Symbol>,
     /// When the limit was last updated (ledger timestamp)
     pub updated_at: u64,
     /// Whether the limit is active
     pub is_active: bool,
+    /// Adjustment strategy
+    pub strategy: LimitStrategy,
+}
+
+/// Consolidated instance-storage configuration for the spending limits contract.
+#[derive(Clone)]
+#[contracttype]
+pub struct LimitsConfig {
+    pub admin: Address,
+    pub last_batch_id: u64,
+    pub total_limits_updated: u64,
+    pub total_batches_processed: u64,
 }
 
 /// Result of processing a single limit update.
@@ -125,234 +145,72 @@ pub struct BatchLimitResult {
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
-    /// Admin address
-    Admin,
-    /// Last created batch ID
-    LastBatchId,
-    /// Total limits updated lifetime
-    TotalLimitsUpdated,
-    /// Total batches processed lifetime
-    TotalBatchesProcessed,
-    /// Stored spending limit by user address
+    /// Consolidated limits configuration.
+    LimitsConfig,
+    /// Stored spending limit by user address.
     SpendingLimit(Address),
-    /// Windowed spending tracking (user, window_id)
+    /// Windowed spending tracking (user, window_id).
     WindowSpending(Address, u64),
-    /// Monthly spending tracking (user, month_id)
+    /// Monthly spending tracking (user, month_id).
     MonthlySpending(Address, u64),
-    /// Escalation configuration
+    /// Escalation configuration.
     EscalationConfig,
-    /// Pending large-spend approvals (spender, amount, timestamp)
-    PendingApproval(Address),
 }
 
 /// Error codes for limit validation and enforcement.
 pub mod ErrorCode {
-    /// Invalid limit amount (negative, zero, or out of bounds)
-    pub const INVALID_LIMIT: u32 = 0;
     /// Invalid limit amount (negative or zero)
-    pub const INVALID_LIMIT_AMOUNT: u32 = 0;
+    pub const INVALID_LIMIT: u32 = 0;
     /// Invalid user address
     pub const INVALID_USER_ADDRESS: u32 = 1;
     /// Invalid reset window
     pub const INVALID_RESET_WINDOW: u32 = 2;
     /// Limit not found
     pub const LIMIT_NOT_FOUND: u32 = 3;
-    /// Large spend requires admin approval
-    pub const ESCALATION_APPROVAL_REQUIRED: u32 = 4;
-    /// Pending approval not found or expired
-    pub const APPROVAL_NOT_FOUND: u32 = 5;
 }
 
-/// Spending category for budget classification.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum BudgetCategory {
-    Food,
-    Transport,
-    Rent,
-    Entertainment,
-}
-
-/// Budget status.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum BudgetStatus {
-    Active,
-    Paused,
-}
-
-/// Budget record.
-#[derive(Clone)]
-#[contracttype]
-pub struct Budget {
-    pub owner: Address,
-    pub limit: i128,
-    pub spent: i128,
-    pub status: BudgetStatus,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum BudgetCategory {
-    Food,
-    Transport,
-    Rent,
-    Entertainment,
-}
-
-// ─── Constants ──────────────────────────────────────────────────────────────
-
-pub const MAX_BATCH_SIZE: u32 = 100;
-pub const MIN_SPENDING_LIMIT: i128 = 1_000_000;
-pub const MAX_SPENDING_LIMIT: i128 = 100_000_000_000_000_000;
-pub const MIN_RESET_WINDOW_SECONDS: u64 = 86_400;
-pub const MAX_RESET_WINDOW_SECONDS: u64 = 86_400 * 365;
-
-// ─── Storage Keys ───────────────────────────────────────────────────────────
-
-/// Storage keys for the spending limits contract.
-///
-/// # Storage Optimization (Issue #484)
-///
-/// The previously separate `Admin`, `LastBatchId`, `TotalLimitsUpdated`, and
-/// `TotalBatchesProcessed` keys have been consolidated into a single
-/// `LimitsConfig` struct. This reduces instance storage operations from 4
-/// reads/writes to 1 per access, lowering the overall storage footprint and
-/// Soroban rent costs.
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    /// Consolidated limits configuration (was 4 separate keys).
-    LimitsConfig,
-    /// Per-user spending limit.
-    SpendingLimit(Address),
-    /// Window-level spending counter.
-    WindowSpending(Address, u64),
-    /// Month-level spending counter.
-    MonthlySpending(Address, u64),
-}
-
-// ─── Limits Config ──────────────────────────────────────────────────────────
-
-/// Consolidated instance-storage configuration for the spending limits
-/// contract.
-///
-/// Replaces the four previously separate storage entries:
-///   `Admin`, `LastBatchId`, `TotalLimitsUpdated`, `TotalBatchesProcessed`.
-///
-/// Reading/writing a single struct is ~4× more efficient than reading/writing
-/// four individual keys due to reduced storage I/O overhead in Soroban.
-#[derive(Clone)]
-#[contracttype]
-pub struct LimitsConfig {
-    pub admin: Address,
-    pub last_batch_id: u64,
-    pub total_limits_updated: u64,
-    pub total_batches_processed: u64,
-}
-
-// ─── Spending Limit Types ───────────────────────────────────────────────────
-
-#[derive(Clone)]
-#[contracttype]
-pub struct SpendingLimit {
-    pub user: Address,
-    pub monthly_limit: i128,
-    pub reset_window_seconds: u64,
-    pub current_spending: i128,
-    pub category: Option<Symbol>,
-    pub updated_at: u64,
-    pub is_active: bool,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct SpendingLimitRequest {
-    pub user: Address,
-    pub monthly_limit: i128,
-    pub reset_window_seconds: u64,
-    pub category: Option<Symbol>,
-}
-
-// ─── Result Types ───────────────────────────────────────────────────────────
-
-#[derive(Clone)]
-#[contracttype]
-pub enum LimitUpdateResult {
-    Success(SpendingLimit),
-    Failure(Address, u32),
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct BatchLimitMetrics {
-    pub total_requests: u32,
-    pub successful_updates: u32,
-    pub failed_updates: u32,
-    pub total_limits_value: i128,
-    pub avg_limit_amount: i128,
-    pub processed_at: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct BatchLimitResult {
-    pub batch_id: u64,
-    pub total_requests: u32,
-    pub successful: u32,
-    pub failed: u32,
-    pub results: Vec<LimitUpdateResult>,
-    pub metrics: BatchLimitMetrics,
-}
-
-// ─── Error Codes ────────────────────────────────────────────────────────────
-
-pub struct ErrorCode;
-
-impl ErrorCode {
-    pub const INVALID_USER_ADDRESS: u32 = 1;
-    pub const INVALID_LIMIT: u32 = 2;
-}
-
-// ─── Event Helpers ──────────────────────────────────────────────────────────
-
+/// Event helpers for the spending limits contract.
 pub struct LimitEvents;
 
 impl LimitEvents {
     pub fn batch_started(env: &Env, batch_id: u64, count: u32) {
         env.events().publish(
-            (Symbol::new(env, "limit"), Symbol::new(env, "batch_started")),
+            (symbol_short!("limit"), symbol_short!("batch_st")),
             (batch_id, count),
         );
     }
 
     pub fn limit_updated(env: &Env, batch_id: u64, limit: &SpendingLimit) {
         env.events().publish(
-            (Symbol::new(env, "limit"), Symbol::new(env, "updated")),
+            (symbol_short!("limit"), symbol_short!("updated")),
             (batch_id, limit.user.clone(), limit.monthly_limit),
+        );
+    }
+
+    pub fn limit_adjusted(env: &Env, user: &Address, old_limit: i128, new_limit: i128) {
+        env.events().publish(
+            (symbol_short!("limit"), symbol_short!("adjusted")),
+            (user.clone(), old_limit, new_limit),
         );
     }
 
     pub fn high_value_limit(env: &Env, batch_id: u64, user: &Address, amount: i128) {
         env.events().publish(
-            (Symbol::new(env, "limit"), Symbol::new(env, "high_value")),
+            (symbol_short!("limit"), symbol_short!("high_val")),
             (batch_id, user.clone(), amount),
         );
     }
 
     pub fn limit_update_failed(env: &Env, batch_id: u64, user: &Address, error_code: u32) {
         env.events().publish(
-            (Symbol::new(env, "limit"), Symbol::new(env, "update_failed")),
+            (symbol_short!("limit"), symbol_short!("upd_fail")),
             (batch_id, user.clone(), error_code),
         );
     }
 
     pub fn batch_completed(env: &Env, batch_id: u64, success: u32, failed: u32, total: i128) {
         env.events().publish(
-            (
-                Symbol::new(env, "limit"),
-                Symbol::new(env, "batch_completed"),
-            ),
+            (symbol_short!("limit"), symbol_short!("batch_cp")),
             (batch_id, success, failed, total),
         );
     }
@@ -365,8 +223,22 @@ impl LimitEvents {
         remaining_monthly: i128,
     ) {
         env.events().publish(
-            (Symbol::new(env, "limit"), Symbol::new(env, "exceeded")),
+            (symbol_short!("limit"), symbol_short!("exceeded")),
             (user.clone(), amount, remaining_window, remaining_monthly),
+        );
+    }
+
+    pub fn escalation_configured(env: &Env, small: i128, medium: i128, enabled: bool) {
+        env.events().publish(
+            (symbol_short!("limit"), symbol_short!("esc_cfg")),
+            (small, medium, enabled),
+        );
+    }
+
+    pub fn escalation_approved(env: &Env, admin: &Address, user: &Address, amount: i128) {
+        env.events().publish(
+            (symbol_short!("limit"), symbol_short!("esc_app")),
+            (admin.clone(), user.clone(), amount),
         );
     }
 }

--- a/contracts/spending-limits/src/validation.rs
+++ b/contracts/spending-limits/src/validation.rs
@@ -72,6 +72,7 @@ mod tests {
             monthly_limit: 100_000_000_000, // 10,000 XLM
             reset_window_seconds: MIN_RESET_WINDOW_SECONDS,
             category: Some(symbol_short!("general")),
+            strategy: crate::types::LimitStrategy::Static,
         }
     }
 


### PR DESCRIPTION
## Summary

- **#548**: Add optional memo field to shared budget contributions, stored on the contribution record and queryable via `get_contribution`.
- **#549**: Add configurable `LimitStrategy` (Static/Adaptive) with deterministic adaptive recalculation when usage reaches 90% of the monthly limit.
- **#550**: Add `transfer_budget_ownership` with dual authorization; previous owner loses owner-level control.
- **#551**: Add `clone_savings_goal` to copy goal settings with zero balance and a unique goal ID.

## What changed

- `shared-budgets`: memo on `contribute_to_budget`, `transfer_budget_ownership`, ownership transfer event, tests.
- `spending-limits`: `LimitStrategy` enum, adaptive limit adjustment in `enforce_spending_limit`, `limit_adjusted` event, cross-contract whitelist module, tests.
- `savings-goals`: `clone_savings_goal` with inherited settings and reset balance, tests.

## Why

Users need to annotate contributions, adapt spending limits to usage, transfer budget control, and duplicate savings goal configurations without manual re-entry.

## Testing performed

- Added unit/integration tests for memo persistence, ownership transfer authorization, adaptive limit recalculation, and goal cloning.
- Local `cargo test` unavailable in this environment; CI should validate contract test suites.

## Risks considered

- Adaptive limit increases are capped at `MAX_SPENDING_LIMIT` and use integer arithmetic for determinism.
- Ownership transfer requires both current and new owner signatures.
- Cloned goals receive new IDs and zero balances; milestone state is not copied.

## Edge cases handled

- Unauthorized/non-owner transfer attempts panic.
- Previous owner cannot manage budget after transfer unless admin.
- Duplicate cloned goal names are rejected.
- Contributions without memo store `None`.

closes: #548
closes: #549
closes: #550
closes: #551
