### PR TITLE
Add metadata key-value fields to transactions

### DIFF
--- a/contracts/transactions/src/lib.rs
+++ b/contracts/transactions/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
-    Env, String, Symbol, Vec,
+    Env, Map, String, Symbol, Vec,
 };
 
 mod storage;
@@ -10,10 +10,10 @@ mod utils;
 
 pub use storage::{
     clear_user_transactions, create_transaction, get_all_transactions, get_last_transaction,
-    get_total_transactions_count, get_transaction, get_transaction_memo, get_transaction_timestamp,
-    get_transactions_paginated, get_user_transactions, get_user_transactions_filtered,
-    is_transaction_owner, transaction_exists, update_transaction_status, Transaction,
-    TransactionStatus,
+    get_total_transactions_count, get_transaction, get_transaction_memo, get_transaction_metadata,
+    get_transaction_timestamp, get_transactions_paginated, get_user_transactions,
+    get_user_transactions_filtered, is_transaction_owner, set_transaction_metadata,
+    transaction_exists, update_transaction_status, Transaction, TransactionStatus,
 };
 
 #[cfg(test)]
@@ -71,6 +71,7 @@ impl TransactionsContract {
         tags: Vec<String>,
         tx_type: Symbol,
         is_public: bool,
+        metadata: Map<Symbol, String>,
     ) -> Symbol {
         from.require_auth();
 
@@ -101,6 +102,7 @@ impl TransactionsContract {
             tags,
             tx_type,
             is_public,
+            metadata,
         );
 
         env.events().publish(
@@ -115,6 +117,35 @@ impl TransactionsContract {
         );
 
         transaction.id
+    }
+
+    /// Set (replace) the metadata key-value pairs for an existing transaction.
+    /// Only the transaction owner can update metadata.
+    pub fn set_metadata(
+        env: Env,
+        id: Symbol,
+        caller: Address,
+        metadata: Map<Symbol, String>,
+    ) -> bool {
+        caller.require_auth();
+
+        if !transaction_exists(&env, id.clone()) {
+            panic_with_error!(&env, TransactionError::TransactionNotFound);
+        }
+
+        let success = storage::set_transaction_metadata(&env, id.clone(), caller, metadata);
+
+        if success {
+            env.events()
+                .publish((symbol_short!("tx"), symbol_short!("meta_set")), id);
+        }
+
+        success
+    }
+
+    /// Get the metadata key-value pairs for a transaction.
+    pub fn get_metadata(env: Env, id: Symbol) -> Option<Map<Symbol, String>> {
+        storage::get_transaction_metadata(&env, id)
     }
 
     /// Update the note attached to a transaction (only transaction owner can update)

--- a/contracts/transactions/src/storage.rs
+++ b/contracts/transactions/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::TransactionError;
-use soroban_sdk::{contracttype, panic_with_error, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{contracttype, panic_with_error, Address, Env, Map, String, Symbol, Vec};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
@@ -28,6 +28,7 @@ pub struct Transaction {
     pub status: TransactionStatus,
     pub tx_type: Symbol,
     pub is_public: bool,
+    pub metadata: Map<Symbol, String>,
 }
 
 #[derive(Clone)]
@@ -56,6 +57,7 @@ pub fn create_transaction(
     tags: Vec<String>,
     tx_type: Symbol,
     is_public: bool,
+    metadata: Map<Symbol, String>,
 ) -> Transaction {
     let tx_id = crate::utils::generate_transaction_id(env);
 
@@ -81,6 +83,7 @@ pub fn create_transaction(
         status: TransactionStatus::Completed,
         tx_type,
         is_public,
+        metadata,
     };
 
     // Store the transaction
@@ -383,6 +386,39 @@ pub fn delete_transaction(env: &Env, id: Symbol) -> bool {
 /// Get transaction memo
 pub fn get_transaction_memo(env: &Env, id: Symbol) -> Option<String> {
     get_transaction(env, id).map(|tx| tx.memo)
+}
+
+/// Set metadata key-value pairs for a transaction (only owner can update).
+pub fn set_transaction_metadata(
+    env: &Env,
+    id: Symbol,
+    caller: Address,
+    metadata: Map<Symbol, String>,
+) -> bool {
+    let mut transaction: Transaction = match env
+        .storage()
+        .persistent()
+        .get(&DataKey::Transaction(id.clone()))
+    {
+        Some(tx) => tx,
+        None => return false,
+    };
+
+    if transaction.from != caller {
+        return false;
+    }
+
+    transaction.metadata = metadata;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Transaction(id), &transaction);
+
+    true
+}
+
+/// Get metadata key-value pairs for a transaction.
+pub fn get_transaction_metadata(env: &Env, id: Symbol) -> Option<Map<Symbol, String>> {
+    get_transaction(env, id).map(|tx| tx.metadata)
 }
 
 /// Get all transactions in the contract

--- a/contracts/transactions/src/test.rs
+++ b/contracts/transactions/src/test.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, Env, String, Symbol, Vec,
+    Address, Env, Map, String, Symbol, Vec,
 };
 
 #[test]
@@ -52,7 +52,7 @@ fn test_create_transaction() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
 
     let transaction = client.get_transaction(&tx_id).unwrap();
@@ -104,7 +104,7 @@ fn test_create_transaction_invalid_amount_zero() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 }
 
@@ -135,7 +135,7 @@ fn test_create_transaction_invalid_amount_negative() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 }
 
