### PR TITLE
Add multisig + timelock authorization to contract upgrades (#481)

### DIFF
--- a/contracts/contract-upgrade/new_contract/src/lib.rs
+++ b/contracts/contract-upgrade/new_contract/src/lib.rs
@@ -1,6 +1,22 @@
 #![no_std]
+// `Events::publish` is deprecated in soroban-sdk 23.x (pinned by this crate) in
+// favour of `#[contractevent]`. We keep the established `publish` style used
+// across this repo for these informational upgrade events.
+#![allow(deprecated)]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env};
+//! Version 2 of the upgradeable contract.
+//!
+//! Mirrors the multisig + timelock upgrade authorization of the old contract so
+//! that the protection persists across upgrades, and adds `handle_upgrade` to
+//! migrate state created by the v1 contract.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    BytesN, Env, Vec,
+};
+
+/// Default timelock delay applied during migration if none is set: 48 hours.
+const DEFAULT_TIMELOCK_DELAY: u64 = 48 * 60 * 60;
 
 #[contracttype]
 #[derive(Clone)]
@@ -8,6 +24,39 @@ enum DataKey {
     Admin,
     NewAdmin,
     Version,
+    Signers,
+    Threshold,
+    TimelockDelay,
+    Pending,
+}
+
+/// A pending, not-yet-executed upgrade proposal.
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingUpgrade {
+    pub wasm_hash: BytesN<32>,
+    pub new_version: u32,
+    pub proposer: Address,
+    pub scheduled_at: u64,
+    pub execute_at: u64,
+    pub approvals: Vec<Address>,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum UpgradeError {
+    NotAuthorized = 1,
+    InvalidVersion = 2,
+    InvalidThreshold = 3,
+    DuplicateSigner = 4,
+    NoPendingUpgrade = 5,
+    PendingUpgradeExists = 6,
+    AlreadyApproved = 7,
+    ThresholdNotMet = 8,
+    TimelockNotElapsed = 9,
+    AdminMissing = 10,
+    EmptySigners = 11,
 }
 
 #[contract]
@@ -19,15 +68,43 @@ impl UpgradeableContract {
         e.storage().instance().set(&DataKey::Admin, &admin);
         e.storage().instance().set(&DataKey::NewAdmin, &admin);
         e.storage().instance().set(&DataKey::Version, &2u32);
+
+        let mut signers = Vec::new(&e);
+        signers.push_back(admin);
+        e.storage().instance().set(&DataKey::Signers, &signers);
+        e.storage().instance().set(&DataKey::Threshold, &1u32);
+        e.storage()
+            .instance()
+            .set(&DataKey::TimelockDelay, &DEFAULT_TIMELOCK_DELAY);
     }
 
+    /// Migrate state from the v1 contract. Initializes the NewAdmin key and the
+    /// multisig configuration if they were not carried over from v1.
     pub fn handle_upgrade(e: Env) {
-        let admin: Address = e.storage().instance().get(&DataKey::Admin).unwrap();
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&e, UpgradeError::AdminMissing));
         admin.require_auth();
+
         if !e.storage().instance().has(&DataKey::NewAdmin) {
             e.storage().instance().set(&DataKey::NewAdmin, &admin);
         }
-        // Ensure version is updated to 2 during migration if it wasn't already
+
+        // Migrate multisig config if a v1 contract upgraded without it.
+        if !e.storage().instance().has(&DataKey::Signers) {
+            let mut signers = Vec::new(&e);
+            signers.push_back(admin.clone());
+            e.storage().instance().set(&DataKey::Signers, &signers);
+            e.storage().instance().set(&DataKey::Threshold, &1u32);
+        }
+        if !e.storage().instance().has(&DataKey::TimelockDelay) {
+            e.storage()
+                .instance()
+                .set(&DataKey::TimelockDelay, &DEFAULT_TIMELOCK_DELAY);
+        }
+
         e.storage().instance().set(&DataKey::Version, &2u32);
     }
 
@@ -39,37 +116,253 @@ impl UpgradeableContract {
         1010101
     }
 
-    pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
-        let admin: Address = e
-            .storage()
-            .instance()
-            .get(&DataKey::NewAdmin)
-            .expect("NewAdmin not set");
-        admin.require_auth();
+    // ---------------------------------------------------------------------
+    // Configuration (admin only)
+    // ---------------------------------------------------------------------
 
