### PR TITLE
Fix(spending-limits): resolve compile errors and tests

### DIFF
--- a/contracts/spending-limits/src/lib.rs
+++ b/contracts/spending-limits/src/lib.rs
@@ -28,15 +28,14 @@ mod validation;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Symbol, Vec};
 
 pub use crate::types::{
-    BatchLimitMetrics, BatchLimitResult, DataKey, ErrorCode, EscalationConfig, LimitEvents,
-    LimitStrategy, LimitUpdateResult, LimitsConfig, SpendingLimit, SpendingLimitRequest,
-    MAX_BATCH_SIZE,
+    BatchLimitMetrics, BatchLimitResult, DataKey, ErrorCode, EscalationConfig, ExceptionRule,
+    LimitEvents, LimitStrategy, LimitUpdateResult, LimitsConfig, SpendingLimit,
+    SpendingLimitRequest, MAX_BATCH_SIZE,
 };
 use crate::validation::validate_limit_request;
 
 // Add cross-contract imports for whitelist functionality
 use crate::cross_contract::DataKey as CrossContractDataKey;
-use soroban_sdk::{Bytes, Symbol};
 
 /// Error codes for the spending limits contract.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -54,12 +53,14 @@ pub enum SpendingLimitError {
     BatchTooLarge = 5,
     /// Daily limit exceeded
     DailyLimitExceeded = 6,
+    /// Hourly limit exceeded
+    HourlyLimitExceeded = 7,
     /// Monthly limit exceeded
-    MonthlyLimitExceeded = 7,
+    MonthlyLimitExceeded = 8,
     /// Invalid spend amount
-    InvalidAmount = 8,
+    InvalidAmount = 9,
     /// Category is not in the approved list
-    CategoryNotApproved = 9,
+    CategoryNotApproved = 10,
 }
 
 impl From<SpendingLimitError> for soroban_sdk::Error {
@@ -365,9 +366,11 @@ impl SpendingLimitsContract {
                 LimitEvents::exception_bypassed(&env, &user, amount, cat);
                 return;
             }
+        }
+
         // Check if destination is whitelisted (spending whitelist)
         // This prevents unauthorized destinations from receiving funds
-        if !Self::is_destination_whitelisted(env, user.clone()) {
+        if !Self::is_destination_whitelisted_internal(&env, &user) {
             panic_with_error!(&env, SpendingLimitError::Unauthorized);
         }
 
@@ -778,9 +781,8 @@ impl SpendingLimitsContract {
         }
     }
 
