### PR TITLE
feat: emit batch payment receipts

### DIFF
--- a/contracts/batch-payment/Cargo.toml
+++ b/contracts/batch-payment/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "22.0.0"
+soroban-sdk = { workspace = true }
+shared = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.0", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/batch-payment/src/lib.rs
+++ b/contracts/batch-payment/src/lib.rs
@@ -1,11 +1,13 @@
 #![no_std]
 
+#[cfg(test)]
 mod test;
 mod types;
 
-use crate::types::Payment;
 use shared::utils::generate_transaction_reference_id;
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol, Vec};
+
+pub use crate::types::{Payment, PaymentReceipt};
 
 #[contract]
 pub struct BatchPaymentContract;
@@ -56,6 +58,14 @@ impl BatchPaymentContract {
             total_amount += payment.amount;
             count += 1;
 
+            let receipt = PaymentReceipt {
+                batch_reference_id: batch_reference_id.clone(),
+                recipient: payment.recipient.clone(),
+                token: token.clone(),
+                amount: payment.amount,
+                index: count,
+            };
+
             // Emit per-payment event with batch reference ID
             // Topics: (payment, batch_id, recipient)
             // Data: (token, amount)
@@ -66,6 +76,15 @@ impl BatchPaymentContract {
             );
             env.events()
                 .publish(topics, (token.clone(), payment.amount));
+
+            env.events().publish(
+                (
+                    symbol_short!("payment"),
+                    symbol_short!("receipt"),
+                    payment.recipient.clone(),
+                ),
+                receipt,
+            );
         }
 
         // Emit batch completion event with reference ID

--- a/contracts/batch-payment/src/test.rs
+++ b/contracts/batch-payment/src/test.rs
@@ -4,33 +4,55 @@ extern crate std;
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events},
-    Address, Env, Vec,
+    Address, Env, Symbol, TryFromVal, Vec,
 };
 
-#[test]
-fn test_batch_transfer() {
+fn setup_test_env() -> (
+    Env,
+    Address,
+    Address,
+    token::Client<'static>,
+    token::StellarAssetClient<'static>,
+    BatchPaymentContractClient<'static>,
+) {
     let env = Env::default();
-    env.mock_all_auths();
+    env.mock_all_auths_allowing_non_root_auth();
 
-    // Register the contract
     let contract_id = env.register(BatchPaymentContract, ());
     let client = BatchPaymentContractClient::new(&env, &contract_id);
 
-    // Setup Token
     let token_admin = Address::generate(&env);
-    // Setup Token
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
-    let token_client = token::Client::new(&env, &token_contract.address());
-    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract.address());
+    let token_id = token_contract.address();
+    let token_client = token::Client::new(&env, &token_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+
+    (
+        env,
+        token_id,
+        token_admin,
+        token_client,
+        token_admin_client,
+        client,
+    )
+}
+
+fn soroban_string_to_std(value: &String) -> std::string::String {
+    let mut bytes = std::vec![0u8; value.len() as usize];
+    value.copy_into_slice(&mut bytes);
+    std::string::String::from_utf8(bytes).unwrap_or_default()
+}
+
+#[test]
+fn test_batch_transfer_emits_receipts() {
+    let (env, token, _token_admin, token_client, token_admin_client, client) = setup_test_env();
 
     let sender = Address::generate(&env);
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
 
-    // Mint tokens to sender
     token_admin_client.mint(&sender, &1000);
 
-    // Prepare payments
     let mut payments = Vec::new(&env);
     payments.push_back(Payment {
         recipient: user1.clone(),
@@ -41,54 +63,52 @@ fn test_batch_transfer() {
         amount: 200,
     });
 
-    // Execute batch transfer
-    let batch_ref_id = client.batch_transfer(&sender, &token_contract.address(), &payments);
+    let batch_ref_id = client.batch_transfer(&sender, &token, &payments);
 
-    // Verify reference ID is returned
     assert!(batch_ref_id.len() > 0);
 
-    // Reference IDs should start with "TXN-"
-    let ref_id_str = std::string::String::from_utf8(
-        batch_ref_id
-            .as_ref()
-            .iter()
-            .map(|b| *b as u8)
-            .collect::<Vec<_>>(),
-    )
-    .unwrap_or_default();
+    let ref_id_str = soroban_string_to_std(&batch_ref_id);
     assert!(ref_id_str.starts_with("TXN-"));
 
-    // Verify balances
+    let events = env.events().all();
+    let receipt_events = events
+        .iter()
+        .filter(|event| {
+            let Some(topic0_val) = event.1.get(0) else {
+                return false;
+            };
+            let Some(topic1_val) = event.1.get(1) else {
+                return false;
+            };
+            let Ok(topic0) = Symbol::try_from_val(&env, &topic0_val) else {
+                return false;
+            };
+            let Ok(topic1) = Symbol::try_from_val(&env, &topic1_val) else {
+                return false;
+            };
+
+            topic0 == symbol_short!("payment") && topic1 == symbol_short!("receipt")
+        })
+        .collect::<std::vec::Vec<_>>();
+
+    assert_eq!(receipt_events.len(), 2);
+
+    let first_receipt = PaymentReceipt::try_from_val(&env, &receipt_events[0].2).unwrap();
+    assert_eq!(first_receipt.batch_reference_id, batch_ref_id);
+    assert_eq!(first_receipt.recipient, user1);
+    assert_eq!(first_receipt.token, token);
+    assert_eq!(first_receipt.amount, 100);
+    assert_eq!(first_receipt.index, 1);
+
     assert_eq!(token_client.balance(&sender), 700);
     assert_eq!(token_client.balance(&user1), 100);
     assert_eq!(token_client.balance(&user2), 200);
-    std::println!("Balances OK");
-
-    // Test direct event emission
-    env.events().publish((1,), 2);
-    std::println!("Direct event emitted");
-
-    // Verify events
-    let events = env.events().all();
-    std::println!("EVENTS: {:?}", events);
-
-    // We expect at least the direct event + contract events + token events
-    // assert!(events.len() > 0);
-    std::println!("Balances verified. Skipping event assertion due to SDK behavior.");
 }
 
 #[test]
 #[should_panic(expected = "Payment amount must be positive")]
 fn test_batch_transfer_zero_amount() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(BatchPaymentContract, ());
-    let client = BatchPaymentContractClient::new(&env, &contract_id);
-
-    let token_admin = Address::generate(&env);
-    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
-    // No need to mint for this test as it fails validation before transfer
+    let (env, token, _token_admin, _token_client, _token_admin_client, client) = setup_test_env();
 
     let sender = Address::generate(&env);
     let user1 = Address::generate(&env);
@@ -99,22 +119,12 @@ fn test_batch_transfer_zero_amount() {
         amount: 0,
     });
 
-    client.batch_transfer(&sender, &token_contract.address(), &payments);
+    client.batch_transfer(&sender, &token, &payments);
 }
 
 #[test]
 fn test_batch_transfer_generates_unique_reference_ids() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    // Register the contract
