### PR TITLE
Add contribution reversal period to savings-goals contract

### DIFF
--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -28,9 +28,10 @@ mod validation;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Symbol, Vec};
 
 pub use crate::types::{
-    BatchGoalMetrics, BatchGoalResult, BatchMilestoneMetrics, BatchMilestoneResult, DataKey,
-    ErrorCode, GoalEvents, GoalResult, MilestoneAchievement, MilestoneAchievementRequest,
-    MilestoneResult, SavingsGoal, SavingsGoalProgress, SavingsGoalRequest, MAX_BATCH_SIZE,
+    BatchGoalMetrics, BatchGoalResult, BatchMilestoneMetrics, BatchMilestoneResult,
+    ContributionRecord, DataKey, ErrorCode, GoalEvents, GoalResult, MilestoneAchievement,
+    MilestoneAchievementRequest, MilestoneResult, SavingsGoal, SavingsGoalProgress,
+    SavingsGoalRequest, MAX_BATCH_SIZE, REVERSAL_PERIOD_SECS,
 };
 use crate::validation::{
     validate_goal_name_unique, validate_goal_request, validate_milestone_request,
@@ -52,24 +53,26 @@ pub enum SavingsGoalError {
     BatchTooLarge = 5,
     /// Goal is closed (target met) and no longer accepts contributions
     GoalClosed = 6,
-    /// Contribution amount is zero or negative
-    InvalidAmount = 7,
     /// Insufficient balance for withdrawal
-    InsufficientBalance = 6,
+    InsufficientBalance = 7,
     /// Goal is not active
-    GoalNotActive = 7,
+    GoalNotActive = 8,
     /// Invalid goal name
-    InvalidGoalName = 8,
+    InvalidGoalName = 9,
     /// Invalid contribution or withdrawal amount
-    InvalidAmount = 9,
+    InvalidAmount = 10,
     /// Goal not found
-    GoalNotFound = 10,
+    GoalNotFound = 11,
     /// Goal is locked against withdrawals
-    GoalLocked = 11,
+    GoalLocked = 12,
     /// Goal has expired
-    GoalExpired = 12,
+    GoalExpired = 13,
     /// One or more prerequisite goals are not complete
-    DependencyNotMet = 13,
+    DependencyNotMet = 14,
+    /// Reversal window has elapsed
+    ReversalExpired = 15,
+    /// No contribution found with the given ID
+    ContributionNotFound = 16,
 }
 
 impl From<SavingsGoalError> for soroban_sdk::Error {
@@ -499,7 +502,8 @@ impl SavingsGoalsContract {
     }
 
     /// Contributes funds to a savings goal and emits milestone events at 25/50/75/100%.
-    pub fn contribute_to_goal(env: Env, caller: Address, goal_id: u64, amount: i128) -> i128 {
+    /// Returns the contribution ID, which can be used to reverse the contribution within the reversal window.
+    pub fn contribute_to_goal(env: Env, caller: Address, goal_id: u64, amount: i128) -> u64 {
         caller.require_auth();
 
         if amount <= 0 {
@@ -558,8 +562,81 @@ impl SavingsGoalsContract {
             .persistent()
             .set(&DataKey::Goal(goal_id), &goal);
 
+        // Store contribution record for reversal eligibility tracking
+        let contrib_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LastContribId(goal_id))
+            .unwrap_or(0)
+            + 1;
+        let record = ContributionRecord {
+            amount,
+            contributed_at: current_time,
+            reversed: false,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contribution(goal_id, contrib_id), &record);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LastContribId(goal_id), &contrib_id);
+
         Self::check_and_emit_milestones(&env, goal_id);
         GoalEvents::goal_contributed(&env, goal_id, &caller, amount, goal.current_amount);
+
+        contrib_id
+    }
+
+    /// Reverses a contribution within the reversal period (REVERSAL_PERIOD_SECS).
+    ///
+    /// # Arguments
+    /// * `caller`       - Must be the goal owner.
+    /// * `goal_id`      - The goal that was contributed to.
+    /// * `contrib_id`   - The contribution ID returned by `contribute_to_goal`.
+    ///
+    /// # Errors
+    /// * `GoalNotFound`        - Goal does not exist.
+    /// * `Unauthorized`        - Caller is not the goal owner.
+    /// * `ContributionNotFound`- Contribution ID unknown or already reversed.
+    /// * `ReversalExpired`     - The reversal window has closed.
+    pub fn reverse_contribution(env: Env, caller: Address, goal_id: u64, contrib_id: u64) -> i128 {
+        caller.require_auth();
+
+        let mut goal: SavingsGoal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Goal(goal_id))
+            .unwrap_or_else(|| panic_with_error!(&env, SavingsGoalError::GoalNotFound));
+
+        if goal.user != caller {
+            panic_with_error!(&env, SavingsGoalError::Unauthorized);
+        }
+
+        let mut record: ContributionRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contribution(goal_id, contrib_id))
+            .unwrap_or_else(|| panic_with_error!(&env, SavingsGoalError::ContributionNotFound));
+
+        if record.reversed {
+            panic_with_error!(&env, SavingsGoalError::ContributionNotFound);
+        }
+
+        let now = env.ledger().timestamp();
+        if now > record.contributed_at.saturating_add(REVERSAL_PERIOD_SECS) {
+            panic_with_error!(&env, SavingsGoalError::ReversalExpired);
+        }
+
+        goal.current_amount = goal.current_amount.saturating_sub(record.amount);
+        goal.is_complete = goal.current_amount >= goal.target_amount;
+        record.reversed = true;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contribution(goal_id, contrib_id), &record);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Goal(goal_id), &goal);
 
         goal.current_amount
     }