@@ -166,7 +166,7 @@ fn test_update_transaction_note() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 
     let transaction = client.get_transaction(&tx_id).unwrap();
@@ -199,7 +199,7 @@ fn test_update_transaction_amount() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
 
     let success = client.update_transaction_amount(&tx_id, &from, &updated_amount);
@@ -254,7 +254,7 @@ fn test_get_transaction_timestamp() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
 
     let timestamp = client.get_transaction_timestamp(&tx_id);
@@ -291,7 +291,7 @@ fn test_get_user_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     client.create_transaction(
         &user1,
@@ -301,7 +301,7 @@ fn test_get_user_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     client.create_transaction(
         &user2,
@@ -311,7 +311,7 @@ fn test_get_user_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 
     let user1_txs = client.get_user_transactions(&user1);
@@ -349,7 +349,7 @@ fn test_clear_user_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     let tx2_id = client.create_transaction(
         &user,
@@ -359,7 +359,7 @@ fn test_clear_user_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 
     let user_txs = client.get_user_transactions(&user);
@@ -401,7 +401,7 @@ fn test_transaction_counter_increments() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     let tx2_id = client.create_transaction(
         &from,
@@ -411,7 +411,7 @@ fn test_transaction_counter_increments() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     let tx3_id = client.create_transaction(
         &from,
@@ -421,7 +421,7 @@ fn test_transaction_counter_increments() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 
     assert_ne!(tx1_id, tx2_id);
@@ -452,7 +452,7 @@ fn test_transaction_exists() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
 
     assert!(client.transaction_exists(&tx_id));
@@ -487,7 +487,7 @@ fn test_create_transaction_stores_creation_timestamp() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 
     let tx = client.get_transaction(&tx_id).unwrap();
@@ -517,7 +517,7 @@ fn test_get_transaction_memo() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
 
     // Test get_transaction_memo function
@@ -560,7 +560,7 @@ fn test_delete_transaction_admin_can_remove_record() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
     assert!(client.transaction_exists(&tx_id));
 
@@ -591,7 +591,7 @@ fn test_delete_transaction_rejects_non_admin() {
     let is_public = false;
 
     let tx_id = client.create_transaction(
-        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public,
+        &from, &to, &amount, &note, &memo, &tags, &tx_type, &is_public, &Map::new(&env),
     );
 
     let caller = Address::generate(&env);
@@ -624,7 +624,7 @@ fn test_get_all_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     let tx2_id = client.create_transaction(
         &user2,
@@ -634,7 +634,7 @@ fn test_get_all_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
     let tx3_id = client.create_transaction(
         &user1,
@@ -644,7 +644,7 @@ fn test_get_all_transactions() {
         &memo,
         &tags,
         &tx_type,
-        &is_public,
+        &is_public, &Map::new(&env),
     );
 
     let all_txs = client.get_all_transactions();
@@ -722,7 +722,7 @@ fn test_get_transactions_paginated_offset_and_limit() {
             &memo,
             &tags,
             &tx_type,
-            &is_public,
+            &is_public, &Map::new(&env),
         );
     }
 
@@ -906,4 +906,118 @@ fn test_get_total_expense() {
 
     // Only expense amounts should be summed
     assert_eq!(client.get_total_expense(), 80);
+}
+
+#[test]
+fn test_create_transaction_with_metadata() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let tags = Vec::new(&env);
+    let tx_type = Symbol::new(&env, "transfer");
+
+    let mut metadata = Map::new(&env);
+    metadata.set(Symbol::new(&env, "category"), String::from_str(&env, "food"));
+    metadata.set(Symbol::new(&env, "ref"), String::from_str(&env, "INV-001"));
+
+    let tx_id = client.create_transaction(
+        &from,
+        &to,
+        &500,
+        &String::from_str(&env, "note"),
+        &String::from_str(&env, "memo"),
+        &tags,
+        &tx_type,
+        &false,
+        &metadata,
+    );
+
+    let tx = client.get_transaction(&tx_id).unwrap();
+    assert_eq!(tx.metadata.get(Symbol::new(&env, "category")), Some(String::from_str(&env, "food")));
+    assert_eq!(tx.metadata.get(Symbol::new(&env, "ref")), Some(String::from_str(&env, "INV-001")));
+}
+
+#[test]
+fn test_set_and_get_metadata() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let tags = Vec::new(&env);
+    let tx_type = Symbol::new(&env, "transfer");
+
+    let tx_id = client.create_transaction(
+        &from,
+        &to,
+        &100,
+        &String::from_str(&env, "note"),
+        &String::from_str(&env, "memo"),
+        &tags,
+        &tx_type,
+        &false,
+        &Map::new(&env),
+    );
+
+    let mut metadata = Map::new(&env);
+    metadata.set(Symbol::new(&env, "source"), String::from_str(&env, "mobile"));
+
+    let success = client.set_metadata(&tx_id, &from, &metadata);
+    assert!(success);
+
+    let retrieved = client.get_metadata(&tx_id).unwrap();
+    assert_eq!(retrieved.get(Symbol::new(&env, "source")), Some(String::from_str(&env, "mobile")));
+}
+
+#[test]
+fn test_set_metadata_non_owner_fails() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+    let tags = Vec::new(&env);
+    let tx_type = Symbol::new(&env, "transfer");
+
+    let tx_id = client.create_transaction(
+        &from,
+        &to,
+        &100,
+        &String::from_str(&env, "note"),
+        &String::from_str(&env, "memo"),
+        &tags,
+        &tx_type,
+        &false,
+        &Map::new(&env),
+    );
+
+    let stranger = Address::generate(&env);
+    let mut metadata = Map::new(&env);
+    metadata.set(Symbol::new(&env, "key"), String::from_str(&env, "val"));
+
+    let success = client.set_metadata(&tx_id, &stranger, &metadata);
+    assert!(!success);
+}
+
+#[test]
+fn test_get_metadata_nonexistent_returns_none() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TransactionsContract, ());
+    let client = TransactionsContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let fake_id = Symbol::new(&env, "ghost");
+    assert!(client.get_metadata(&fake_id).is_none());
 }


### PR DESCRIPTION
 Add metadata key-value fields to transactions
  
  Transactions lacked contextual information beyond fixed fields. This adds
  support for custom key-value metadata on any transaction.
  
  Changes
  
  - Added metadata: Map<Symbol, String> field to the Transaction struct
  - create_transaction now accepts an initial metadata map
  - New set_metadata(id, caller, metadata) — owner-only update, emits meta_set
   event
  - New get_metadata(id) — returns the stored metadata map
  - All existing tests updated; 4 new metadata-specific tests added
  
  Testing
  
  - test_create_transaction_with_metadata — metadata stored at creation is
  retrievable
  - test_set_and_get_metadata — owner can update and retrieve metadata
  post-creation
  - test_set_metadata_non_owner_fails — non-owner update returns false
  - test_get_metadata_nonexistent_returns_none — missing tx returns None
closes #601