-    let contract_id = env.register(BatchPaymentContract, ());
-    let client = BatchPaymentContractClient::new(&env, &contract_id);
-
-    // Setup Token
-    let token_admin = Address::generate(&env);
-    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
-    let token_admin_client = token::StellarAssetClient::new(&env, &token_contract.address());
+    let (env, token, _token_admin, _token_client, token_admin_client, client) = setup_test_env();
 
     let sender = Address::generate(&env);
     let user1 = Address::generate(&env);
@@ -142,36 +152,9 @@ fn test_batch_transfer_generates_unique_reference_ids() {
         amount: 150,
     });
 
-    // Execute first batch transfer
-    let batch_ref_id_1 = client.batch_transfer(&sender, &token_contract.address(), &payments1);
+    let batch_ref_id_1 = client.batch_transfer(&sender, &token, &payments1);
 
-    // Execute second batch transfer
-    let batch_ref_id_2 = client.batch_transfer(&sender, &token_contract.address(), &payments2);
+    let batch_ref_id_2 = client.batch_transfer(&sender, &token, &payments2);
 
-    // Reference IDs should be different
     assert_ne!(batch_ref_id_1, batch_ref_id_2);
-    std::println!("Batch 1 Reference ID: {:?}", batch_ref_id_1);
-    std::println!("Batch 2 Reference ID: {:?}", batch_ref_id_2);
-}
-
-use soroban_sdk::{contract, contractimpl, Address, Env};
-
-use crate::{ContractUtils, DataKey};
-
-#[contract]
-pub struct AdminContract;
-
-#[contractimpl]
-impl AdminContract {
-    /// Initialize contract with admin
-    pub fn initialize(env: Env, admin: Address) {
-        env.storage().instance().set(&DataKey::Admin, &admin);
-    }
-
-    /// Retrieve the stored admin address
-    ///
-    /// This function does not require authentication.
-    pub fn get_admin(env: Env) -> Address {
-        ContractUtils::get_admin(&env)
-    }
 }

--- a/contracts/batch-payment/src/types.rs
+++ b/contracts/batch-payment/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -7,56 +7,12 @@ pub struct Payment {
     pub amount: i128,
 }
 
