### PR TITLE
feat(batch-rewards): add idempotency support for batch reward distribution

### DIFF
--- a/contracts/batch-rewards/src/lib.rs
+++ b/contracts/batch-rewards/src/lib.rs
@@ -7,7 +7,7 @@ mod validation;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env, Vec};
+use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Bytes, Env, Vec};
 
 pub use crate::types::{
     BatchRewardResult, DataKey, RewardEvents, RewardRequest, RewardResult, MAX_BATCH_SIZE,
@@ -35,6 +35,8 @@ pub enum BatchRewardsError {
     InsufficientBalance = 7,
     /// Invalid reward amount
     InvalidAmount = 8,
+    /// Duplicate request replay detected for the same idempotency token
+    DuplicateRequest = 9,
 }
 
 impl From<BatchRewardsError> for soroban_sdk::Error {
@@ -112,6 +114,7 @@ impl BatchRewardsContract {
     /// * `env` - The Soroban environment
     /// * `caller` - The address initiating the batch rewards
     /// * `token` - The token contract address (e.g., XLM)
+    /// * `idempotency_token` - Unique token to make batch reward execution idempotent.
     /// * `rewards` - Vector of reward requests containing recipient and amount
     ///
     /// # Returns
@@ -120,11 +123,18 @@ impl BatchRewardsContract {
         env: Env,
         caller: Address,
         token: Address,
+        idempotency_token: Bytes,
         rewards: Vec<RewardRequest>,
     ) -> BatchRewardResult {
         // Verify authorization
         caller.require_auth();
         Self::require_admin(&env, &caller);
+
+        // Reject duplicate idempotency tokens before state changes.
+        let token_key = DataKey::IdempotencyToken(idempotency_token.clone());
+        if env.storage().persistent().has(&token_key) {
+            panic_with_error!(&env, BatchRewardsError::DuplicateRequest);
+        }
 
         // Validate batch size
         let request_count = rewards.len();
@@ -239,6 +249,9 @@ impl BatchRewardsContract {
         env.storage()
             .instance()
             .set(&DataKey::TotalBatches, &batch_id);
+
+        // Mark the idempotency token as used for this completed batch.
+        env.storage().persistent().set(&token_key, &true);
 
         let total_processed: u64 = env
             .storage()

--- a/contracts/batch-rewards/src/test.rs
+++ b/contracts/batch-rewards/src/test.rs
@@ -5,7 +5,7 @@
 use crate::{BatchRewardsContract, BatchRewardsContractClient, RewardRequest, RewardResult};
 use soroban_sdk::{
     testutils::{Address as _, Events as _, Ledger},
-    token, Address, Env, Vec,
+    token, Address, Bytes, Env, Vec,
 };
 
 /// Creates a test environment with the contract deployed and initialized.
@@ -41,6 +41,12 @@ fn setup_test_env() -> (
 /// Helper to create a reward request.
 fn create_reward_request(_env: &Env, recipient: Address, amount: i128) -> RewardRequest {
     RewardRequest { recipient, amount }
+}
+
+fn idempotency_token(env: &Env, seed: u8) -> Bytes {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    Bytes::from_array(env, &bytes)
 }
 
 // Initialization Tests
@@ -93,7 +99,7 @@ fn test_distribute_rewards_single_recipient() {
         reward_amount,
     ));
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 1), &rewards);
 
     assert_eq!(result.total_requests, 1);
     assert_eq!(result.successful, 1);
@@ -122,7 +128,7 @@ fn test_distribute_rewards_multiple_recipients() {
     rewards.push_back(create_reward_request(&env, recipient2.clone(), amount));
     rewards.push_back(create_reward_request(&env, recipient3.clone(), amount));
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 2), &rewards);
 
     assert_eq!(result.total_requests, 3);
     assert_eq!(result.successful, 3);
@@ -159,7 +165,7 @@ fn test_distribute_rewards_partial_failures() {
         invalid_amount,
     ));
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 3), &rewards);
 
     assert_eq!(result.total_requests, 2);
     assert_eq!(result.successful, 1);
@@ -187,7 +193,7 @@ fn test_distribute_rewards_accumulates_stats() {
     rewards.push_back(create_reward_request(&env, recipient1.clone(), amount));
     rewards.push_back(create_reward_request(&env, recipient2.clone(), amount));
 
-    let result1 = client.distribute_rewards(&admin, &token, &rewards);
+    let result1 = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 4), &rewards);
     assert_eq!(result1.total_distributed, amount * 2);
 
     // Check stats after first batch
@@ -200,7 +206,7 @@ fn test_distribute_rewards_accumulates_stats() {
     rewards.push_back(create_reward_request(&env, recipient1.clone(), amount));
     rewards.push_back(create_reward_request(&env, recipient2.clone(), amount));
 
-    let result2 = client.distribute_rewards(&admin, &token, &rewards);
+    let result2 = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 5), &rewards);
     assert_eq!(result2.total_distributed, amount * 2);
 
     // Check accumulated stats