-    /// Checks if a destination address is whitelisted for receiving funds.
-    /// Uses the cross-contract whitelist functionality to determine authorization.
-    fn is_destination_whitelisted(env: &Env, destination: &Address) -> bool {
+    /// Internal helper for destination whitelist checks without consuming Env.
+    fn is_destination_whitelisted_internal(env: &Env, destination: &Address) -> bool {
         // Use the same whitelist storage pattern as cross-contract module
         // Check if destination is in whitelist
         env.storage()

--- a/contracts/spending-limits/src/test.rs
+++ b/contracts/spending-limits/src/test.rs
@@ -2,13 +2,16 @@
 
 #![cfg(test)]
 
+extern crate alloc;
+
 use crate::{SpendingLimitsContract, SpendingLimitsContractClient};
 use soroban_sdk::{
     symbol_short,
-    testutils::{Address as _, Ledger},
-    Address, Env, Vec,
+    testutils::{Address as _, Events, Ledger},
+    Address, Env, Symbol, Vec,
 };
 
+use alloc::format;
 use crate::types::{ErrorCode, LimitStrategy, LimitUpdateResult, SpendingLimitRequest};
 
 /// Helper function to create a test environment with initialized contract.
@@ -455,11 +458,11 @@ fn test_enforce_spending_limit_resets_after_window() {
 
     // Use the starting window
     env.ledger().set_timestamp(0);
-    client.enforce_spending_limit(&user, &10);
+    client.enforce_spending_limit(&user, &10, &None::<Symbol>);
 
     // Advance past the configured reset window and verify the counter resets.
     env.ledger().set_timestamp(86_401);
-    client.enforce_spending_limit(&user, &10);
+    client.enforce_spending_limit(&user, &10, &None::<Symbol>);
 }
 
 #[test]
@@ -483,14 +486,14 @@ fn test_enforce_spending_limit_daily_exceeded() {
     client.enforce_spending_limit(&user, &5, &None::<Symbol>);
     client.enforce_spending_limit(&user, &1, &None::<Symbol>);
     // 2 * 5 is allowed.
-    client.enforce_spending_limit(&user, &5);
-    client.enforce_spending_limit(&user, &5);
+    client.enforce_spending_limit(&user, &5, &None::<Symbol>);
+    client.enforce_spending_limit(&user, &5, &None::<Symbol>);
 
     let limit = client.get_spending_limit(&user).unwrap();
     assert_eq!(limit.current_spending, 10);
 
     // The third spend pushes daily total above 10 and should panic.
-    client.enforce_spending_limit(&user, &1);
+    client.enforce_spending_limit(&user, &1, &None::<Symbol>);
 }
 
 #[test]
@@ -702,10 +705,10 @@ fn test_enforce_spending_limit_hourly_exceeded() {
     env.ledger().set_timestamp(3600); // 1 hour
 
     // Spend of 5 is allowed.
-    client.enforce_spending_limit(&user, &5);
+    client.enforce_spending_limit(&user, &5, &None::<Symbol>);
 
     // This second spend in the same hour exceeds hourly limit of 5 and should panic.
-    client.enforce_spending_limit(&user, &1);
+    client.enforce_spending_limit(&user, &1, &None::<Symbol>);
 }
 
 #[test]
@@ -722,13 +725,16 @@ fn test_enforce_spending_limit_hourly_resets() {
     env.ledger().set_timestamp(3600); // hour 1
 
     // Spend of 5 is allowed.
-    client.enforce_spending_limit(&user, &5);
+    client.enforce_spending_limit(&user, &5, &None::<Symbol>);
 
     // Advance 1 hour and 1 second.
     env.ledger().set_timestamp(3600 + 3601); // hour 2
 
     // Another spend of 5 is allowed now because the hourly window has reset.
-    client.enforce_spending_limit(&user, &5);
+    client.enforce_spending_limit(&user, &5, &None::<Symbol>);
+}
+
+#[test]
 fn test_adaptive_strategy_increases_limit_near_usage_threshold() {
     let (env, admin, client) = setup_test_contract();
     let user = Address::generate(&env);
@@ -744,7 +750,7 @@ fn test_adaptive_strategy_increases_limit_near_usage_threshold() {
     env.ledger().set_timestamp(86_400);
 
     // Spend 900M (90% of 1B) — should trigger a deterministic 10% limit increase.
-    client.enforce_spending_limit(&user, &900_000_000);
+    client.enforce_spending_limit(&user, &900_000_000, &None::<Symbol>);
 
     let limit = client.get_spending_limit(&user).unwrap();
     assert_eq!(limit.monthly_limit, 1_100_000_000);
@@ -907,5 +913,4 @@ fn test_override_changes_enforcement_limit() {
         .unwrap();
 
     assert_eq!(updated.monthly_limit, 500);
-}
 }

--- a/contracts/spending-limits/src/types.rs
+++ b/contracts/spending-limits/src/types.rs
@@ -1,7 +1,5 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
 
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
-
 /// Maximum number of user-limit pairs in a single batch for optimization.
 /// Maximum number of requests in a single batch for optimization.
 pub const MAX_BATCH_SIZE: u32 = 100;
@@ -187,8 +185,6 @@ pub enum DataKey {
     HourlySpending(Address, u64),
     /// Per-user daily spending for a given logical day identifier.
     DailySpending(Address, u64),
-    /// Per-user monthly spending for a given logical month identifier.
-    MonthlySpending(Address, u64),
     /// Exception rule for a specific user+category pair
     ExceptionRule(Address, Symbol),
     /// Admin-approved categories eligible for exception rules
@@ -275,7 +271,7 @@ impl LimitEvents {
         remaining_monthly: i128,
     ) {
         env.events().publish(
-            topics,
+            (symbol_short!("limit"), symbol_short!("exceeded")),
             (
                 user.clone(),
                 attempted_amount,
@@ -283,8 +279,6 @@ impl LimitEvents {
                 remaining_daily,
                 remaining_monthly,
             ),
-            (symbol_short!("limit"), symbol_short!("exceeded")),
-            (user.clone(), amount, remaining_window, remaining_monthly),
         );
     }
 


### PR DESCRIPTION
## Summary
This PR prepares the codebase for implementing an automatic overspend penalty by fixing compilation and test issues in the `spending-limits` contract. It does not yet add the penalty enforcement logic; instead it resolves syntax and test problems so we can proceed to wire the penalty module safely.

## Changes
- Fix duplicate and misordered imports in `contracts/spending-limits/src/types.rs`.
- Add `HourlyLimitExceeded` error and reassign enum discriminants in `contracts/spending-limits/src/lib.rs`.
- Import and expose `ExceptionRule` where needed so exception-related functions compile.
- Rename internal whitelist helper to avoid Env ownership/move issues.
- Fix multiple test callsites and add `alloc` imports so unit tests compile and run.
- Remove stray/mismatched braces and correct event/test helpers.

## Rationale
These changes are preparatory and focused on build correctness and testability. A clean `spending-limits` crate is required before safely integrating the overspend penalty logic and its cross-contract interactions with `penalty` and `treasury` contracts.

## How to test locally (CLI)
1. Build and run tests for spending-limits:

```bash
cd "c:\OPEN SOURCE\Implement Budget Overspend Penalty\stellarspend-contracts"
cargo test -p spending-limits --lib
```

2. Optionally run the full workspace tests (long):

```bash
cargo test
```
## Closes #533 