### PR TITLE
feat: add goal expiration functionality

### DIFF
--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -62,6 +62,8 @@ pub enum SavingsGoalError {
     GoalNotFound = 10,
     /// Goal is locked against withdrawals
     GoalLocked = 11,
+    /// Goal has expired
+    GoalExpired = 12,
 }
 
 impl From<SavingsGoalError> for soroban_sdk::Error {
@@ -342,11 +344,15 @@ impl SavingsGoalsContract {
                     // Validation succeeded - create the goal
                     goal_id_counter += 1;
 
-                    let mut goal = SavingsGoal {
                     let is_complete = request.initial_contribution >= request.target_amount;
                     let created_at = env.ledger().timestamp();
                     let unlock_at = if request.lock_duration_seconds > 0 {
                         created_at.saturating_add(request.lock_duration_seconds)
+                    } else {
+                        0
+                    };
+                    let expires_at = if request.expiration_seconds > 0 {
+                        created_at.saturating_add(request.expiration_seconds)
                     } else {
                         0
                     };
@@ -362,6 +368,7 @@ impl SavingsGoalsContract {
                         is_complete: false,
                         is_complete,
                         unlock_at,
+                        expires_at,
                     };
 
                     // Accumulate metrics
@@ -508,6 +515,18 @@ impl SavingsGoalsContract {
         if goal.user != caller {
             panic_with_error!(&env, SavingsGoalError::Unauthorized);
         }
+
+        // Check if goal has expired
+        let current_time = env.ledger().timestamp();
+        if goal.expires_at > 0 && current_time >= goal.expires_at {
+            // Mark goal as inactive
+            goal.is_active = false;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Goal(goal_id), &goal);
+            panic_with_error!(&env, SavingsGoalError::GoalExpired);
+        }
+
         if !goal.is_active {
             panic_with_error!(&env, SavingsGoalError::GoalNotActive);
         }
@@ -569,6 +588,18 @@ impl SavingsGoalsContract {
             0
         };
 
+        // Inherit expiration duration if it was originally set
+        let expiration_duration = if existing_goal.expires_at > existing_goal.created_at {
+            existing_goal.expires_at - existing_goal.created_at
+        } else {
+            0
+        };
+        let expires_at = if expiration_duration > 0 {
+            created_at.saturating_add(expiration_duration)
+        } else {
+            0
+        };
+
         let new_goal = SavingsGoal {
             goal_id: goal_id_counter,
             user: caller.clone(),
@@ -580,6 +611,7 @@ impl SavingsGoalsContract {
             is_active: true,
             is_complete: false,
             unlock_at,
+            expires_at,
         };
 
         // Store the goal

--- a/contracts/savings-goals/src/test.rs
+++ b/contracts/savings-goals/src/test.rs
@@ -38,6 +38,7 @@ fn create_valid_request(
         deadline: current_ledger + 1000,
         initial_contribution: amount / 10, // 10% initial contribution
         lock_duration_seconds: 0,
+        expiration_seconds: 0,
     }
 }
 
@@ -74,6 +75,7 @@ fn test_auto_milestone_events() {
         deadline: env.ledger().sequence() as u64 + 1000,
         initial_contribution: 25_000_000,
         lock_duration_seconds: 0,
+        expiration_seconds: 0,
     });
     let result = client.batch_set_savings_goals(&admin, &requests);
     assert_eq!(result.successful, 1);
@@ -958,6 +960,7 @@ fn test_locked_goal_rejects_withdrawal() {
         deadline: env.ledger().sequence() as u64 + 1000,
         initial_contribution: 50_000_000,
         lock_duration_seconds: 86_400,
+        expiration_seconds: 0,
     });
     client.batch_set_savings_goals(&admin, &requests);
 
@@ -982,6 +985,7 @@ fn test_unlocked_goal_allows_withdrawal() {
         deadline: env.ledger().sequence() as u64 + 1000,
         initial_contribution: 50_000_000,
         lock_duration_seconds: 0,
+        expiration_seconds: 0,
     });
     client.batch_set_savings_goals(&admin, &requests);
 
@@ -1003,6 +1007,7 @@ fn test_withdrawal_allowed_after_lock_expires() {
         deadline: env.ledger().sequence() as u64 + 1000,
         initial_contribution: 50_000_000,
         lock_duration_seconds: 3_600,
+        expiration_seconds: 0,
     });
     client.batch_set_savings_goals(&admin, &requests);
 
@@ -1051,6 +1056,7 @@ fn test_contribute_emits_milestone_events() {
         deadline: env.ledger().sequence() as u64 + 1000,
         initial_contribution: 0,
         lock_duration_seconds: 0,
+        expiration_seconds: 0,
     });
     client.batch_set_savings_goals(&admin, &requests);
 
@@ -1080,6 +1086,7 @@ fn test_clone_savings_goal() {
         deadline: env.ledger().sequence() as u64 + 1000,
         initial_contribution: 50_000_000,
         lock_duration_seconds: 3600,
+        expiration_seconds: 0,
     });
     client.batch_set_savings_goals(&admin, &requests);
 

--- a/contracts/savings-goals/src/types.rs
+++ b/contracts/savings-goals/src/types.rs
@@ -27,6 +27,8 @@ pub struct SavingsGoalRequest {
     pub initial_contribution: i128,
     /// Optional lock duration in seconds (0 = no lock, withdrawals allowed immediately)
     pub lock_duration_seconds: u64,
+    /// Expiration duration in seconds (0 = no expiration)
+    pub expiration_seconds: u64,
 }
 
 /// Represents a created savings goal.
@@ -53,6 +55,8 @@ pub struct SavingsGoal {
     pub is_complete: bool,
     /// Timestamp after which withdrawals are allowed (0 = no lock)
     pub unlock_at: u64,
+    /// Timestamp after which the goal expires (0 = no expiration)
+    pub expires_at: u64,
 }
 
 /// Represents progress information for a savings goal.


### PR DESCRIPTION
Closes #531

---

- Add expires_at field to SavingsGoal struct to track expiration timestamps
- Add expiration_seconds field to SavingsGoalRequest for setting expiration duration
- Add GoalExpired error code (12) to SavingsGoalError enum
- Update batch_set_savings_goals to calculate and set expires_at timestamp
- Update contribute_to_goal to check goal expiration and reject contributions to expired goals
- Mark expired goals as inactive when expiration is detected
- Update clone_savings_goal to inherit and apply expiration duration
- Update all test cases to include expiration_seconds field

Acceptance Criteria:
- Expired goals reject contributions (error: GoalExpired)
- Goals are marked inactive when they expire
- Expiration timestamps are properly calculated during goal creation