### PR TITLE
feat(#495): add merchant tagging support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "contracts/users",
     "contracts/transactions",
     "contracts/transaction-validation",
+    "contracts/merchant-tagging",
 ]
 
 [package]

--- a/contracts/merchant-tagging/Cargo.toml
+++ b/contracts/merchant-tagging/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "merchant-tagging"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/merchant-tagging/src/events.rs
+++ b/contracts/merchant-tagging/src/events.rs
@@ -1,0 +1,49 @@
+//! Event emitters for the merchant-tagging contract.
+
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+/// Emitted when a new merchant is registered.
+pub fn emit_merchant_registered(env: &Env, merchant_id: &Symbol, registrar: &Address) {
+    env.events().publish(
+        (symbol_short!("merchant"), symbol_short!("registered")),
+        (merchant_id.clone(), registrar.clone()),
+    );
+}
+
+/// Emitted when a merchant record is updated.
+pub fn emit_merchant_updated(env: &Env, merchant_id: &Symbol, updater: &Address) {
+    env.events().publish(
+        (symbol_short!("merchant"), symbol_short!("updated")),
+        (merchant_id.clone(), updater.clone()),
+    );
+}
+
+/// Emitted when a merchant is deactivated.
+pub fn emit_merchant_deactivated(env: &Env, merchant_id: &Symbol, caller: &Address) {
+    env.events().publish(
+        (symbol_short!("merchant"), symbol_short!("deactivated")),
+        (merchant_id.clone(), caller.clone()),
+    );
+}
+
+/// Emitted when a transaction is tagged with a merchant.
+pub fn emit_transaction_tagged(
+    env: &Env,
+    tx_id: u64,
+    merchant_id: &Symbol,
+    amount: i128,
+    asset: &Symbol,
+) {
+    env.events().publish(
+        (symbol_short!("merchant"), symbol_short!("tx_tagged")),
+        (tx_id, merchant_id.clone(), amount, asset.clone()),
+    );
+}
+
+/// Emitted when a transaction tag is removed.
+pub fn emit_tag_removed(env: &Env, tx_id: u64, merchant_id: &Symbol) {
+    env.events().publish(
+        (symbol_short!("merchant"), symbol_short!("tag_removed")),
+        (tx_id, merchant_id.clone()),
+    );
+}