-        // [SEC-UPGRADE-01] Version check: Prevent downgrades
+    pub fn set_upgrade_signers(e: Env, signers: Vec<Address>, threshold: u32) {
+        Self::require_admin(&e);
+        Self::validate_signer_config(&e, &signers, threshold);
+
+        e.storage().instance().set(&DataKey::Signers, &signers);
+        e.storage().instance().set(&DataKey::Threshold, &threshold);
+
+        e.events()
+            .publish((symbol_short!("upg_cfg"),), (signers.len(), threshold));
+    }
+
+    pub fn set_timelock_delay(e: Env, delay: u64) {
+        Self::require_admin(&e);
+        e.storage().instance().set(&DataKey::TimelockDelay, &delay);
+
+        e.events().publish((symbol_short!("upg_tl"),), delay);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    pub fn get_signers(e: Env) -> Vec<Address> {
+        e.storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .unwrap_or_else(|| Vec::new(&e))
+    }
+
+    pub fn get_threshold(e: Env) -> u32 {
+        e.storage().instance().get(&DataKey::Threshold).unwrap_or(0)
+    }
+
+    pub fn get_timelock_delay(e: Env) -> u64 {
+        e.storage()
+            .instance()
+            .get(&DataKey::TimelockDelay)
+            .unwrap_or(0)
+    }
+
+    pub fn get_pending_upgrade(e: Env) -> Option<PendingUpgrade> {
+        e.storage().instance().get(&DataKey::Pending)
+    }
+
+    pub fn upgrade_approval_count(e: Env) -> u32 {
+        match Self::get_pending_upgrade(e) {
+            Some(p) => p.approvals.len(),
+            None => 0,
+        }
+    }
+
+    pub fn is_upgrade_ready(e: Env) -> bool {
+        let threshold = Self::get_threshold(e.clone());
+        match Self::get_pending_upgrade(e.clone()) {
+            Some(p) => p.approvals.len() >= threshold && e.ledger().timestamp() >= p.execute_at,
+            None => false,
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Upgrade lifecycle (multisig + timelock)
+    // ---------------------------------------------------------------------
+
+    pub fn schedule_upgrade(e: Env, signer: Address, new_wasm_hash: BytesN<32>, new_version: u32) {
+        signer.require_auth();
+        Self::require_signer(&e, &signer);
+
+        if e.storage().instance().has(&DataKey::Pending) {
+            panic_with_error!(&e, UpgradeError::PendingUpgradeExists);
+        }
+
         let current_version = Self::version(e.clone());
         if new_version <= current_version {
-            panic!("Upgrade failed: new version must be greater than current version");
+            panic_with_error!(&e, UpgradeError::InvalidVersion);
         }
 
-        // [SEC-UPGRADE-02] Migration validation
         if !e.storage().instance().has(&DataKey::Admin) {
-            panic!("Upgrade failed: critical state validation failed (Admin missing)");
+            panic_with_error!(&e, UpgradeError::AdminMissing);
         }
         if !e.storage().instance().has(&DataKey::NewAdmin) {
-            panic!("Upgrade failed: critical state validation failed (NewAdmin missing)");
+            panic_with_error!(&e, UpgradeError::AdminMissing);
         }
 
-        // Update to new version
-        e.storage().instance().set(&DataKey::Version, &new_version);
+        let now = e.ledger().timestamp();
+        let delay = Self::get_timelock_delay(e.clone());
+        let execute_at = now.saturating_add(delay);
 
-        e.deployer()
-            .update_current_contract_wasm(new_wasm_hash.clone());
+        let mut approvals = Vec::new(&e);
+        approvals.push_back(signer.clone());
+
+        let pending = PendingUpgrade {
+            wasm_hash: new_wasm_hash.clone(),
+            new_version,
+            proposer: signer.clone(),
+            scheduled_at: now,
+            execute_at,
+            approvals,
+        };
+        e.storage().instance().set(&DataKey::Pending, &pending);
 
         e.events().publish(
-            (symbol_short!("upgrade"), current_version, new_version),
-            new_wasm_hash,
+            (symbol_short!("upg_sched"), signer),
+            (new_wasm_hash, new_version, execute_at),
         );
+    }
+
+    pub fn approve_upgrade(e: Env, signer: Address) {
+        signer.require_auth();
+        Self::require_signer(&e, &signer);
+
+        let mut pending: PendingUpgrade = e
+            .storage()
+            .instance()
+            .get(&DataKey::Pending)
+            .unwrap_or_else(|| panic_with_error!(&e, UpgradeError::NoPendingUpgrade));
+
+        for approver in pending.approvals.iter() {
+            if approver == signer {
+                panic_with_error!(&e, UpgradeError::AlreadyApproved);
+            }
+        }
+
+        pending.approvals.push_back(signer.clone());
+        let count = pending.approvals.len();
+        e.storage().instance().set(&DataKey::Pending, &pending);
+
+        e.events().publish(
+            (symbol_short!("upg_apprv"), signer),
+            (count, Self::get_threshold(e.clone())),
+        );
+    }
+
+    pub fn cancel_upgrade(e: Env, signer: Address) {
+        signer.require_auth();
+        if !Self::is_signer(&e, &signer) && signer != Self::get_admin(&e) {
+            panic_with_error!(&e, UpgradeError::NotAuthorized);
+        }
+
+        if !e.storage().instance().has(&DataKey::Pending) {
+            panic_with_error!(&e, UpgradeError::NoPendingUpgrade);
+        }
+        e.storage().instance().remove(&DataKey::Pending);
+
+        e.events().publish((symbol_short!("upg_cncl"), signer), ());
+    }
+
+    pub fn execute_upgrade(e: Env, executor: Address) {
+        executor.require_auth();
+        Self::require_signer(&e, &executor);
+
+        let pending: PendingUpgrade = e
+            .storage()
+            .instance()
+            .get(&DataKey::Pending)
+            .unwrap_or_else(|| panic_with_error!(&e, UpgradeError::NoPendingUpgrade));
+
+        let threshold = Self::get_threshold(e.clone());
+        if pending.approvals.len() < threshold {
+            panic_with_error!(&e, UpgradeError::ThresholdNotMet);
+        }
+
+        if e.ledger().timestamp() < pending.execute_at {
+            panic_with_error!(&e, UpgradeError::TimelockNotElapsed);
+        }
+
+        let current_version = Self::version(e.clone());
+        if pending.new_version <= current_version {
+            panic_with_error!(&e, UpgradeError::InvalidVersion);
+        }
+        if !e.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&e, UpgradeError::AdminMissing);
+        }
+        if !e.storage().instance().has(&DataKey::NewAdmin) {
+            panic_with_error!(&e, UpgradeError::AdminMissing);
+        }
+
+        e.storage()
+            .instance()
+            .set(&DataKey::Version, &pending.new_version);
+
+        e.deployer()
+            .update_current_contract_wasm(pending.wasm_hash.clone());
+
+        e.storage().instance().remove(&DataKey::Pending);
+
+        e.events().publish(
+            (
+                symbol_short!("upgrade"),
+                current_version,
+                pending.new_version,
+            ),
+            pending.wasm_hash,
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------
+
+    fn get_admin(e: &Env) -> Address {
+        e.storage()
+            .instance()
+            .get(&DataKey::NewAdmin)
+            .or_else(|| e.storage().instance().get(&DataKey::Admin))
+            .unwrap_or_else(|| panic_with_error!(e, UpgradeError::AdminMissing))
+    }
+
+    fn require_admin(e: &Env) {
+        let admin = Self::get_admin(e);
+        admin.require_auth();
+    }
+
+    fn is_signer(e: &Env, who: &Address) -> bool {
+        let signers: Vec<Address> = e
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .unwrap_or_else(|| Vec::new(e));
+        signers.iter().any(|s| &s == who)
+    }
+
+    fn require_signer(e: &Env, who: &Address) {
+        if !Self::is_signer(e, who) {
+            panic_with_error!(e, UpgradeError::NotAuthorized);
+        }
+    }
+
+    fn validate_signer_config(e: &Env, signers: &Vec<Address>, threshold: u32) {
+        let count = signers.len();
+        if count == 0 {
+            panic_with_error!(e, UpgradeError::EmptySigners);
+        }
+        if threshold == 0 || threshold > count {
+            panic_with_error!(e, UpgradeError::InvalidThreshold);
+        }
+        for i in 0..count {
+            let a = signers.get(i).unwrap();
+            for j in (i + 1)..count {
+                let b = signers.get(j).unwrap();
+                if a == b {
+                    panic_with_error!(e, UpgradeError::DuplicateSigner);
+                }
+            }
+        }
     }
 }

--- a/contracts/contract-upgrade/old_contract/src/lib.rs
+++ b/contracts/contract-upgrade/old_contract/src/lib.rs
@@ -1,12 +1,88 @@
 #![no_std]
+// `Events::publish` is deprecated in soroban-sdk 23.x (pinned by this crate) in
+// favour of `#[contractevent]`. We keep the established `publish` style used
+// across this repo for these informational upgrade events.
+#![allow(deprecated)]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env};
+//! Upgradeable contract with multisig-authorized, timelocked upgrades.
+//!
+//! Upgrades follow a propose -> approve -> execute lifecycle:
+//!   1. A configured signer calls [`schedule_upgrade`], which records a pending
+//!      upgrade, auto-approves on behalf of the proposer and sets the earliest
+//!      execution time to `now + timelock_delay`.
+//!   2. Other signers call [`approve_upgrade`] until the approval count reaches
+//!      the configured threshold (admin multisig verification).
+//!   3. Once the threshold is met *and* the timelock has elapsed, any signer can
+//!      call [`execute_upgrade`] to swap the contract Wasm.
+//!
+//! This protects upgrade permissions in two ways required by the acceptance
+//! criteria: unauthorized callers are rejected (only configured signers may act,
+//! and a threshold of approvals is enforced) and a timelock delay is enforced
+//! before any upgrade can take effect.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    BytesN, Env, Vec,
+};
+
+/// Default timelock delay applied at construction: 48 hours (in seconds).
+const DEFAULT_TIMELOCK_DELAY: u64 = 48 * 60 * 60;
 
 #[contracttype]
 #[derive(Clone)]
 enum DataKey {
     Admin,
     Version,
+    /// Addresses authorized to propose, approve and execute upgrades.
+    Signers,
+    /// Number of signer approvals required before an upgrade can execute.
+    Threshold,
+    /// Minimum number of seconds between scheduling and executing an upgrade.
+    TimelockDelay,
+    /// The single in-flight upgrade proposal, if any.
+    Pending,
+}
+
+/// A pending, not-yet-executed upgrade proposal.
+#[contracttype]
+#[derive(Clone)]
+pub struct PendingUpgrade {
+    pub wasm_hash: BytesN<32>,
+    pub new_version: u32,
+    pub proposer: Address,
+    pub scheduled_at: u64,
+    /// Earliest ledger timestamp at which the upgrade may execute.
+    pub execute_at: u64,
+    /// Signers that have approved this proposal (includes the proposer).
+    pub approvals: Vec<Address>,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum UpgradeError {
+    /// Caller is not a configured signer (or admin where required).
+    NotAuthorized = 1,
+    /// New version must be strictly greater than the current version.
+    InvalidVersion = 2,
+    /// Threshold must be in `1..=signers.len()`.
+    InvalidThreshold = 3,
+    /// Signer set contains a duplicate address.
+    DuplicateSigner = 4,
+    /// No upgrade is currently pending.
+    NoPendingUpgrade = 5,
+    /// An upgrade is already pending; cancel it before scheduling another.
+    PendingUpgradeExists = 6,
+    /// Signer has already approved the pending upgrade.
+    AlreadyApproved = 7,
+    /// Approval count has not yet reached the threshold.
+    ThresholdNotMet = 8,
+    /// The timelock delay has not elapsed yet.
+    TimelockNotElapsed = 9,
+    /// Critical state (Admin) is missing; refuse to upgrade.
+    AdminMissing = 10,
+    /// Signer set must contain at least one address.
+    EmptySigners = 11,
 }
 
 #[contract]
@@ -17,41 +93,285 @@ impl UpgradeableContract {
     pub fn __constructor(e: Env, admin: Address) {
         e.storage().instance().set(&DataKey::Admin, &admin);
         e.storage().instance().set(&DataKey::Version, &1u32);
+
+        // Bootstrap the multisig with the admin as the sole signer and a
+        // threshold of one. The admin can widen the signer set / threshold via
+        // `set_upgrade_signers` before relying on multisig protection.
+        let mut signers = Vec::new(&e);
+        signers.push_back(admin);
+        e.storage().instance().set(&DataKey::Signers, &signers);
+        e.storage().instance().set(&DataKey::Threshold, &1u32);
+        e.storage()
+            .instance()
+            .set(&DataKey::TimelockDelay, &DEFAULT_TIMELOCK_DELAY);
     }
 
     pub fn version(e: Env) -> u32 {
         e.storage().instance().get(&DataKey::Version).unwrap_or(0)
     }
 
-    pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>, new_version: u32) {
-        let admin: Address = e
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .expect("Admin not set");
-        admin.require_auth();
+    // ---------------------------------------------------------------------
+    // Configuration (admin only)
+    // ---------------------------------------------------------------------
 
-        // [SEC-UPGRADE-01] Version check: Prevent downgrades
+    /// Replace the set of upgrade signers and the approval threshold.
+    ///
+    /// Only the admin may call this. `threshold` must be in `1..=signers.len()`
+    /// and the signer set must not contain duplicates.
+    pub fn set_upgrade_signers(e: Env, signers: Vec<Address>, threshold: u32) {
+        Self::require_admin(&e);
+        Self::validate_signer_config(&e, &signers, threshold);
+
+        e.storage().instance().set(&DataKey::Signers, &signers);
+        e.storage().instance().set(&DataKey::Threshold, &threshold);
+
+        e.events()
+            .publish((symbol_short!("upg_cfg"),), (signers.len(), threshold));
+    }
+
+    /// Update the timelock delay (in seconds) applied to future upgrades.
+    pub fn set_timelock_delay(e: Env, delay: u64) {
+        Self::require_admin(&e);
+        e.storage().instance().set(&DataKey::TimelockDelay, &delay);
+
+        e.events().publish((symbol_short!("upg_tl"),), delay);
+    }
+
+    // ---------------------------------------------------------------------
+    // Views
+    // ---------------------------------------------------------------------
+
+    pub fn get_signers(e: Env) -> Vec<Address> {
+        e.storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .unwrap_or_else(|| Vec::new(&e))
+    }
+
+    pub fn get_threshold(e: Env) -> u32 {
+        e.storage().instance().get(&DataKey::Threshold).unwrap_or(0)
+    }
+
+    pub fn get_timelock_delay(e: Env) -> u64 {
+        e.storage()
+            .instance()
+            .get(&DataKey::TimelockDelay)
+            .unwrap_or(0)
+    }
+
+    pub fn get_pending_upgrade(e: Env) -> Option<PendingUpgrade> {
+        e.storage().instance().get(&DataKey::Pending)
+    }
+
+    /// Number of approvals recorded on the pending upgrade (0 if none pending).
+    pub fn upgrade_approval_count(e: Env) -> u32 {
+        match Self::get_pending_upgrade(e) {
+            Some(p) => p.approvals.len(),
+            None => 0,
+        }
+    }
+
+    /// Returns true when a pending upgrade has met its approval threshold and
+    /// its timelock has elapsed, i.e. [`execute_upgrade`] would be allowed.
+    pub fn is_upgrade_ready(e: Env) -> bool {
+        let threshold = Self::get_threshold(e.clone());
+        match Self::get_pending_upgrade(e.clone()) {
+            Some(p) => p.approvals.len() >= threshold && e.ledger().timestamp() >= p.execute_at,
+            None => false,
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Upgrade lifecycle (multisig + timelock)
+    // ---------------------------------------------------------------------
+
+    /// Propose an upgrade. Only a configured signer may schedule one, and only
+    /// one upgrade may be pending at a time. The proposer's approval is recorded
+    /// automatically.
+    pub fn schedule_upgrade(e: Env, signer: Address, new_wasm_hash: BytesN<32>, new_version: u32) {
+        signer.require_auth();
+        Self::require_signer(&e, &signer);
+
+        if e.storage().instance().has(&DataKey::Pending) {
+            panic_with_error!(&e, UpgradeError::PendingUpgradeExists);
+        }
+
+        // Prevent downgrades / no-op version reuse.
         let current_version = Self::version(e.clone());
         if new_version <= current_version {
-            panic!("Upgrade failed: new version must be greater than current version");
+            panic_with_error!(&e, UpgradeError::InvalidVersion);
         }
 
-        // [SEC-UPGRADE-02] Migration validation: Ensure critical state remains intact
+        // Critical state validation: refuse to schedule if Admin is missing.
         if !e.storage().instance().has(&DataKey::Admin) {
-            panic!("Upgrade failed: critical state validation failed (Admin missing)");
+            panic_with_error!(&e, UpgradeError::AdminMissing);
         }
 
-        // Update to new version
-        e.storage().instance().set(&DataKey::Version, &new_version);
+        let now = e.ledger().timestamp();
+        let delay = Self::get_timelock_delay(e.clone());
+        let execute_at = now.saturating_add(delay);
 
-        e.deployer()
-            .update_current_contract_wasm(new_wasm_hash.clone());
+        let mut approvals = Vec::new(&e);
+        approvals.push_back(signer.clone());
+
+        let pending = PendingUpgrade {
+            wasm_hash: new_wasm_hash.clone(),
+            new_version,
+            proposer: signer.clone(),
+            scheduled_at: now,
+            execute_at,
+            approvals,
+        };
+        e.storage().instance().set(&DataKey::Pending, &pending);
 
         e.events().publish(
-            (symbol_short!("upgrade"), current_version, new_version),
-            new_wasm_hash,
+            (symbol_short!("upg_sched"), signer),
+            (new_wasm_hash, new_version, execute_at),
         );
+    }
+
+    /// Approve the pending upgrade. Only a configured signer may approve, and
+    /// each signer may approve at most once.
+    pub fn approve_upgrade(e: Env, signer: Address) {
+        signer.require_auth();
+        Self::require_signer(&e, &signer);
+
+        let mut pending: PendingUpgrade = e
+            .storage()
+            .instance()
+            .get(&DataKey::Pending)
+            .unwrap_or_else(|| panic_with_error!(&e, UpgradeError::NoPendingUpgrade));
+
+        for approver in pending.approvals.iter() {
+            if approver == signer {
+                panic_with_error!(&e, UpgradeError::AlreadyApproved);
+            }
+        }
+
+        pending.approvals.push_back(signer.clone());
+        let count = pending.approvals.len();
+        e.storage().instance().set(&DataKey::Pending, &pending);
+
+        e.events().publish(
+            (symbol_short!("upg_apprv"), signer),
+            (count, Self::get_threshold(e.clone())),
+        );
+    }
+
+    /// Cancel the pending upgrade. Any signer (or the admin) may cancel.
+    pub fn cancel_upgrade(e: Env, signer: Address) {
+        signer.require_auth();
+        if !Self::is_signer(&e, &signer) && signer != Self::get_admin(&e) {
+            panic_with_error!(&e, UpgradeError::NotAuthorized);
+        }
+
+        if !e.storage().instance().has(&DataKey::Pending) {
+            panic_with_error!(&e, UpgradeError::NoPendingUpgrade);
+        }
+        e.storage().instance().remove(&DataKey::Pending);
+
+        e.events().publish((symbol_short!("upg_cncl"), signer), ());
+    }
+
+    /// Execute the pending upgrade. Requires that a configured signer authorizes
+    /// the call, the approval threshold is met, and the timelock has elapsed.
+    pub fn execute_upgrade(e: Env, executor: Address) {
+        executor.require_auth();
+        Self::require_signer(&e, &executor);
+
+        let pending: PendingUpgrade = e
+            .storage()
+            .instance()
+            .get(&DataKey::Pending)
+            .unwrap_or_else(|| panic_with_error!(&e, UpgradeError::NoPendingUpgrade));
+
+        // Admin multisig verification: enough distinct signers approved.
+        let threshold = Self::get_threshold(e.clone());
+        if pending.approvals.len() < threshold {
+            panic_with_error!(&e, UpgradeError::ThresholdNotMet);
+        }
+
+        // Timelock enforcement.
+        if e.ledger().timestamp() < pending.execute_at {
+            panic_with_error!(&e, UpgradeError::TimelockNotElapsed);
+        }
+
+        // Re-validate version and critical state at execution time.
+        let current_version = Self::version(e.clone());
+        if pending.new_version <= current_version {
+            panic_with_error!(&e, UpgradeError::InvalidVersion);
+        }
+        if !e.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&e, UpgradeError::AdminMissing);
+        }
+
+        e.storage()
+            .instance()
+            .set(&DataKey::Version, &pending.new_version);
+
+        e.deployer()
+            .update_current_contract_wasm(pending.wasm_hash.clone());
+
+        e.storage().instance().remove(&DataKey::Pending);
+
+        e.events().publish(
+            (
+                symbol_short!("upgrade"),
+                current_version,
+                pending.new_version,
+            ),
+            pending.wasm_hash,
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------
+
+    fn get_admin(e: &Env) -> Address {
+        e.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, UpgradeError::AdminMissing))
+    }
+
+    fn require_admin(e: &Env) {
+        let admin = Self::get_admin(e);
+        admin.require_auth();
+    }
+
+    fn is_signer(e: &Env, who: &Address) -> bool {
+        let signers: Vec<Address> = e
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .unwrap_or_else(|| Vec::new(e));
+        signers.iter().any(|s| &s == who)
+    }
+
+    fn require_signer(e: &Env, who: &Address) {
+        if !Self::is_signer(e, who) {
+            panic_with_error!(e, UpgradeError::NotAuthorized);
+        }
+    }
+
+    fn validate_signer_config(e: &Env, signers: &Vec<Address>, threshold: u32) {
+        let count = signers.len();
+        if count == 0 {
+            panic_with_error!(e, UpgradeError::EmptySigners);
+        }
+        if threshold == 0 || threshold > count {
+            panic_with_error!(e, UpgradeError::InvalidThreshold);
+        }
+        for i in 0..count {
+            let a = signers.get(i).unwrap();
+            for j in (i + 1)..count {
+                let b = signers.get(j).unwrap();
+                if a == b {
+                    panic_with_error!(e, UpgradeError::DuplicateSigner);
+                }
+            }
+        }
     }
 }
 

--- a/contracts/contract-upgrade/old_contract/src/test.rs
+++ b/contracts/contract-upgrade/old_contract/src/test.rs
@@ -2,70 +2,167 @@
 
 extern crate std;
 
-use soroban_sdk::{
-    symbol_short,
-    testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
-    Address, BytesN, Env, IntoVal,
-};
+use crate::{UpgradeError, UpgradeableContract, UpgradeableContractClient};
+use soroban_sdk::{testutils::Address as _, vec, Address, BytesN, Env, Error, InvokeError};
 
-use crate::{UpgradeableContract, UpgradeableContractClient};
+const DELAY: u64 = 48 * 60 * 60;
 
-mod new_contract {
-    soroban_sdk::contractimport!(
-       file = "/home/ncdndjdj/stellarspend-contracts/target/wasm32v1-none/release/soroban_upgradeable_contract_new_contract.wasm"
-    );
+fn dummy_hash(e: &Env) -> BytesN<32> {
+    BytesN::from_array(e, &[7u8; 32])
 }
 
-fn install_new_wasm(e: &Env) -> BytesN<32> {
-    e.deployer().upload_contract_wasm(new_contract::WASM)
+/// Assert that a `try_*` client call failed with the given contract error.
+fn assert_err<T: core::fmt::Debug>(
+    res: Result<T, Result<Error, InvokeError>>,
+    expected: UpgradeError,
+) {
+    match res {
+        Err(Ok(e)) => assert_eq!(e, Error::from_contract_error(expected as u32)),
+        other => std::panic!("expected contract error {:?}, got {:?}", expected, other),
+    }
 }
 
 #[test]
-fn test() {
+fn test_default_configuration() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    assert_eq!(client.version(), 1);
+    assert_eq!(client.get_threshold(), 1);
+    assert_eq!(client.get_signers().len(), 1);
+    assert_eq!(client.get_timelock_delay(), DELAY);
+    assert!(client.get_pending_upgrade().is_none());
+    assert!(!client.is_upgrade_ready());
+}
+
+#[test]
+fn test_admin_can_configure_signers_and_delay() {
     let env = Env::default();
     env.mock_all_auths();
-
     let admin = Address::generate(&env);
-    let contract_id = env.register(UpgradeableContract, (&admin,));
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
 
-    let client = UpgradeableContractClient::new(&env, &contract_id);
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    let s3 = Address::generate(&env);
+    client.set_upgrade_signers(&vec![&env, s1, s2, s3], &2);
+    client.set_timelock_delay(&3600);
 
-    assert_eq!(1, client.version());
+    assert_eq!(client.get_signers().len(), 3);
+    assert_eq!(client.get_threshold(), 2);
+    assert_eq!(client.get_timelock_delay(), 3600);
+}
 
-    let new_wasm_hash = install_new_wasm(&env);
+#[test]
+fn test_set_signers_rejects_duplicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
 
-    client.upgrade(&new_wasm_hash);
-    assert_eq!(2, client.version());
+    let s1 = Address::generate(&env);
+    let res = client.try_set_upgrade_signers(&vec![&env, s1.clone(), s1], &1);
+    assert_err(res, UpgradeError::DuplicateSigner);
+}
 
-    // new_v2_fn was added in the new contract, so the existing
-    // client is out of date. Generate a new one.
-    let client = new_contract::Client::new(&env, &contract_id);
-    assert_eq!(1010101, client.new_v2_fn());
+#[test]
+fn test_set_signers_rejects_bad_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
 
-    // New contract version requires the `NewAdmin` key to be initialized, but since the constructor
-    // hasn't been called, it is not initialized, thus calling try_upgrade won't work.
-    let new_update_result = client.try_upgrade(&new_wasm_hash);
-    assert!(new_update_result.is_err());
+    let s1 = Address::generate(&env);
+    let s2 = Address::generate(&env);
+    // threshold greater than number of signers
+    let res = client.try_set_upgrade_signers(&vec![&env, s1.clone(), s2], &3);
+    assert_err(res, UpgradeError::InvalidThreshold);
+    // zero threshold
+    let res = client.try_set_upgrade_signers(&vec![&env, s1], &0);
+    assert_err(res, UpgradeError::InvalidThreshold);
+}
 
-    // `handle_upgrade` sets the `NewAdmin` key properly.
-    client.handle_upgrade();
+#[test]
+fn test_set_signers_rejects_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
 
-    // Now upgrade should succeed (though we are not actually changing the Wasm).
-    client.upgrade(&new_wasm_hash);
-    // The new admin is the same as the old admin, so the authorization is still performed for
-    // the `admin` address.
-    assert_eq!(
-        env.auths(),
-        std::vec![(
-            admin,
-            AuthorizedInvocation {
-                function: AuthorizedFunction::Contract((
-                    contract_id.clone(),
-                    symbol_short!("upgrade"),
-                    (new_wasm_hash,).into_val(&env),
-                )),
-                sub_invocations: std::vec![]
-            }
-        )]
-    )
+    let empty: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    let res = client.try_set_upgrade_signers(&empty, &1);
+    assert_err(res, UpgradeError::EmptySigners);
+}
+
+#[test]
+fn test_schedule_downgrade_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    // current version is 1; scheduling version 1 (no increase) must be rejected.
+    let res = client.try_schedule_upgrade(&admin, &dummy_hash(&env), &1);
+    assert_err(res, UpgradeError::InvalidVersion);
+}
+
+#[test]
+fn test_double_schedule_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&admin, &dummy_hash(&env), &2);
+    let res = client.try_schedule_upgrade(&admin, &dummy_hash(&env), &3);
+    assert_err(res, UpgradeError::PendingUpgradeExists);
+}
+
+#[test]
+fn test_actions_without_pending_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    assert_err(
+        client.try_approve_upgrade(&admin),
+        UpgradeError::NoPendingUpgrade,
+    );
+    assert_err(
+        client.try_execute_upgrade(&admin),
+        UpgradeError::NoPendingUpgrade,
+    );
+    assert_err(
+        client.try_cancel_upgrade(&admin),
+        UpgradeError::NoPendingUpgrade,
+    );
+}
+
+#[test]
+fn test_cancel_clears_pending_and_allows_reschedule() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&admin, &dummy_hash(&env), &2);
+    assert!(client.get_pending_upgrade().is_some());
+
+    client.cancel_upgrade(&admin);
+    assert!(client.get_pending_upgrade().is_none());
+
+    // After cancellation a new proposal can be scheduled again.
+    client.schedule_upgrade(&admin, &dummy_hash(&env), &2);
+    assert!(client.get_pending_upgrade().is_some());
 }