--- a/contracts/savings-goals/src/test.rs
+++ b/contracts/savings-goals/src/test.rs
@@ -1261,3 +1261,49 @@ fn test_clone_savings_goal_unauthorized() {
     let cloned_name = Symbol::new(&env, "cloned");
     client.clone_savings_goal(&user2, &1, &cloned_name); // user2 tries to clone user1's goal
 }
+
+#[test]
+fn test_reverse_contribution_within_window() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    // Create a goal
+    let mut goal_requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    goal_requests.push_back(create_valid_request(&env, &user, "reverse_goal", 100_000_000));
+    client.batch_set_savings_goals(&admin, &goal_requests);
+
+    let goal_id: u64 = 1;
+    let contribution_amount: i128 = 5_000_000;
+
+    // Contribute and capture the contrib_id
+    let contrib_id = client.contribute_to_goal(&user, &goal_id, &contribution_amount);
+
+    // Reverse immediately (still within the 24-hour window)
+    let remaining = client.reverse_contribution(&user, &goal_id, &contrib_id);
+
+    // Balance should be back to the initial contribution (10% = 10_000_000) only
+    let goal = client.get_goal(&goal_id).unwrap();
+    assert_eq!(remaining, goal.current_amount);
+    assert_eq!(goal.current_amount, 100_000_000 / 10); // initial_contribution only
+}
+
+#[test]
+#[should_panic]
+fn test_reverse_contribution_after_window_rejected() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    // Create a goal
+    let mut goal_requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    goal_requests.push_back(create_valid_request(&env, &user, "expired_rev", 100_000_000));
+    client.batch_set_savings_goals(&admin, &goal_requests);
+
+    let goal_id: u64 = 1;
+    let contrib_id = client.contribute_to_goal(&user, &goal_id, &5_000_000i128);
+
+    // Advance time past the 24-hour reversal window
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_401);
+
+    // Should panic with ReversalExpired
+    client.reverse_contribution(&user, &goal_id, &contrib_id);
+}

--- a/contracts/savings-goals/src/types.rs
+++ b/contracts/savings-goals/src/types.rs
@@ -197,6 +197,21 @@ pub struct BatchMilestoneResult {
     pub metrics: BatchMilestoneMetrics,
 }
 
+/// Reversal window in seconds (24 hours).
+pub const REVERSAL_PERIOD_SECS: u64 = 86_400;
+
+/// A record of a single contribution, stored for reversal eligibility.
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct ContributionRecord {
+    /// The contribution amount.
+    pub amount: i128,
+    /// Ledger timestamp when the contribution was made.
+    pub contributed_at: u64,
+    /// Whether this contribution has already been reversed.
+    pub reversed: bool,
+}
+
 /// Storage keys for contract state.
 #[derive(Clone)]
 #[contracttype]
@@ -231,6 +246,10 @@ pub enum DataKey {
     GoalClosedAt(u64),
     /// Maps (user, goal_name) -> goal_id for duplicate detection
     GoalByName(Address, Symbol),
+    /// Contribution record keyed by (goal_id, contribution sequential index)
+    Contribution(u64, u64),
+    /// Last contribution index per goal
+    LastContribId(u64),
 }
 
 /// Error codes for goal validation and creation.


### PR DESCRIPTION
Add contribution reversal period to savings-goals contract
  
  Allows users to reverse accidental contributions to a savings goal within a 24-hour window.
  
  Changes
  
  - types.rs — Added ContributionRecord struct (amount, timestamp, reversed flag),
  REVERSAL_PERIOD_SECS = 86_400 constant, and Contribution/LastContribId storage keys
  - lib.rs — Fixed pre-existing duplicate discriminant bug in SavingsGoalError; added
  ReversalExpired and ContributionNotFound error variants; contribute_to_goal now stores a
  contribution record and returns a contrib_id for reversal reference; new reverse_contribution
   function deducts the contribution if called within the window
  - test.rs — Tests for eligible reversal (within window) and expired reversal (rejected after
  24h)
  
  Acceptance Criteria
  
  - ✅ Eligible contributions reversible within 24 hours via reverse_contribution(caller,
  goal_id, contrib_id)
  - ✅ Reversal after 24 hours panics with ReversalExpired
  - ✅ Already-reversed contributions rejected with ContributionNotFound
closes #656 