--- a/contracts/merchant-tagging/src/lib.rs
+++ b/contracts/merchant-tagging/src/lib.rs
@@ -1,0 +1,426 @@
+//! # Merchant Tagging Contract
+//!
+//! Adds merchant metadata to transactions so they can be grouped and
+//! analysed by merchant. Resolves issue #495.
+//!
+//! ## Features
+//!
+//! - **Merchant registry** — register merchants with a name, category tags,
+//!   and an optional Stellar address.
+//! - **Transaction tagging** — attach a merchant ID, amount, asset, and note
+//!   to any transaction ID.
+//! - **Queryable index** — retrieve all transaction IDs for a given merchant.
+//! - **Merchant analytics** — running totals of transaction count and volume
+//!   per merchant, updated on every tag operation.
+//! - **Tag removal** — remove a merchant tag from a transaction.
+//! - **Admin controls** — only the admin can register/update/deactivate
+//!   merchants; any address can tag its own transactions.
+
+#![no_std]
+
+pub mod events;
+pub mod types;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
+
+use crate::events::{
+    emit_merchant_deactivated, emit_merchant_registered, emit_merchant_updated,
+    emit_tag_removed, emit_transaction_tagged,
+};
+use crate::types::{
+    DataKey, Merchant, MerchantAnalytics, TransactionMerchantTag,
+    MAX_MERCHANT_NAME_LEN, MAX_QUERY_RESULTS, MAX_TAG_LEN, MAX_TAGS_PER_MERCHANT,
+};
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct MerchantTaggingContract;
+
+#[contractimpl]
+impl MerchantTaggingContract {
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    /// Initialise the contract with an admin address.
+    ///
+    /// Panics if already initialised.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalTagged, &0u32);
+    }
+
+    /// Return the admin address.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    // ── Merchant registry ─────────────────────────────────────────────────────
+
+    /// Register a new merchant (admin only).
+    ///
+    /// # Arguments
+    /// * `caller`  — must be the admin.
+    /// * `id`      — unique merchant symbol (e.g. `symbol_short!("AMAZON")`).
+    /// * `name`    — human-readable name (max `MAX_MERCHANT_NAME_LEN` chars).
+    /// * `tags`    — category tags (max `MAX_TAGS_PER_MERCHANT`, each max `MAX_TAG_LEN`).
+    /// * `address` — optional Stellar address for the merchant.
+    ///
+    /// # Panics
+    /// - `"not initialized"` if `init` was not called.
+    /// - `"unauthorized"` if `caller` is not the admin.
+    /// - `"merchant already exists"` if `id` is already registered.
+    /// - `"name too long"` / `"too many tags"` / `"tag too long"` on validation failure.
+    pub fn register_merchant(
+        env: Env,
+        caller: Address,
+        id: Symbol,
+        name: String,
+        tags: Vec<Symbol>,
+        address: Option<Address>,
+    ) {
+        Self::require_admin(&env, &caller);
+
+        if env.storage().instance().has(&DataKey::Merchant(id.clone())) {
+            panic!("merchant already exists");
+        }
+
+        Self::validate_name(&name);
+        Self::validate_tags(&tags);
+
+        let merchant = Merchant {
+            id: id.clone(),
+            name,
+            tags,
+            address,
+            registered_at: env.ledger().timestamp(),
+            active: true,
+        };
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Merchant(id.clone()), &merchant);
+
+        // Add to global index
+        let mut index: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+        index.push_back(id.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::MerchantIndex, &index);
+
+        emit_merchant_registered(&env, &id, &caller);
+    }
+
+    /// Update an existing merchant's name, tags, or address (admin only).
+    ///
+    /// Pass `None` for any field to leave it unchanged.
+    pub fn update_merchant(
+        env: Env,
+        caller: Address,
+        id: Symbol,
+        name: Option<String>,
+        tags: Option<Vec<Symbol>>,
+        address: Option<Address>,
+    ) {
+        Self::require_admin(&env, &caller);
+
+        let mut merchant: Merchant = env
+            .storage()
+            .instance()
+            .get(&DataKey::Merchant(id.clone()))
+            .expect("merchant not found");
+
+        if let Some(n) = name {
+            Self::validate_name(&n);
+            merchant.name = n;
+        }
+        if let Some(t) = tags {
+            Self::validate_tags(&t);
+            merchant.tags = t;
+        }
+        if let Some(a) = address {
+            merchant.address = Some(a);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Merchant(id.clone()), &merchant);
+
+        emit_merchant_updated(&env, &id, &caller);
+    }
+
+    /// Deactivate a merchant (admin only). Existing tags are preserved.
+    pub fn deactivate_merchant(env: Env, caller: Address, id: Symbol) {
+        Self::require_admin(&env, &caller);
+
+        let mut merchant: Merchant = env
+            .storage()
+            .instance()
+            .get(&DataKey::Merchant(id.clone()))
+            .expect("merchant not found");
+
+        merchant.active = false;
+        env.storage()
+            .instance()
+            .set(&DataKey::Merchant(id.clone()), &merchant);
+
+        emit_merchant_deactivated(&env, &id, &caller);
+    }
+
+    /// Retrieve a merchant record by ID.
+    pub fn get_merchant(env: Env, id: Symbol) -> Option<Merchant> {
+        env.storage().instance().get(&DataKey::Merchant(id))
+    }
+
+    /// Return all registered merchant IDs.
+    pub fn list_merchants(env: Env) -> Vec<Symbol> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantIndex)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ── Transaction tagging ───────────────────────────────────────────────────
+
+    /// Tag a transaction with a merchant.
+    ///
+    /// The `tagger` must authorise this call. The merchant must be active.
+    ///
+    /// # Arguments
+    /// * `tagger`      — address performing the tag (must sign).
+    /// * `tx_id`       — unique transaction identifier.
+    /// * `merchant_id` — ID of the merchant to associate.
+    /// * `amount`      — transaction amount in stroops (must be > 0).
+    /// * `asset`       — asset code symbol (e.g. `symbol_short!("XLM")`).
+    /// * `note`        — optional free-text note (pass empty string for none).
+    ///
+    /// # Panics
+    /// - `"merchant not found"` if `merchant_id` is not registered.
+    /// - `"merchant inactive"` if the merchant has been deactivated.
+    /// - `"amount must be positive"` if `amount <= 0`.
+    /// - `"already tagged"` if `tx_id` is already tagged with this merchant.
+    pub fn tag_transaction(
+        env: Env,
+        tagger: Address,
+        tx_id: u64,
+        merchant_id: Symbol,
+        amount: i128,
+        asset: Symbol,
+        note: String,
+    ) {
+        tagger.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let merchant: Merchant = env
+            .storage()
+            .instance()
+            .get(&DataKey::Merchant(merchant_id.clone()))
+            .expect("merchant not found");
+
+        if !merchant.active {
+            panic!("merchant inactive");
+        }
+
+        let tag_key = DataKey::TransactionMerchant(tx_id, merchant_id.clone());
+        if env.storage().persistent().has(&tag_key) {
+            panic!("already tagged");
+        }
+
+        let tag = TransactionMerchantTag {
+            tx_id,
+            merchant_id: merchant_id.clone(),
+            amount,
+            asset: asset.clone(),
+            timestamp: env.ledger().timestamp(),
+            note,
+        };
+
+        env.storage().persistent().set(&tag_key, &tag);
+
+        // Update merchant transaction index
+        let idx_key = DataKey::MerchantTransactions(merchant_id.clone());
+        let mut tx_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&idx_key)
+            .unwrap_or_else(|| Vec::new(&env));
+        tx_ids.push_back(tx_id);
+        env.storage().persistent().set(&idx_key, &tx_ids);
+
+        // Update merchant analytics
+        let analytics_key = DataKey::MerchantAnalytics(merchant_id.clone());
+        let mut analytics: MerchantAnalytics = env
+            .storage()
+            .instance()
+            .get(&analytics_key)
+            .unwrap_or(MerchantAnalytics {
+                merchant_id: merchant_id.clone(),
+                tx_count: 0,
+                total_volume: 0,
+                last_tx_at: 0,
+            });
+
+        analytics.tx_count += 1;
+        analytics.total_volume = analytics
+            .total_volume
+            .checked_add(amount)
+            .expect("volume overflow");
+        analytics.last_tx_at = env.ledger().timestamp();
+        env.storage()
+            .instance()
+            .set(&analytics_key, &analytics);
+
+        // Increment global counter
+        let total: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalTagged)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalTagged, &(total + 1));
+
+        emit_transaction_tagged(&env, tx_id, &merchant_id, amount, &asset);
+    }
+
+    /// Remove a merchant tag from a transaction.
+    ///
+    /// The `caller` must be the admin or the original tagger.
+    /// Analytics totals are NOT reversed (audit trail preserved).
+    pub fn remove_tag(env: Env, caller: Address, tx_id: u64, merchant_id: Symbol) {
+        caller.require_auth();
+        // Only admin can remove tags (to prevent abuse)
+        Self::require_admin(&env, &caller);
+
+        let tag_key = DataKey::TransactionMerchant(tx_id, merchant_id.clone());
+        if !env.storage().persistent().has(&tag_key) {
+            panic!("tag not found");
+        }
+
+        env.storage().persistent().remove(&tag_key);
+        emit_tag_removed(&env, tx_id, &merchant_id);
+    }
+
+    // ── Query functions ───────────────────────────────────────────────────────
+
+    /// Retrieve the merchant tag for a specific transaction.
+    pub fn get_transaction_tag(
+        env: Env,
+        tx_id: u64,
+        merchant_id: Symbol,
+    ) -> Option<TransactionMerchantTag> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TransactionMerchant(tx_id, merchant_id))
+    }
+
+    /// Return all transaction IDs tagged with a given merchant.
+    ///
+    /// Results are capped at `MAX_QUERY_RESULTS` to avoid resource exhaustion.
+    pub fn get_merchant_transactions(env: Env, merchant_id: Symbol) -> Vec<u64> {
+        let all: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantTransactions(merchant_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Cap results
+        if all.len() <= MAX_QUERY_RESULTS {
+            return all;
+        }
+        let mut capped: Vec<u64> = Vec::new(&env);
+        for i in 0..MAX_QUERY_RESULTS {
+            capped.push_back(all.get(i).unwrap());
+        }
+        capped
+    }
+
+    /// Return aggregate analytics for a merchant.
+    pub fn get_merchant_analytics(env: Env, merchant_id: Symbol) -> Option<MerchantAnalytics> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MerchantAnalytics(merchant_id))
+    }
+
+    /// Return the total number of tagged transactions across all merchants.
+    pub fn get_total_tagged(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalTagged)
+            .unwrap_or(0)
+    }
+
+    /// Query all merchants that have a specific category tag.
+    ///
+    /// Iterates the merchant index and returns matching merchant IDs.
+    pub fn get_merchants_by_tag(env: Env, tag: Symbol) -> Vec<Symbol> {
+        let index: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut result: Vec<Symbol> = Vec::new(&env);
+        for merchant_id in index.iter() {
+            if let Some(merchant) = env
+                .storage()
+                .instance()
+                .get::<_, Merchant>(&DataKey::Merchant(merchant_id.clone()))
+            {
+                if merchant.tags.contains(&tag) {
+                    result.push_back(merchant_id);
+                }
+            }
+        }
+        result
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    fn require_admin(env: &Env, caller: &Address) {
+        caller.require_auth();
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if caller != &admin {
+            panic!("unauthorized");
+        }
+    }
+
+    fn validate_name(name: &String) {
+        if name.len() > MAX_MERCHANT_NAME_LEN {
+            panic!("name too long");
+        }
+        if name.len() == 0 {
+            panic!("name cannot be empty");
+        }
+    }
+
+    fn validate_tags(tags: &Vec<Symbol>) {
+        if tags.len() > MAX_TAGS_PER_MERCHANT {
+            panic!("too many tags");
+        }
+        for tag in tags.iter() {
+            if tag.to_string().len() as u32 > MAX_TAG_LEN {
+                panic!("tag too long");
+            }
+        }
+    }
+}