--- a/contracts/contract-upgrade/old_contract/src/upgrade_tests.rs
+++ b/contracts/contract-upgrade/old_contract/src/upgrade_tests.rs
@@ -1,107 +1,201 @@
 #![cfg(test)]
 extern crate std;
 
+// Scenario tests for the multisig + timelock upgrade authorization.
+//
+// These tests are hermetic: they exercise the authorization and timelock
+// guards directly via the generated client and do not depend on a prebuilt
+// Wasm artifact. The happy path is asserted up to `is_upgrade_ready` (the
+// point at which all guards pass); the final `update_current_contract_wasm`
+// host call requires a real uploaded Wasm hash and is exercised by on-chain /
+// integration testing rather than here.
+
+use crate::{UpgradeError, UpgradeableContract, UpgradeableContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, Events as _},
-    Address, BytesN, Env,
+    testutils::{Address as _, Ledger},
+    vec, Address, BytesN, Env, Error, InvokeError,
 };
 
-mod old_contract {
-    soroban_sdk::contractimport!(
-        file = "/home/ncdndjdj/stellarspend-contracts/target/wasm32v1-none/release/soroban_upgradeable_contract_old_contract.wasm"
-    );
+const DELAY: u64 = 48 * 60 * 60;
+const START: u64 = 1_000_000;
+
+fn hash(e: &Env) -> BytesN<32> {
+    BytesN::from_array(e, &[9u8; 32])
 }
 
-mod new_contract {
-    soroban_sdk::contractimport!(
-        file = "/home/ncdndjdj/stellarspend-contracts/target/wasm32v1-none/release/soroban_upgradeable_contract_new_contract.wasm"
-    );
+/// Assert that a `try_*` client call failed with the given contract error.
+fn assert_err<T: core::fmt::Debug>(
+    res: Result<T, Result<Error, InvokeError>>,
+    expected: UpgradeError,
+) {
+    match res {
+        Err(Ok(e)) => assert_eq!(e, Error::from_contract_error(expected as u32)),
+        other => std::panic!("expected contract error {:?}, got {:?}", expected, other),
+    }
 }
 
-fn install_new_wasm(e: &Env) -> BytesN<32> {
-    e.deployer().upload_contract_wasm(new_contract::WASM)
+/// Register a contract with a 2-of-3 multisig and the default timelock.
+fn setup_2of3(env: &Env) -> (Address, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(env, &id);
+
+    let s1 = Address::generate(env);
+    let s2 = Address::generate(env);
+    let s3 = Address::generate(env);
+    client.set_upgrade_signers(&vec![env, s1.clone(), s2.clone(), s3.clone()], &2);
+
+    (id, s1, s2, s3)
 }
 
-fn setup(e: &Env) -> (Address, Address) {
-    let admin = Address::generate(e);
-    let contract_id = e.register(old_contract::WASM, (&admin,));
-    (admin, contract_id)
-}
+// --- Acceptance: unauthorized upgrades rejected ---------------------------
 
-// Test 1: Upgrade authorization - only admin can upgrade
 #[test]
-#[should_panic]
-fn test_unauthorized_upgrade_fails() {
+fn test_non_signer_cannot_schedule() {
     let env = Env::default();
-    // no mock_all_auths - auth will fail
+    env.mock_all_auths();
+    let (id, _s1, _s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    let stranger = Address::generate(&env);
+    let res = client.try_schedule_upgrade(&stranger, &hash(&env), &2);
+    assert_err(res, UpgradeError::NotAuthorized);
+}
+
+#[test]
+fn test_non_signer_cannot_approve() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (id, s1, _s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    let stranger = Address::generate(&env);
+    let res = client.try_approve_upgrade(&stranger);
+    assert_err(res, UpgradeError::NotAuthorized);
+}
+
+#[test]
+fn test_non_signer_cannot_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (id, s1, _s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    let stranger = Address::generate(&env);
+    let res = client.try_execute_upgrade(&stranger);
+    assert_err(res, UpgradeError::NotAuthorized);
+}
+
+#[test]
+fn test_unauthorized_when_no_auth_provided() {
+    // Without mock_all_auths, require_auth() itself must reject the call.
+    let env = Env::default();
     let admin = Address::generate(&env);
-    let contract_id = env.register(old_contract::WASM, (&admin,));
-    let client = old_contract::Client::new(&env, &contract_id);
-    let new_wasm_hash = install_new_wasm(&env);
-    client.upgrade(&new_wasm_hash);
+    let id = env.register(UpgradeableContract, (&admin,));
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    let res = client.try_schedule_upgrade(&admin, &hash(&env), &2);
+    assert!(res.is_err());
 }
 
-// Test 2: Upgrade emits event
+// --- Acceptance: threshold (multisig) enforced ----------------------------
+
 #[test]
-fn test_upgrade_emits_event() {
+fn test_execute_rejected_below_threshold() {
     let env = Env::default();
     env.mock_all_auths();
-    let (_, contract_id) = setup(&env);
-    let client = old_contract::Client::new(&env, &contract_id);
-    let new_wasm_hash = install_new_wasm(&env);
-    client.upgrade(&new_wasm_hash);
-    let events = env.events().all();
-    assert!(!events.is_empty(), "upgrade should emit an event");
+    env.ledger().set_timestamp(START);
+    let (id, s1, _s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    // Only the proposer has approved (1 of 2 required).
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    assert_eq!(client.upgrade_approval_count(), 1);
+
+    // Even after the timelock elapses, a single approval is insufficient.
+    env.ledger().set_timestamp(START + DELAY + 1);
+    assert!(!client.is_upgrade_ready());
+    let res = client.try_execute_upgrade(&s1);
+    assert_err(res, UpgradeError::ThresholdNotMet);
 }
 
-// Test 3: State is preserved after upgrade
 #[test]
-fn test_state_preserved_after_upgrade() {
+fn test_duplicate_approval_rejected() {
     let env = Env::default();
     env.mock_all_auths();
-    let (_, contract_id) = setup(&env);
-    let client = old_contract::Client::new(&env, &contract_id);
-    assert_eq!(1, client.version());
-    let new_wasm_hash = install_new_wasm(&env);
-    client.upgrade(&new_wasm_hash);
-    // version should now be 2
-    let new_client = new_contract::Client::new(&env, &contract_id);
-    assert_eq!(2, new_client.version());
+    let (id, s1, _s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    // Proposer already auto-approved; approving again must fail.
+    let res = client.try_approve_upgrade(&s1);
+    assert_err(res, UpgradeError::AlreadyApproved);
 }
 
-// Test 4: Upgrade without handle_upgrade fails second upgrade
+// --- Acceptance: timelock enforced ----------------------------------------
+
 #[test]
-fn test_second_upgrade_fails_without_migration() {
+fn test_execute_rejected_before_timelock() {
     let env = Env::default();
     env.mock_all_auths();
-    let (_, contract_id) = setup(&env);
-    let client = old_contract::Client::new(&env, &contract_id);
-    let new_wasm_hash = install_new_wasm(&env);
-    client.upgrade(&new_wasm_hash);
-    let new_client = new_contract::Client::new(&env, &contract_id);
-    // NewAdmin key not set yet, second upgrade should fail
-    let result = new_client.try_upgrade(&new_wasm_hash);
-    assert!(
-        result.is_err(),
-        "upgrade should fail without handle_upgrade"
-    );
+    env.ledger().set_timestamp(START);
+    let (id, s1, s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    client.approve_upgrade(&s2);
+    assert_eq!(client.upgrade_approval_count(), 2);
+
+    // Threshold met but timelock not yet elapsed.
+    assert!(!client.is_upgrade_ready());
+    let res = client.try_execute_upgrade(&s1);
+    assert_err(res, UpgradeError::TimelockNotElapsed);
+
+    // One second before the deadline is still too early.
+    env.ledger().set_timestamp(START + DELAY - 1);
+    let res = client.try_execute_upgrade(&s1);
+    assert_err(res, UpgradeError::TimelockNotElapsed);
 }
 
-// Test 5: handle_upgrade properly migrates state
 #[test]
-fn test_handle_upgrade_migrates_state() {
+fn test_ready_only_when_threshold_and_timelock_satisfied() {
     let env = Env::default();
     env.mock_all_auths();
-    let (_, contract_id) = setup(&env);
-    let client = old_contract::Client::new(&env, &contract_id);
-    let new_wasm_hash = install_new_wasm(&env);
-    client.upgrade(&new_wasm_hash);
-    let new_client = new_contract::Client::new(&env, &contract_id);
-    new_client.handle_upgrade();
-    // after migration, upgrade should succeed
-    let result = new_client.try_upgrade(&new_wasm_hash);
-    assert!(
-        result.is_ok(),
-        "upgrade should succeed after handle_upgrade"
-    );
+    env.ledger().set_timestamp(START);
+    let (id, s1, s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    assert!(!client.is_upgrade_ready()); // 1 approval, timelock pending
+
+    client.approve_upgrade(&s2);
+    assert!(!client.is_upgrade_ready()); // threshold met, timelock pending
+
+    env.ledger().set_timestamp(START + DELAY);
+    // Both conditions satisfied: the upgrade would now be allowed to execute.
+    assert!(client.is_upgrade_ready());
+
+    let pending = client.get_pending_upgrade().unwrap();
+    assert_eq!(pending.new_version, 2);
+    assert_eq!(pending.execute_at, START + DELAY);
+    assert_eq!(pending.approvals.len(), 2);
+}
+
+#[test]
+fn test_zero_delay_still_requires_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(START);
+    let (id, s1, _s2, _s3) = setup_2of3(&env);
+    let client = UpgradeableContractClient::new(&env, &id);
+
+    // Admin can shorten the timelock, but multisig is still enforced.
+    client.set_timelock_delay(&0);
+    client.schedule_upgrade(&s1, &hash(&env), &2);
+    assert!(!client.is_upgrade_ready()); // only 1 of 2 approvals
+
+    let res = client.try_execute_upgrade(&s1);
+    assert_err(res, UpgradeError::ThresholdNotMet);
 }

--- a/contracts/rate_limit.rs
+++ b/contracts/rate_limit.rs
@@ -1,6 +1,6 @@
 //! Rate limit logic for wallet transaction frequency.
 
-use soroban_sdk::{contract, contractimpl, contracterror, contracttype, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
 
 const DEFAULT_LIMIT: u32 = 5; // Default max transactions per window
 const DEFAULT_WINDOW_SECONDS: u64 = 3600; // 1 hour window
@@ -38,7 +38,7 @@ impl Default for RateLimitConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
     Config,
-    RateLimitCount(Address, u64),  // (wallet, window_start)
+    RateLimitCount(Address, u64), // (wallet, window_start)
 }
 
 #[contract]
@@ -62,13 +62,15 @@ impl RateLimitContract {
         let count: u32 = env.storage().persistent().get(&key).unwrap_or(0);
 
         if count >= config.max_tx {
-            env.events().publish(("rate_limit_exceeded", wallet.clone()), count);
+            env.events()
+                .publish(("rate_limit_exceeded", wallet.clone()), count);
             return Err(RateLimitError::Exceeded);
         }
 
         if count >= config.warn_threshold {
             // Emit warning event; if overspend is allowed we still record the tx.
-            env.events().publish(("rate_limit_warning", wallet.clone()), count);
+            env.events()
+                .publish(("rate_limit_warning", wallet.clone()), count);
             if !config.allow_overspend {
                 return Err(RateLimitError::SoftLimitReached);
             }
@@ -96,6 +98,7 @@ impl RateLimitContract {
             allow_overspend,
         };
         env.storage().persistent().set(&DataKey::Config, &cfg);
-        env.events().publish(("rate_limit_config", caller), cfg.max_tx);
+        env.events()
+            .publish(("rate_limit_config", caller), cfg.max_tx);
     }
 }

--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -606,10 +606,9 @@ impl SavingsGoalsContract {
             .instance()
             .get(&DataKey::TotalGoalsCreated)
             .unwrap_or(0);
-        env.storage().instance().set(
-            &DataKey::TotalGoalsCreated,
-            &(total_goals + 1),
-        );
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalGoalsCreated, &(total_goals + 1));
 
         // Emit creation event (reusing batch 0 for manual creation)
         GoalEvents::goal_created(&env, 0, &new_goal);

--- a/contracts/shared-budgets/src/test.rs
+++ b/contracts/shared-budgets/src/test.rs
@@ -141,7 +141,13 @@ fn test_contribution_with_memo() {
     let creator = Address::generate(&env);
     let contributor = Address::generate(&env);
     let budget_name = Symbol::new(&env, "memo_budget");
-    let budget_id = client.create_budget(&creator, &budget_name, &Vec::new(&env), &token, &Vec::new(&env));
+    let budget_id = client.create_budget(
+        &creator,
+        &budget_name,
+        &Vec::new(&env),
+        &token,
+        &Vec::new(&env),
+    );
 
     let amount = 100_000_000;
     let memo = Some(Symbol::new(&env, "lunch_contribution"));
@@ -359,8 +365,7 @@ fn test_transfer_budget_ownership() {
 
     let budget_name = Symbol::new(&env, "transfer_budget");
     let spending_rules: Vec<BudgetSpendingRule> = Vec::new(&env);
-    let budget_id =
-        client.create_budget(&creator, &budget_name, &members, &token, &spending_rules);
+    let budget_id = client.create_budget(&creator, &budget_name, &members, &token, &spending_rules);
 
     client.transfer_budget_ownership(&creator, &budget_id, &new_owner);
 
@@ -389,8 +394,7 @@ fn test_previous_owner_cannot_manage_budget_after_transfer() {
 
     let budget_name = Symbol::new(&env, "post_transfer_budget");
     let spending_rules: Vec<BudgetSpendingRule> = Vec::new(&env);
-    let budget_id =
-        client.create_budget(&creator, &budget_name, &members, &token, &spending_rules);
+    let budget_id = client.create_budget(&creator, &budget_name, &members, &token, &spending_rules);
 
     client.transfer_budget_ownership(&creator, &budget_id, &new_owner);
 

--- a/contracts/shared-budgets/src/types.rs
+++ b/contracts/shared-budgets/src/types.rs
@@ -110,7 +110,8 @@ impl SharedBudgetEvents {
         memo: Option<Symbol>,
     ) {
         let topics = (symbol_short!("budget"), symbol_short!("contrib"), budget_id);
-        env.events().publish(topics, (contributor.clone(), amount, memo));
+        env.events()
+            .publish(topics, (contributor.clone(), amount, memo));
     }
 
     /// Event emitted when an allocation fails for a recipient.
@@ -172,7 +173,11 @@ impl SharedBudgetEvents {
         previous_owner: &Address,
         new_owner: &Address,
     ) {
-        let topics = (symbol_short!("budget"), symbol_short!("xfer_own"), budget_id);
+        let topics = (
+            symbol_short!("budget"),
+            symbol_short!("xfer_own"),
+            budget_id,
+        );
         env.events()
             .publish(topics, (previous_owner.clone(), new_owner.clone()));
     }

--- a/contracts/spending-limits/src/lib.rs
+++ b/contracts/spending-limits/src/lib.rs
@@ -457,7 +457,9 @@ impl SpendingLimitsContract {
         {
             let old_limit = limit.monthly_limit;
             let increment = limit.monthly_limit / 10;
-            let proposed_limit = old_limit.checked_add(increment).unwrap_or(crate::types::MAX_SPENDING_LIMIT);
+            let proposed_limit = old_limit
+                .checked_add(increment)
+                .unwrap_or(crate::types::MAX_SPENDING_LIMIT);
 
             limit.monthly_limit = if proposed_limit > crate::types::MAX_SPENDING_LIMIT {
                 crate::types::MAX_SPENDING_LIMIT

--- a/contracts/transactions/src/utils.rs
+++ b/contracts/transactions/src/utils.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, String, Symbol};
 use soroban_sdk::string::ToString;
+use soroban_sdk::{Env, String, Symbol};
 
 /// Generate a unique transaction ID
 pub fn generate_transaction_id(env: &Env) -> Symbol {

--- a/tests/rate_limit_tests.rs
+++ b/tests/rate_limit_tests.rs
@@ -2,7 +2,10 @@
 
 #![cfg(test)]
 
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
 
 #[path = "../contracts/rate_limit.rs"]
 mod rate_limit;
@@ -20,7 +23,7 @@ fn setup_env() -> (Env, Address) {
 fn test_within_limit() {
     let (env, contract_id) = setup_env();
     let wallet = Address::generate(&env);
-    
+
     env.as_contract(&contract_id, || {
         for _ in 0..5 {
             let result = RateLimitContract::check_and_record(env.clone(), wallet.clone());
@@ -33,7 +36,7 @@ fn test_within_limit() {
 fn test_exceed_limit() {
     let (env, contract_id) = setup_env();
     let wallet = Address::generate(&env);
-    
+
     env.as_contract(&contract_id, || {
         for _ in 0..5 {
             let result = RateLimitContract::check_and_record(env.clone(), wallet.clone());
@@ -48,7 +51,7 @@ fn test_exceed_limit() {
 fn test_new_window_resets_limit() {
     let (env, contract_id) = setup_env();
     let wallet = Address::generate(&env);
-    
+
     env.as_contract(&contract_id, || {
         for _ in 0..5 {
             let result = RateLimitContract::check_and_record(env.clone(), wallet.clone());
@@ -66,7 +69,7 @@ fn test_multiple_wallets_independent_limits() {
     let (env, contract_id) = setup_env();
     let wallet1 = Address::generate(&env);
     let wallet2 = Address::generate(&env);
-    
+
     env.as_contract(&contract_id, || {
         for _ in 0..5 {
             assert!(RateLimitContract::check_and_record(env.clone(), wallet1.clone()).is_ok());


### PR DESCRIPTION
This pr replaces the one-shot upgrade with a guarded propose → approve → execute lifecycle, gated by an admin multisig and a timelock:

set_upgrade_signers(signers, threshold) — admin-only; configures an N-of-M signer set (validates non-empty, no duplicates, 1 ≤ threshold ≤ len). Defaults to the admin as sole signer.
set_timelock_delay(delay) — admin-only; default 48h.
schedule_upgrade(signer, wasm_hash, version) — signer-only; records a pending proposal, auto-approves for the proposer, and sets execute_at = now + delay.
approve_upgrade(signer) — collects distinct signer approvals; duplicates rejected.
execute_upgrade(signer) — performs the Wasm swap only when approvals ≥ threshold and the timelock has elapsed.
cancel_upgrade(signer) — clears a pending proposal.
View helpers: get_signers, get_threshold, get_timelock_delay, get_pending_upgrade, upgrade_approval_count, is_upgrade_ready.
The v2 (new_contract) mirrors the same logic and migrates the multisig/timelock config in handle_upgrade, so protection persists across upgrades.

Acceptance criteria
✅ Unauthorized upgrades rejected — non-signers cannot schedule/approve/execute, and the approval threshold is enforced.
✅ Timelock enforced — execution before execute_at is rejected.
Testing
cargo test (18/18 pass), cargo clippy --all-targets -- -D warnings (clean), and cargo fmt --check (clean) for both packages. Tests cover authorization rejection, threshold enforcement, timelock enforcement, downgrade rejection, cancellation, and reconfiguration.

closes #481 