@@ -226,7 +232,7 @@ fn test_distribute_rewards_large_batch() {
         rewards.push_back(create_reward_request(&env, recipient, amount));
     }
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 6), &rewards);
 
     assert_eq!(result.total_requests, batch_size);
     assert_eq!(result.successful, batch_size);
@@ -240,7 +246,7 @@ fn test_distribute_rewards_empty_batch() {
     let (env, admin, token, _token_client, client) = setup_test_env();
 
     let rewards: Vec<RewardRequest> = Vec::new(&env);
-    client.distribute_rewards(&admin, &token, &rewards);
+    client.distribute_rewards(&admin, &token, &idempotency_token(&env, 7), &rewards);
 }
 
 #[test]
@@ -261,7 +267,7 @@ fn test_distribute_rewards_batch_too_large() {
         rewards.push_back(create_reward_request(&env, recipient, amount));
     }
 
-    client.distribute_rewards(&admin, &token, &rewards);
+    client.distribute_rewards(&admin, &token, &idempotency_token(&env, 8), &rewards);
 }
 
 #[test]
@@ -278,7 +284,7 @@ fn test_distribute_rewards_insufficient_balance() {
     let mut rewards: Vec<RewardRequest> = Vec::new(&env);
     rewards.push_back(create_reward_request(&env, recipient, amount));
 
-    client.distribute_rewards(&admin, &token, &rewards);
+    client.distribute_rewards(&admin, &token, &idempotency_token(&env, 9), &rewards);
 }
 
 #[test]
@@ -295,7 +301,7 @@ fn test_distribute_rewards_unauthorized() {
     let mut rewards: Vec<RewardRequest> = Vec::new(&env);
     rewards.push_back(create_reward_request(&env, recipient, amount));
 
-    client.distribute_rewards(&unauthorized_caller, &token, &rewards);
+    client.distribute_rewards(&unauthorized_caller, &token, &idempotency_token(&env, 10), &rewards);
 }
 
 #[test]
@@ -310,7 +316,7 @@ fn test_distribute_rewards_events_emitted() {
     let mut rewards: Vec<RewardRequest> = Vec::new(&env);
     rewards.push_back(create_reward_request(&env, recipient.clone(), amount));
 
-    client.distribute_rewards(&admin, &token, &rewards);
+    client.distribute_rewards(&admin, &token, &idempotency_token(&env, 11), &rewards);
 
     // Verify events were emitted
     let events = env.events().all();
@@ -345,6 +351,24 @@ fn test_distribute_rewards_events_emitted() {
 }
 
 #[test]
+#[should_panic(expected = "DuplicateRequest")]
+fn test_duplicate_replay_is_rejected() {
+    let (env, admin, token, token_client, client) = setup_test_env();
+
+    let recipient = Address::generate(&env);
+    let amount: i128 = 10_000_000;
+
+    token_client.mint(&admin, &(amount * 2));
+
+    let mut rewards: Vec<RewardRequest> = Vec::new(&env);
+    rewards.push_back(create_reward_request(&env, recipient.clone(), amount));
+
+    let idempotency = idempotency_token(&env, 99);
+    client.distribute_rewards(&admin, &token, &idempotency, &rewards);
+    client.distribute_rewards(&admin, &token, &idempotency, &rewards);
+}
+
+#[test]
 fn test_distribute_rewards_with_zero_amount() {
     let (env, admin, token, token_client, client) = setup_test_env();
 
@@ -358,7 +382,7 @@ fn test_distribute_rewards_with_zero_amount() {
     rewards.push_back(create_reward_request(&env, recipient.clone(), valid_amount));
     rewards.push_back(create_reward_request(&env, recipient.clone(), zero_amount));
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 3), &rewards);
 
     assert_eq!(result.total_requests, 2);
     assert_eq!(result.successful, 1);
@@ -381,7 +405,7 @@ fn test_distribute_rewards_events_on_failure() {
         invalid_amount,
     ));
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 13), &rewards);
 
     assert_eq!(result.failed, 1);
 