--- a/contracts/merchant-tagging/src/types.rs
+++ b/contracts/merchant-tagging/src/types.rs
@@ -1,0 +1,90 @@
+//! Types for the merchant-tagging contract.
+
+use soroban_sdk::{contracttype, Address, String, Symbol};
+
+/// Maximum length of a merchant name (characters).
+pub const MAX_MERCHANT_NAME_LEN: u32 = 64;
+
+/// Maximum length of a merchant category tag (characters).
+pub const MAX_TAG_LEN: u32 = 32;
+
+/// Maximum number of tags per merchant.
+pub const MAX_TAGS_PER_MERCHANT: u32 = 10;
+
+/// Maximum number of transactions returned in a single query.
+pub const MAX_QUERY_RESULTS: u32 = 100;
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+/// Storage key variants for the merchant-tagging contract.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Contract administrator.
+    Admin,
+    /// Merchant record keyed by merchant ID.
+    Merchant(Symbol),
+    /// List of all registered merchant IDs.
+    MerchantIndex,
+    /// Merchant tag attached to a specific transaction.
+    /// Key: (transaction_id, merchant_id)
+    TransactionMerchant(u64, Symbol),
+    /// Index: all transaction IDs tagged with a given merchant.
+    MerchantTransactions(Symbol),
+    /// Aggregate spend analytics per merchant.
+    MerchantAnalytics(Symbol),
+    /// Running total of transactions processed.
+    TotalTagged,
+}
+
+// ── Core types ────────────────────────────────────────────────────────────────
+
+/// A registered merchant with metadata and category tags.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Merchant {
+    /// Unique merchant identifier (short symbol, e.g. `symbol_short!("STARBUCKS")`).
+    pub id: Symbol,
+    /// Human-readable merchant name.
+    pub name: String,
+    /// Category tags (e.g. "food", "retail", "travel"). Max `MAX_TAGS_PER_MERCHANT`.
+    pub tags: soroban_sdk::Vec<Symbol>,
+    /// Address of the merchant account on Stellar (optional).
+    pub address: Option<Address>,
+    /// Ledger timestamp when the merchant was registered.
+    pub registered_at: u64,
+    /// Whether this merchant record is active.
+    pub active: bool,
+}
+
+/// Metadata attached to a single transaction linking it to a merchant.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransactionMerchantTag {
+    /// Transaction identifier.
+    pub tx_id: u64,
+    /// Merchant this transaction is attributed to.
+    pub merchant_id: Symbol,
+    /// Amount of the transaction in stroops.
+    pub amount: i128,
+    /// Asset code (e.g. "XLM", "USDC").
+    pub asset: Symbol,
+    /// Ledger timestamp of the transaction.
+    pub timestamp: u64,
+    /// Optional free-text note.
+    pub note: String,
+}
+
+/// Aggregate analytics for a single merchant.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantAnalytics {
+    /// Merchant identifier.
+    pub merchant_id: Symbol,
+    /// Total number of tagged transactions.
+    pub tx_count: u32,
+    /// Total spend volume in stroops.
+    pub total_volume: i128,
+    /// Ledger timestamp of the most recent transaction.
+    pub last_tx_at: u64,
+}

