### PR TITLE
Added category analytics time-based filtering

### DIFF
--- a/contracts/category-analytics/src/lib.rs
+++ b/contracts/category-analytics/src/lib.rs
@@ -10,7 +10,7 @@ mod test;
 pub mod types;
 
 use crate::events::emit_spending_updated;
-use crate::types::{CategorySpend, CategorySpending, DataKey, MonthlyAnalytics};
+use crate::types::{CategorySpend, CategorySpending, DataKey, MonthlyAnalytics, TimeFilter};
 
 #[contract]
 pub struct CategoryAnalytics;
@@ -105,6 +105,80 @@ impl CategoryAnalytics {
                 category.clone(),
                 year,
                 month,
+            );
+            total_volume = total_volume
+                .checked_add(analytics.volume)
+                .expect("volume overflow");
+            total_count += analytics.count;
+        }
+
+        CategorySpending {
+            count: total_count,
+            volume: total_volume,
+        }
+    }
+
+    /// Retrieves analytics for a user and category in a specific month with time filtering.
+    ///
+    /// Filters metrics to ensure they fall within the specified `time_filter` range.
+    /// Results outside the range are excluded, and empty ranges (start > end) return
+    /// empty results without panicking.
+    pub fn get_category_metrics_filtered(
+        env: Env,
+        user: Address,
+        category: Symbol,
+        year: u32,
+        month: u32,
+        time_filter: TimeFilter,
+    ) -> MonthlyAnalytics {
+        let analytics = Self::get_category_metrics(
+            env.clone(),
+            user.clone(),
+            category.clone(),
+            year,
+            month,
+        );
+
+        // Check if the analytics entry is within the time range
+        if analytics.last_updated >= time_filter.start_timestamp
+            && analytics.last_updated <= time_filter.end_timestamp
+        {
+            analytics
+        } else {
+            MonthlyAnalytics {
+                user,
+                category,
+                year,
+                month,
+                volume: 0,
+                count: 0,
+                last_updated: 0,
+            }
+        }
+    }
+
+    /// Aggregates yearly trend for a user and category with time filtering.
+    ///
+    /// Excludes month metrics that do not fall within the `time_filter` range.
+    /// Empty ranges return zero totals without panicking.
+    pub fn get_yearly_trend_filtered(
+        env: Env,
+        user: Address,
+        category: Symbol,
+        year: u32,
+        time_filter: TimeFilter,
+    ) -> CategorySpending {
+        let mut total_volume: i128 = 0;
+        let mut total_count: u32 = 0;
+
+        for month in 1..=12 {
+            let analytics = Self::get_category_metrics_filtered(
+                env.clone(),
+                user.clone(),
+                category.clone(),
+                year,
+                month,
+                time_filter.clone(),
             );
             total_volume = total_volume
                 .checked_add(analytics.volume)

--- a/contracts/category-analytics/src/types.rs
+++ b/contracts/category-analytics/src/types.rs
@@ -29,6 +29,15 @@ pub struct MonthlyAnalytics {
     pub last_updated: u64,
 }
 
+/// Time filter for analytics queries.
+/// Allows filtering by start and end ledger timestamps.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimeFilter {
+    pub start_timestamp: u64,
+    pub end_timestamp: u64,
+}
+
 /// Storage keys for the contract
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/contracts/category-analytics/tests/integration.rs
+++ b/contracts/category-analytics/tests/integration.rs
@@ -100,3 +100,66 @@ fn test_multi_category_batch_aggregation() {
     assert_eq!(shopping_yearly.volume, 6500);
     assert_eq!(shopping_yearly.count, 2);
 }
+
+#[test]
+fn test_time_based_filtering() {
+    let (env, _admin, client) = setup_analytics_contract();
+    let user = Address::generate(&env);
+    let category = Symbol::new(&env, "shopping");
+
+    // We will record spending at three different timestamps.
+    // Month calculation is based on average month length of 2592000 seconds.
+    // Base timestamp = 1768608000 (Feb 2026)
+    let t1 = 1768608000;
+    env.ledger().set_timestamp(t1);
+    client.record_spending(&user, &category, &5000);
+
+    // Still in Feb 2026 but later
+    let t2 = 1768608000 + 1000;
+    env.ledger().set_timestamp(t2);
+    client.record_spending(&user, &category, &3000);
+
+    // Let's check get_category_metrics_filtered
+    // 1. Filter including everything
+    let filter_all = crate::types::TimeFilter {
+        start_timestamp: t1,
+        end_timestamp: t2,
+    };
+    let metrics_all = client.get_category_metrics_filtered(&user, &category, &2026, &2, &filter_all);
+    assert_eq!(metrics_all.volume, 8000);
+    assert_eq!(metrics_all.count, 2);
+
+    // 2. Filter excluding everything (before t1)
+    let filter_before = crate::types::TimeFilter {
+        start_timestamp: 0,
+        end_timestamp: t1 - 1,
+    };
+    let metrics_before = client.get_category_metrics_filtered(&user, &category, &2026, &2, &filter_before);
+    assert_eq!(metrics_before.volume, 0);
+    assert_eq!(metrics_before.count, 0);
+
+    // 3. Empty/invalid time range (start > end)
+    let filter_invalid = crate::types::TimeFilter {
+        start_timestamp: t2,
+        end_timestamp: t1,
+    };
+    let metrics_invalid = client.get_category_metrics_filtered(&user, &category, &2026, &2, &filter_invalid);
+    assert_eq!(metrics_invalid.volume, 0);
+    assert_eq!(metrics_invalid.count, 0);
+
+    // 4. Yearly trend filtered including only part of the range
+    // Let's query yearly trend filtered with filter_all which covers both transactions
+    let yearly_all = client.get_yearly_trend_filtered(&user, &category, &2026, &filter_all);
+    assert_eq!(yearly_all.volume, 8000);
+    assert_eq!(yearly_all.count, 2);
+
+    // Query yearly trend filtered with filter_before which covers none
+    let yearly_before = client.get_yearly_trend_filtered(&user, &category, &2026, &filter_before);
+    assert_eq!(yearly_before.volume, 0);
+    assert_eq!(yearly_before.count, 0);
+
+    // Query yearly trend filtered with invalid filter
+    let yearly_invalid = client.get_yearly_trend_filtered(&user, &category, &2026, &filter_invalid);
+    assert_eq!(yearly_invalid.volume, 0);
+    assert_eq!(yearly_invalid.count, 0);
+}


### PR DESCRIPTION
closes #596

I have completed the implementation of the category analytics time-based filtering:

contracts/category-analytics/src/types.rs: Added descriptive documentation to the TimeFilter struct.
contracts/category-analytics/src/lib.rs: Added documentation to clarify the time range filtering behavior in get_category_metrics_filtered and get_yearly_trend_filtered, including the handling of invalid/empty time ranges.
contracts/category-analytics/tests/integration.rs: Implemented the integration test test_time_based_filtering that covers:
Filtering of monthly and yearly metrics within a specific time range.
Exclusion of results that fall outside the range.
Graceful return of empty results when querying empty or invalid time ranges (where start_timestamp > end_timestamp) without panicking.