-use crate::storage::{bump_instance, DataKey};
-use crate::types::Error;
-use soroban_sdk::{panic_with_error, Address, Env};
-
-/// Persist the admin address.
-///
-/// Private to this module — external code must go through `AdminContract::initialize`,
-/// which enforces the one-time-only invariant.
-pub(crate) fn set_admin(env: &Env, admin: &Address) {
-    env.storage().instance().set(&DataKey::Admin, admin);
-    bump_instance(env);
-}
-
-/// Load the admin address and refresh the instance TTL.
-///
-/// Panics with `Error::NotInitialized` if the contract has never been initialized,
-/// giving callers a typed error instead of a host trap.
-pub fn get_admin(env: &Env) -> Address {
-    let admin = env
-        .storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .unwrap_or_else(|| panic_with_error!(env, Error::NotInitialized));
-    bump_instance(env);
-    admin
-}
-
-/// Return `true` when an admin has been set.
-///
-/// Cheaper than `get_admin` when you only need existence, not the address —
-/// avoids a full deserialise.
-pub fn is_initialized(env: &Env) -> bool {
-    env.storage().instance().has(&DataKey::Admin)
-}
-
-/// Assert that `caller` is the stored admin.
-///
-/// Combines the storage read, the Soroban auth check, and the TTL bump in one
-/// call so every admin-gated function reads identically:
-///
-/// ```rust
-/// pub fn protected_action(env: Env, caller: Address) {
-///     require_admin(&env, &caller);
-///     // ... rest of logic
-/// }
-/// ```
-pub fn require_admin(env: &Env, caller: &Address) {
-    let admin = get_admin(env); // panics with NotInitialized if unset
-    if &admin != caller {
-        panic_with_error!(env, Error::Unauthorized);
-    }
-    caller.require_auth();
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentReceipt {
+    pub batch_reference_id: String,
+    pub recipient: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub index: u32,
 }

--- a/contracts/shared/src/utils.rs
+++ b/contracts/shared/src/utils.rs
@@ -1,3 +1,4 @@
+use alloc::format;
 use soroban_sdk::{Env, String, Symbol};
 
 /// Shared validation errors for simple reusable helpers.
@@ -65,7 +66,7 @@ pub fn increment_counter(env: &Env, counter_key: &Symbol) -> u64 {
 /// tracking and reconciliation of individual transactions.
 pub fn generate_transaction_reference_id(
     env: &Env,
-    sender: &soroban_sdk::Address,
+    _sender: &soroban_sdk::Address,
     counter_key: &Symbol,
 ) -> String {
     // Increment the transaction counter to ensure uniqueness
@@ -80,10 +81,7 @@ pub fn generate_transaction_reference_id(
 
     // Combine components to create reference ID
     // Format: TXN-{ledger}{counter}
-    let ref_id = String::from_str(
-        env,
-        &format!("TXN-{}{}", ledger_str, counter_str[..8].to_string()),
-    );
+    let ref_id = String::from_str(env, &format!("TXN-{}{}", ledger_str, &counter_str[8..]));
 
     ref_id
 }
@@ -94,7 +92,7 @@ mod tests {
         generate_transaction_reference_id, increment_counter, validate_amount,
         validate_user_address, ValidationError,
     };
-    use soroban_sdk::{contract, contractimpl, Env, String, Symbol};
+    use soroban_sdk::{contract, contractimpl, testutils::Address as _, Env, String, Symbol};
 
     #[contract]
     struct TestContract;
@@ -176,8 +174,7 @@ mod tests {
         env.as_contract(&contract_id, || {
             let ref_id = generate_transaction_reference_id(&env, &sender, &counter_key);
 
-            // Verify format: should start with "TXN-"
-            let ref_str = String::from_str(&env, "TXN-");
+            // Verify format: should include the transaction prefix.
             assert!(ref_id.len() > 4);
         });
     }


### PR DESCRIPTION
## Summary

Closes #665.

Adds explicit receipt events for each successful batch payment transfer and restores the batch-payment package so the receipt behavior is covered by tests.

## Changes

- add a `PaymentReceipt` contract type
- emit `payment`/`receipt` events after each successful transfer
- wire `batch-payment` to the workspace `shared` dependency used for reference IDs
- remove unrelated pasted admin code from `batch-payment` types/tests
- fix shared reference IDs to use the changing counter digits
- assert receipt event payloads in tests

## Validation

- `cargo fmt -p batch-payment -p shared -- --check`
- `cargo test -p batch-payment`
- `cargo test -p shared`
- `git diff --check`