--- a/contracts/merchant-tagging/tests/merchant_tagging_tests.rs
+++ b/contracts/merchant-tagging/tests/merchant_tagging_tests.rs
@@ -1,0 +1,382 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    symbol_short, testutils::Address as _, Address, Env, String, Vec,
+};
+
+use merchant_tagging::MerchantTaggingContractClient;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn setup() -> (Env, Address, MerchantTaggingContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, merchant_tagging::MerchantTaggingContract);
+    let client = MerchantTaggingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    (env, admin, client)
+}
+
+fn empty_tags(env: &Env) -> Vec<soroban_sdk::Symbol> {
+    Vec::new(env)
+}
+
+fn make_tags(env: &Env, tags: &[&str]) -> Vec<soroban_sdk::Symbol> {
+    let mut v = Vec::new(env);
+    for t in tags {
+        v.push_back(soroban_sdk::Symbol::new(env, t));
+    }
+    v
+}
+
+// ── Init tests ────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_init_sets_admin() {
+    let (_, admin, client) = setup();
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn test_double_init_panics() {
+    let (env, admin, client) = setup();
+    let other = Address::generate(&env);
+    client.init(&other); // second init should panic
+}
+
+// ── Merchant registration ─────────────────────────────────────────────────────
+
+#[test]
+fn test_register_merchant() {
+    let (env, admin, client) = setup();
+    let id = symbol_short!("AMAZON");
+    let name = String::from_str(&env, "Amazon");
+    let tags = make_tags(&env, &["retail", "ecommerce"]);
+
+    client.register_merchant(&admin, &id, &name, &tags, &None);
+
+    let merchant = client.get_merchant(&id).expect("merchant should exist");
+    assert_eq!(merchant.id, id);
+    assert_eq!(merchant.name, name);
+    assert!(merchant.active);
+    assert_eq!(merchant.tags.len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "merchant already exists")]
+fn test_register_duplicate_merchant_panics() {
+    let (env, admin, client) = setup();
+    let id = symbol_short!("AMAZON");
+    let name = String::from_str(&env, "Amazon");
+    client.register_merchant(&admin, &id, &name, &empty_tags(&env), &None);
+    client.register_merchant(&admin, &id, &name, &empty_tags(&env), &None);
+}
+
+#[test]
+#[should_panic(expected = "unauthorized")]
+fn test_register_merchant_non_admin_panics() {
+    let (env, _, client) = setup();
+    let non_admin = Address::generate(&env);
+    let id = symbol_short!("AMAZON");
+    let name = String::from_str(&env, "Amazon");
+    client.register_merchant(&non_admin, &id, &name, &empty_tags(&env), &None);
+}
+
+#[test]
+fn test_list_merchants() {
+    let (env, admin, client) = setup();
+    client.register_merchant(
+        &admin,
+        &symbol_short!("AMAZON"),
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+    client.register_merchant(
+        &admin,
+        &symbol_short!("NETFLIX"),
+        &String::from_str(&env, "Netflix"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    let list = client.list_merchants();
+    assert_eq!(list.len(), 2);
+}
+
+// ── Merchant update / deactivation ───────────────────────────────────────────
+
+#[test]
+fn test_update_merchant_name() {
+    let (env, admin, client) = setup();
+    let id = symbol_short!("AMAZON");
+    client.register_merchant(
+        &admin,
+        &id,
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    let new_name = String::from_str(&env, "Amazon Inc.");
+    client.update_merchant(&admin, &id, &Some(new_name.clone()), &None, &None);
+
+    let merchant = client.get_merchant(&id).unwrap();
+    assert_eq!(merchant.name, new_name);
+}
+
+#[test]
+fn test_deactivate_merchant() {
+    let (env, admin, client) = setup();
+    let id = symbol_short!("AMAZON");
+    client.register_merchant(
+        &admin,
+        &id,
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    client.deactivate_merchant(&admin, &id);
+
+    let merchant = client.get_merchant(&id).unwrap();
+    assert!(!merchant.active);
+}
+
+// ── Transaction tagging ───────────────────────────────────────────────────────
+
+#[test]
+fn test_tag_transaction() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("STARBUCKS");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Starbucks"),
+        &make_tags(&env, &["food", "coffee"]),
+        &None,
+    );
+
+    let tagger = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+    let note = String::from_str(&env, "Morning coffee");
+
+    client.tag_transaction(&tagger, &1u64, &merchant_id, &500_000i128, &asset, &note);
+
+    let tag = client
+        .get_transaction_tag(&1u64, &merchant_id)
+        .expect("tag should exist");
+    assert_eq!(tag.tx_id, 1);
+    assert_eq!(tag.amount, 500_000);
+    assert_eq!(tag.merchant_id, merchant_id);
+}
+
+#[test]
+#[should_panic(expected = "amount must be positive")]
+fn test_tag_zero_amount_panics() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("STARBUCKS");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Starbucks"),
+        &empty_tags(&env),
+        &None,
+    );
+    let tagger = Address::generate(&env);
+    client.tag_transaction(
+        &tagger,
+        &1u64,
+        &merchant_id,
+        &0i128,
+        &symbol_short!("XLM"),
+        &String::from_str(&env, ""),
+    );
+}
+
+#[test]
+#[should_panic(expected = "merchant inactive")]
+fn test_tag_inactive_merchant_panics() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("STARBUCKS");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Starbucks"),
+        &empty_tags(&env),
+        &None,
+    );
+    client.deactivate_merchant(&admin, &merchant_id);
+
+    let tagger = Address::generate(&env);
+    client.tag_transaction(
+        &tagger,
+        &1u64,
+        &merchant_id,
+        &500_000i128,
+        &symbol_short!("XLM"),
+        &String::from_str(&env, ""),
+    );
+}
+
+#[test]
+#[should_panic(expected = "already tagged")]
+fn test_duplicate_tag_panics() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("STARBUCKS");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Starbucks"),
+        &empty_tags(&env),
+        &None,
+    );
+    let tagger = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+    let note = String::from_str(&env, "");
+    client.tag_transaction(&tagger, &1u64, &merchant_id, &500_000i128, &asset, &note.clone());
+    client.tag_transaction(&tagger, &1u64, &merchant_id, &500_000i128, &asset, &note);
+}
+
+// ── Query functions ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_merchant_transactions() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("AMAZON");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    let tagger = Address::generate(&env);
+    let asset = symbol_short!("USDC");
+    let note = String::from_str(&env, "");
+
+    client.tag_transaction(&tagger, &10u64, &merchant_id, &1_000_000i128, &asset, &note.clone());
+    client.tag_transaction(&tagger, &11u64, &merchant_id, &2_000_000i128, &asset, &note.clone());
+    client.tag_transaction(&tagger, &12u64, &merchant_id, &3_000_000i128, &asset, &note);
+
+    let txs = client.get_merchant_transactions(&merchant_id);
+    assert_eq!(txs.len(), 3);
+}
+
+#[test]
+fn test_merchant_analytics_accumulate() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("AMAZON");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    let tagger = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+    let note = String::from_str(&env, "");
+
+    client.tag_transaction(&tagger, &1u64, &merchant_id, &1_000i128, &asset, &note.clone());
+    client.tag_transaction(&tagger, &2u64, &merchant_id, &2_000i128, &asset, &note);
+
+    let analytics = client
+        .get_merchant_analytics(&merchant_id)
+        .expect("analytics should exist");
+    assert_eq!(analytics.tx_count, 2);
+    assert_eq!(analytics.total_volume, 3_000);
+}
+
+#[test]
+fn test_get_merchants_by_tag() {
+    let (env, admin, client) = setup();
+
+    client.register_merchant(
+        &admin,
+        &symbol_short!("AMAZON"),
+        &String::from_str(&env, "Amazon"),
+        &make_tags(&env, &["retail"]),
+        &None,
+    );
+    client.register_merchant(
+        &admin,
+        &symbol_short!("WALMART"),
+        &String::from_str(&env, "Walmart"),
+        &make_tags(&env, &["retail", "grocery"]),
+        &None,
+    );
+    client.register_merchant(
+        &admin,
+        &symbol_short!("NETFLIX"),
+        &String::from_str(&env, "Netflix"),
+        &make_tags(&env, &["streaming"]),
+        &None,
+    );
+
+    let retail_tag = soroban_sdk::Symbol::new(&env, "retail");
+    let retail_merchants = client.get_merchants_by_tag(&retail_tag);
+    assert_eq!(retail_merchants.len(), 2);
+
+    let streaming_tag = soroban_sdk::Symbol::new(&env, "streaming");
+    let streaming_merchants = client.get_merchants_by_tag(&streaming_tag);
+    assert_eq!(streaming_merchants.len(), 1);
+}
+
+#[test]
+fn test_total_tagged_counter() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("AMAZON");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    assert_eq!(client.get_total_tagged(), 0);
+
+    let tagger = Address::generate(&env);
+    let asset = symbol_short!("XLM");
+    let note = String::from_str(&env, "");
+    client.tag_transaction(&tagger, &1u64, &merchant_id, &1_000i128, &asset, &note.clone());
+    client.tag_transaction(&tagger, &2u64, &merchant_id, &2_000i128, &asset, &note);
+
+    assert_eq!(client.get_total_tagged(), 2);
+}
+
+// ── Tag removal ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_remove_tag() {
+    let (env, admin, client) = setup();
+    let merchant_id = symbol_short!("AMAZON");
+    client.register_merchant(
+        &admin,
+        &merchant_id,
+        &String::from_str(&env, "Amazon"),
+        &empty_tags(&env),
+        &None,
+    );
+
+    let tagger = Address::generate(&env);
+    client.tag_transaction(
+        &tagger,
+        &1u64,
+        &merchant_id,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &String::from_str(&env, ""),
+    );
+
+    assert!(client.get_transaction_tag(&1u64, &merchant_id).is_some());
+
+    client.remove_tag(&admin, &1u64, &merchant_id);
+
+    assert!(client.get_transaction_tag(&1u64, &merchant_id).is_none());
+}


