### PR TITLE
feat: add contract health check query and activity feed contract

### DIFF
--- a/contracts/activity-feed/src/lib.rs
+++ b/contracts/activity-feed/src/lib.rs
@@ -1,0 +1,76 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, Symbol, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ActivityEvent {
+    pub event_type: Symbol,
+    pub timestamp: u64,
+    pub sequence: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    TotalEvents,
+    Event(u64),
+}
+
+#[contract]
+pub struct ActivityFeedContract;
+
+#[contractimpl]
+impl ActivityFeedContract {
+    /// Record a new protocol event in the activity feed.
+    pub fn record_event(env: Env, event_type: Symbol) -> u64 {
+        let seq: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalEvents)
+            .unwrap_or(0)
+            + 1;
+
+        let event = ActivityEvent {
+            event_type: event_type.clone(),
+            timestamp: env.ledger().timestamp(),
+            sequence: seq,
+        };
+
+        env.storage().persistent().set(&DataKey::Event(seq), &event);
+        env.storage().instance().set(&DataKey::TotalEvents, &seq);
+        env.events().publish((symbol_short!("activity"),), (event_type, seq));
+        seq
+    }
+
+    /// Get a paginated page of recent events (newest first).
+    /// page starts at 1, page_size max 50.
+    pub fn get_feed(env: Env, page: u64, page_size: u64) -> Vec<ActivityEvent> {
+        let total: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalEvents)
+            .unwrap_or(0);
+
+        let size = if page_size == 0 || page_size > 50 { 20 } else { page_size };
+        let p = if page == 0 { 1 } else { page };
+        let end = total.saturating_sub((p - 1) * size);
+        let start = end.saturating_sub(size) + 1;
+
+        let mut results: Vec<ActivityEvent> = Vec::new(&env);
+        let mut i = end;
+        while i >= start && i > 0 {
+            if let Some(ev) = env.storage().persistent().get(&DataKey::Event(i)) {
+                results.push_back(ev);
+            }
+            if i == 0 { break; }
+            i -= 1;
+        }
+        results
+    }
+
+    /// Get the total number of recorded events.
+    pub fn total_events(env: Env) -> u64 {
+        env.storage().instance().get(&DataKey::TotalEvents).unwrap_or(0)
+    }
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -19,9 +19,20 @@ pub fn get_version(env: Env) -> String {
     String::from_str(&env, SHARED_VERSION)
 }
 
-/// Health check function that returns true if the contract is active.
-pub fn health_check() -> bool {
-    true
+/// Health check response containing contract status and version.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct HealthStatus {
+    pub status: String,
+    pub version: String,
+}
+
+/// Returns contract health status and version for monitoring and frontend use.
+pub fn health_check(env: Env) -> HealthStatus {
+    HealthStatus {
+        status: String::from_str(&env, "ok"),
+        version: String::from_str(&env, SHARED_VERSION),
+    }
 }
 
 #[contracttype]
@@ -53,7 +64,7 @@ mod test;
 
 #[cfg(test)]
 mod tests {
-    use super::get_version;
+    use super::{get_version, health_check};
     use soroban_sdk::{Env, String};
 
     #[test]
@@ -61,5 +72,13 @@ mod tests {
         let env = Env::default();
         let version = get_version(env);
         assert_eq!(version, String::from_str(&Env::default(), "0.1.0"));
+    }
+
+    #[test]
+    fn health_check_returns_ok_and_version() {
+        let env = Env::default();
+        let status = health_check(env.clone());
+        assert_eq!(status.status, String::from_str(&env, "ok"));
+        assert_eq!(status.version, String::from_str(&env, "0.1.0"));
     }
 }


### PR DESCRIPTION
Implements two new features:

- contracts/shared/src/lib.rs: updated health_check() to return a HealthStatus struct with status and version fields, plus a test verifying the response structure
- contracts/activity-feed/src/lib.rs: new ActivityFeedContract with record_event(), paginated get_feed(), and total_events() query, with events sorted chronologically (newest first)

closes #630
closes #652