@@ -412,7 +436,7 @@ fn test_distribute_rewards_result_structure() {
     rewards.push_back(create_reward_request(&env, recipient1.clone(), amount1));
     rewards.push_back(create_reward_request(&env, recipient2.clone(), amount2));
 
-    let result = client.distribute_rewards(&admin, &token, &rewards);
+    let result = client.distribute_rewards(&admin, &token, &idempotency_token(&env, 14), &rewards);
 
     // Verify result structure
     assert_eq!(result.total_requests, 2);
@@ -450,13 +474,14 @@ fn test_multiple_simultaneous_batch_distributions() {
     token_client.mint(&admin, &(amount * 30 + 10_000_000));
 
     // Execute 3 batches
-    for _batch in 0..3 {
+    for batch_index in 0..3 {
         let mut rewards: Vec<RewardRequest> = Vec::new(&env);
         for recipient in recipients.iter() {
             rewards.push_back(create_reward_request(&env, recipient.clone(), amount));
         }
 
-        let result = client.distribute_rewards(&admin, &token, &rewards);
+        let idempotency = idempotency_token(&env, (batch_index + 15) as u8);
+        let result = client.distribute_rewards(&admin, &token, &idempotency, &rewards);
         assert_eq!(result.successful, 10);
         assert_eq!(result.total_distributed, amount * 10);
     }

--- a/contracts/batch-rewards/src/test.rs
+++ b/contracts/batch-rewards/src/test.rs
@@ -301,7 +301,12 @@ fn test_distribute_rewards_unauthorized() {
     let mut rewards: Vec<RewardRequest> = Vec::new(&env);
     rewards.push_back(create_reward_request(&env, recipient, amount));
 
-    client.distribute_rewards(&unauthorized_caller, &token, &idempotency_token(&env, 10), &rewards);
+    client.distribute_rewards(
+        &unauthorized_caller,
+        &token,
+        &idempotency_token(&env, 10),
+        &rewards,
+    );
 }
 
 #[test]

--- a/contracts/batch-rewards/src/types.rs
+++ b/contracts/batch-rewards/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, symbol_short, Address, Env, Vec};
+use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Vec};
 
 pub const MAX_BATCH_SIZE: u32 = 100;
 
@@ -33,6 +33,7 @@ pub enum DataKey {
     TotalBatches,
     TotalRewardsProcessed,
     TotalVolumeDistributed,
+    IdempotencyToken(Bytes),
 }
 
 pub struct RewardEvents;

--- a/contracts/spending-limits/src/test.rs
+++ b/contracts/spending-limits/src/test.rs
@@ -10,6 +10,7 @@ use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     Address, Env, Symbol, Vec,
 };
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::types::{ErrorCode, LimitStrategy, LimitUpdateResult, SpendingLimitRequest};
 use alloc::format;
@@ -456,13 +457,22 @@ fn test_enforce_spending_limit_resets_after_window() {
     requests.push_back(request);
     client.batch_update_spending_limits(&admin, &requests);
 
-    // Use the starting window
+    // Use the starting window and consume the daily limit.
     env.ledger().set_timestamp(0);
     client.enforce_spending_limit(&user, &10, &None::<Symbol>);
 
-    // Advance past the configured reset window and verify the counter resets.
+    // Same-day extra spend should be blocked by the daily limit.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.enforce_spending_limit(&user, &1, &None::<Symbol>);
+    }));
+    assert!(result.is_err(), "Same-day spend above the daily limit should fail");
+
+    // Advance past the 24-hour window and verify the count resets.
     env.ledger().set_timestamp(86_401);
     client.enforce_spending_limit(&user, &10, &None::<Symbol>);
+
+    let limit = client.get_spending_limit(&user).unwrap();
+    assert_eq!(limit.current_spending, 20);
 }
 
 #[test]

--- a/contracts/spending-limits/src/test.rs
+++ b/contracts/spending-limits/src/test.rs
@@ -465,7 +465,10 @@ fn test_enforce_spending_limit_resets_after_window() {
     let result = catch_unwind(AssertUnwindSafe(|| {
         client.enforce_spending_limit(&user, &1, &None::<Symbol>);
     }));
-    assert!(result.is_err(), "Same-day spend above the daily limit should fail");
+    assert!(
+        result.is_err(),
+        "Same-day spend above the daily limit should fail"
+    );
 
     // Advance past the 24-hour window and verify the count resets.
     env.ledger().set_timestamp(86_401);


### PR DESCRIPTION
**Summary**

This PR introduces idempotency support for batch reward distribution to prevent duplicate rewards when a batch request is retried.

**Changes Made**

* Added idempotency token tracking in `contracts/batch-rewards/src/lib.rs`.
* Introduced idempotency-related types in `contracts/batch-rewards/src/types.rs`.
* Added tests to verify that duplicate batch reward requests are rejected while the initial request is processed successfully.

 **Why**

Without idempotency support, retrying a failed or timed-out batch reward request could distribute rewards multiple times. This implementation ensures each batch request is processed only once, improving the reliability and safety of reward distribution.

**Acceptance Criteria**

* ✅ Duplicate batch reward replay is rejected.
* ✅ First batch reward request succeeds normally.
* ✅ `cargo test -p batch-rewards` passes.
* ✅ CI checks pass before PR is merged.

closes #666 
