### PR TITLE
feat: add recurring payment pause and resume

### DIFF
--- a/contracts/recurring-payment/src/lib.rs
+++ b/contracts/recurring-payment/src/lib.rs
@@ -57,6 +57,7 @@ impl RecurringPaymentContract {
             interval,
             next_execution: start_time,
             active: true,
+            paused: false,
             execution_count: 0,
             missed_count: 0,
             last_missed_at: 0,
@@ -87,6 +88,9 @@ impl RecurringPaymentContract {
         if !payment.active {
             panic!("Payment is not active");
         }
+        if payment.paused {
+            panic!("Payment is paused");
+        }
 
         let current_time = env.ledger().timestamp();
         if current_time < payment.next_execution {
@@ -107,7 +111,7 @@ impl RecurringPaymentContract {
                 (symbol_short!("recur"), symbol_short!("missed"), payment_id),
                 (payment.missed_count, payment.last_missed_at),
             );
-            panic!("Insufficient funds for payment");
+            return;
         }
         token_client.transfer(&payment.sender, &payment.recipient, &payment.amount);
 
@@ -173,6 +177,66 @@ impl RecurringPaymentContract {
                 symbol_short!("canceled"),
                 payment_id,
             ),
+            payment.sender,
+        );
+    }
+
+    /// Pauses a recurring payment without canceling its schedule.
+    ///
+    /// Only the original sender may pause the payment.
+    pub fn pause_payment(env: Env, payment_id: u64) {
+        let mut payment: RecurringPayment = env
+            .storage()
+            .instance()
+            .get(&DataKey::Payment(payment_id))
+            .expect("Payment not found");
+
+        payment.sender.require_auth();
+
+        if !payment.active {
+            panic!("Payment is not active");
+        }
+        if payment.paused {
+            panic!("Payment is already paused");
+        }
+
+        payment.paused = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::Payment(payment_id), &payment);
+
+        env.events().publish(
+            (symbol_short!("recur"), symbol_short!("paused"), payment_id),
+            payment.sender,
+        );
+    }
+
+    /// Resumes a paused recurring payment.
+    ///
+    /// Only the original sender may resume the payment.
+    pub fn resume_payment(env: Env, payment_id: u64) {
+        let mut payment: RecurringPayment = env
+            .storage()
+            .instance()
+            .get(&DataKey::Payment(payment_id))
+            .expect("Payment not found");
+
+        payment.sender.require_auth();
+
+        if !payment.active {
+            panic!("Payment is not active");
+        }
+        if !payment.paused {
+            panic!("Payment is not paused");
+        }
+
+        payment.paused = false;
+        env.storage()
+            .instance()
+            .set(&DataKey::Payment(payment_id), &payment);
+
+        env.events().publish(
+            (symbol_short!("recur"), symbol_short!("resumed"), payment_id),
             payment.sender,
         );
     }

--- a/contracts/recurring-payment/src/test.rs
+++ b/contracts/recurring-payment/src/test.rs
@@ -1,41 +1,76 @@
 #![cfg(test)]
 
+extern crate std;
+
 use super::*;
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{token, Address, Env};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
-fn create_token_contract<'a>(e: &Env, admin: &Address) -> (Address, token::Client<'a>) {
-    let addr = e.register_stellar_asset_contract(admin.clone());
-    (addr.clone(), token::Client::new(e, &addr))
+fn setup_test_env() -> (
+    Env,
+    Address,
+    Address,
+    Address,
+    token::Client<'static>,
+    token::StellarAssetClient<'static>,
+    RecurringPaymentContractClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let stellar_asset = env.register_stellar_asset_contract_v2(token_admin);
+    let token_addr = stellar_asset.address();
+    let token_client = token::Client::new(&env, &token_addr);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_addr);
+
+    let contract_id = env.register(RecurringPaymentContract, ());
+    let client = RecurringPaymentContractClient::new(&env, &contract_id);
+
+    (
+        env,
+        sender,
+        recipient,
+        token_addr,
+        token_client,
+        token_admin_client,
+        client,
+    )
+}
+
+fn create_payment(
+    client: &RecurringPaymentContractClient,
+    sender: &Address,
+    recipient: &Address,
+    token: &Address,
+    amount: i128,
+    interval: u64,
+    start_time: u64,
+) -> u64 {
+    client.create_payment(sender, recipient, token, &amount, &interval, &start_time)
 }
 
 #[test]
 fn test_recurring_payment_flow() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, sender, recipient, token_addr, token_client, token_admin_client, client) =