### PR DESCRIPTION
- Create contracts/merchant-tagging/ as a new Soroban workspace contract
- src/types.rs: DataKey, Merchant, TransactionMerchantTag, MerchantAnalytics types
  - MAX_MERCHANT_NAME_LEN=64, MAX_TAG_LEN=32, MAX_TAGS_PER_MERCHANT=10
  - MAX_QUERY_RESULTS=100 cap on get_merchant_transactions
- src/events.rs: emit_merchant_registered, emit_merchant_updated, emit_merchant_deactivated, emit_transaction_tagged, emit_tag_removed
- src/lib.rs: MerchantTaggingContract with full implementation
  - init(admin): initialise contract, panics on double-init
  - register_merchant(caller, id, name, tags, address): admin-only, validates name/tags
  - update_merchant(caller, id, name?, tags?, address?): partial update, admin-only
  - deactivate_merchant(caller, id): soft-delete, admin-only
  - get_merchant(id): retrieve merchant record
  - list_merchants(): return all registered merchant IDs
  - tag_transaction(tagger, tx_id, merchant_id, amount, asset, note): attaches merchant metadata to a transaction, updates analytics index
  - remove_tag(caller, tx_id, merchant_id): admin-only tag removal
  - get_transaction_tag(tx_id, merchant_id): retrieve a specific tag
  - get_merchant_transactions(merchant_id): queryable index of all tx IDs per merchant
  - get_merchant_analytics(merchant_id): aggregate tx_count + total_volume per merchant
  - get_merchants_by_tag(tag): query merchants by category tag
  - get_total_tagged(): global tagged transaction counter
- tests/merchant_tagging_tests.rs: 16 tests covering
  - init, double-init guard
  - register, duplicate, unauthorized
  - list merchants
  - update name, deactivate
  - tag transaction, zero amount, inactive merchant, duplicate tag
  - get_merchant_transactions, analytics accumulation
  - get_merchants_by_tag (multi-tag query)
  - total_tagged counter
  - remove_tag
- Cargo.toml: add merchant-tagging to workspace members

Closes #495