+        setup_test_env();
 
-    let admin = Address::generate(&env);
-    let sender = Address::generate(&env);
-    let recipient = Address::generate(&env);
-
-    let (token_addr, token_client) = create_token_contract(&env, &admin);
     let amount = 1000i128;
-    let interval = 3600u64; // 1 hour
+    let interval = 3600u64;
     let start_time = 1000u64;
+    token_admin_client.mint(&sender, &5000i128);
 
-    token_client.mint(&sender, &5000i128);
-
-    let contract_id = env.register_contract(None, RecurringPaymentContract);
-    let client = RecurringPaymentContractClient::new(&env, &contract_id);
-
-    // 1. Create payment
-    let payment_id = client.create_payment(
+    let payment_id = create_payment(
+        &client,
         &sender,
         &recipient,
         &token_addr,
-        &amount,
-        &interval,
-        &start_time,
+        amount,
+        interval,
+        start_time,
     );
     assert_eq!(payment_id, 1);
 
@@ -43,13 +78,9 @@ fn test_recurring_payment_flow() {
     assert_eq!(payment.amount, amount);
     assert_eq!(payment.next_execution, start_time);
     assert!(payment.active);
+    assert!(!payment.paused);
     assert_eq!(payment.execution_count, 0);
 
-    // 2. Try to execute too early
-    env.ledger().set_timestamp(start_time - 1);
-    // client.execute_payment(&payment_id); // This should panic
-
-    // 3. Execute at start_time
     env.ledger().set_timestamp(start_time);
     client.execute_payment(&payment_id);
 
@@ -60,165 +91,171 @@ fn test_recurring_payment_flow() {
     assert_eq!(payment.next_execution, start_time + interval);
     assert_eq!(payment.execution_count, 1);
 
-    // 4. Cancel payment
     client.cancel_payment(&payment_id);
     let payment = client.get_payment(&payment_id);
     assert!(!payment.active);
-
-    // 5. Try to execute canceled payment
-    env.ledger().set_timestamp(start_time + interval);
-    // client.execute_payment(&payment_id); // This should panic
 }
 
 #[test]
 #[should_panic(expected = "Amount must be positive")]
 fn test_create_with_zero_amount() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let sender = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let token = Address::generate(&env);
+    let (_env, sender, recipient, token_addr, _token_client, _token_admin_client, client) =
+        setup_test_env();
 
-    let contract_id = env.register_contract(None, RecurringPaymentContract);
-    let client = RecurringPaymentContractClient::new(&env, &contract_id);
-
-    client.create_payment(&sender, &recipient, &token, &0, &3600, &1000);
+    client.create_payment(&sender, &recipient, &token_addr, &0, &3600, &1000);
 }
 
 #[test]
 fn test_execute_with_delay() {
-    let env = Env::default();
-    env.mock_all_auths();
+    let (env, sender, recipient, token_addr, token_client, token_admin_client, client) =
+        setup_test_env();
 
-    let admin = Address::generate(&env);
-    let sender = Address::generate(&env);
-    let recipient = Address::generate(&env);
-
-    let (token_addr, token_client) = create_token_contract(&env, &admin);
     let amount = 1000i128;
     let interval = 3600u64;
     let start_time = 1000u64;
+    token_admin_client.mint(&sender, &5000i128);
 
-    token_client.mint(&sender, &5000i128);
-
-    let contract_id = env.register_contract(None, RecurringPaymentContract);
-    let client = RecurringPaymentContractClient::new(&env, &contract_id);
-
-    client.create_payment(
+    create_payment(
+        &client,
         &sender,
         &recipient,
         &token_addr,
-        &amount,
-        &interval,
-        &start_time,
+        amount,
+        interval,
+        start_time,
     );
 
-    // Set time way ahead (e.g., 2.5 intervals ahead)
     env.ledger().set_timestamp(start_time + interval * 2 + 500);
     client.execute_payment(&1);
 
     let payment = client.get_payment(&1);
-    // next_execution should be start_time + 3 * interval
     assert_eq!(payment.next_execution, start_time + 3 * interval);
     assert_eq!(token_client.balance(&recipient), 1000);
     assert_eq!(payment.execution_count, 1);
+}
 
-    #[test]
-    fn test_missed_payment_increments_count() {
-        let env = Env::default();
-        env.mock_all_auths();
+#[test]
+fn test_paused_payment_does_not_execute() {
+    let (env, sender, recipient, token_addr, token_client, token_admin_client, client) =
+        setup_test_env();
 
-        let sender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token_admin = Address::generate(&env);
-        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
-        let token_address = token.address();
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 3600, 1000);
+    token_admin_client.mint(&sender, &500);
+    client.pause_payment(&payment_id);
 
-        // Fund sender with less than required amount
-        let token_client = token::StellarAssetClient::new(&env, &token_address);
-        token_client.mint(&sender, &50);
-
-        let contract_id = env.register(RecurringPaymentContract, ());
-        let client = RecurringPaymentContractClient::new(&env, &contract_id);
-
-        let payment_id =
-            client.create_payment(&sender, &recipient, &token_address, &100, &3600, &0);
-
-        // Try to execute with insufficient funds — should panic
-        let result = std::panic::catch_unwind(|| {
-            client.execute_payment(&payment_id);
-        });
-        assert!(result.is_err());
-
-        // Check missed_count incremented
-        let payment = client.get_payment(&payment_id);
-        assert_eq!(payment.missed_count, 1);
-        assert!(payment.last_missed_at > 0);
-    }
-
-    #[test]
-    fn test_successful_execution_resets_missed_count() {
-        let env = Env::default();
-        env.mock_all_auths();
-
-        let sender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token_admin = Address::generate(&env);
-        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
-        let token_address = token.address();
-
-        let token_client = token::StellarAssetClient::new(&env, &token_address);
-
-        let contract_id = env.register(RecurringPaymentContract, ());
-        let client = RecurringPaymentContractClient::new(&env, &contract_id);
-
-        let payment_id =
-            client.create_payment(&sender, &recipient, &token_address, &100, &3600, &0);
-
-        // First cause a miss with insufficient funds
-        token_client.mint(&sender, &50);
-        let _ = std::panic::catch_unwind(|| {
-            client.execute_payment(&payment_id);
-        });
-
-        // Now fund properly and execute successfully
-        token_client.mint(&sender, &200);
+    env.ledger().set_timestamp(1000);
+    let result = catch_unwind(AssertUnwindSafe(|| {
         client.execute_payment(&payment_id);
+    }));
+    assert!(result.is_err());
 
-        // missed_count should be reset to 0
-        let payment = client.get_payment(&payment_id);
-        assert_eq!(payment.missed_count, 0);
-        assert_eq!(payment.last_missed_at, 0);
-    }
+    let payment = client.get_payment(&payment_id);
+    assert!(payment.active);
+    assert!(payment.paused);
+    assert_eq!(payment.execution_count, 0);
+    assert_eq!(payment.next_execution, 1000);
+    assert_eq!(token_client.balance(&sender), 500);
+    assert_eq!(token_client.balance(&recipient), 0);
+}
 
-    #[test]
-    fn test_missed_count_increments_multiple_times() {
-        let env = Env::default();
-        env.mock_all_auths();
+#[test]
+fn test_resume_payment_restores_execution() {
+    let (env, sender, recipient, token_addr, token_client, token_admin_client, client) =
+        setup_test_env();
 
-        let sender = Address::generate(&env);
-        let recipient = Address::generate(&env);
-        let token_admin = Address::generate(&env);
-        let token = env.register_stellar_asset_contract_v2(token_admin.clone());
-        let token_address = token.address();
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 3600, 1000);
+    token_admin_client.mint(&sender, &500);
+    client.pause_payment(&payment_id);
 
-        let token_client = token::StellarAssetClient::new(&env, &token_address);
-        token_client.mint(&sender, &10); // not enough for 100
+    let paused = client.get_payment(&payment_id);
+    assert!(paused.paused);
 
-        let contract_id = env.register(RecurringPaymentContract, ());
-        let client = RecurringPaymentContractClient::new(&env, &contract_id);
+    client.resume_payment(&payment_id);
+    let resumed = client.get_payment(&payment_id);
+    assert!(resumed.active);
+    assert!(!resumed.paused);
 
-        let payment_id = client.create_payment(&sender, &recipient, &token_address, &100, &1, &0);
+    env.ledger().set_timestamp(1000);
+    client.execute_payment(&payment_id);
 
-        // Miss twice
-        let _ = std::panic::catch_unwind(|| {
-            client.execute_payment(&payment_id);
-        });
-        let _ = std::panic::catch_unwind(|| {
-            client.execute_payment(&payment_id);
-        });
+    let payment = client.get_payment(&payment_id);
+    assert_eq!(payment.execution_count, 1);
+    assert_eq!(payment.next_execution, 4600);
+    assert_eq!(token_client.balance(&sender), 400);
+    assert_eq!(token_client.balance(&recipient), 100);
+}
 
-        let payment = client.get_payment(&payment_id);
-        assert_eq!(payment.missed_count, 2);
-    }
+#[test]
+#[should_panic(expected = "Payment is not paused")]
+fn test_resume_unpaused_payment_panics() {
+    let (_env, sender, recipient, token_addr, _token_client, _token_admin_client, client) =
+        setup_test_env();
+
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 3600, 1000);
+    client.resume_payment(&payment_id);
+}
+
+#[test]
+#[should_panic(expected = "Payment is not active")]
+fn test_cancelled_payment_cannot_resume() {
+    let (_env, sender, recipient, token_addr, _token_client, _token_admin_client, client) =
+        setup_test_env();
+
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 3600, 1000);
+    client.cancel_payment(&payment_id);
+    client.resume_payment(&payment_id);
+}
+
+#[test]
+fn test_missed_payment_increments_count() {
+    let (env, sender, recipient, token_addr, _token_client, token_admin_client, client) =
+        setup_test_env();
+
+    token_admin_client.mint(&sender, &50);
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 3600, 1000);
+
+    env.ledger().set_timestamp(1000);
+    client.execute_payment(&payment_id);
+
+    let payment = client.get_payment(&payment_id);
+    assert_eq!(payment.missed_count, 1);
+    assert_eq!(payment.last_missed_at, 1000);
+    assert_eq!(payment.execution_count, 0);
+}
+
+#[test]
+fn test_successful_execution_resets_missed_count() {
+    let (env, sender, recipient, token_addr, _token_client, token_admin_client, client) =
+        setup_test_env();
+
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 3600, 1000);
+
+    token_admin_client.mint(&sender, &50);
+    env.ledger().set_timestamp(1000);
+    client.execute_payment(&payment_id);
+
+    token_admin_client.mint(&sender, &200);
+    client.execute_payment(&payment_id);
+
+    let payment = client.get_payment(&payment_id);
+    assert_eq!(payment.missed_count, 0);
+    assert_eq!(payment.last_missed_at, 0);
+    assert_eq!(payment.execution_count, 1);
+}
+
+#[test]
+fn test_missed_count_increments_multiple_times() {
+    let (env, sender, recipient, token_addr, _token_client, token_admin_client, client) =
+        setup_test_env();
+
+    token_admin_client.mint(&sender, &10);
+    let payment_id = create_payment(&client, &sender, &recipient, &token_addr, 100, 1, 1000);
+
+    env.ledger().set_timestamp(1000);
+    client.execute_payment(&payment_id);
+    client.execute_payment(&payment_id);
+
+    let payment = client.get_payment(&payment_id);
+    assert_eq!(payment.missed_count, 2);
+    assert_eq!(payment.last_missed_at, 1000);
 }

--- a/contracts/recurring-payment/src/types.rs
+++ b/contracts/recurring-payment/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Vec};
+use soroban_sdk::{contracttype, Address};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,7 +23,10 @@ pub struct RecurringPayment {
     pub interval: u64,
     pub next_execution: u64,
     pub active: bool,
+    pub paused: bool,
     pub execution_count: u32,
+    pub missed_count: u32,
+    pub last_missed_at: u64,
 }
 
 /// Represents a recurring income stream that auto-funds budgets or goals.


### PR DESCRIPTION
## Summary

Closes #664.

Adds pause/resume support for recurring payments and restores the recurring-payment test suite so it exercises the current Soroban token test APIs.

## Changes

- add a `paused` flag to recurring payment schedules
- block `execute_payment` while a schedule is paused
- add `pause_payment` and `resume_payment` sender-authorized contract methods
- keep missed-payment accounting durable by recording insufficient-fund executions without panicking and rolling back state
- replace the broken nested tests with top-level coverage for pause, resume, cancellation, delayed execution, and missed-payment recovery

## Validation

- `cargo fmt --check -p recurring-payment`
- `cargo test -p recurring-payment`
