### PR TITLE
refactor: document user vs users crate distinction (#712)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "contracts/budget",
     "contracts/category-analytics",
     "contracts/spending-categories",
+    "contracts/user",
     "contracts/users",
     "contracts/transactional",
     "contracts/transactions",

--- a/contracts/user/Cargo.toml
+++ b/contracts/user/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "user"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Deprecated legacy stub — see contracts/users for the canonical implementation"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/user/src/lib.rs
+++ b/contracts/user/src/lib.rs
@@ -1,3 +1,11 @@
+//! # Deprecated — use the `users` crate instead
+//!
+//! This crate is a legacy stub that predates the full implementation in
+//! `contracts/users`. It exists for historical reference only and **must not**
+//! receive new features or be depended upon by other contracts.
+//!
+//! See `docs/user-vs-users-crates.md` for the authoritative decision record.
+
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Map};

--- a/docs/user-vs-users-crates.md
+++ b/docs/user-vs-users-crates.md
@@ -1,0 +1,82 @@
+# `user` vs `users` Crates — Distinction and Ownership
+
+## Summary
+
+Two crates exist under `contracts/` with overlapping names and similar surface areas:
+`contracts/user` and `contracts/users`. This document clarifies their roles, explains why
+both exist, and establishes which one owns user-related logic going forward.
+
+---
+
+## `contracts/users` — Canonical implementation ✅
+
+**This is the authoritative crate for all user-related logic.**
+
+| Feature | Status |
+|---|---|
+| Admin initialisation | ✅ |
+| `register_user` (idempotent, returns `bool`) | ✅ |
+| User count | ✅ |
+| Deactivate user | ✅ |
+| Profile update (currency, nickname) | ✅ |
+| Last-login timestamp | ✅ |
+| On-chain events | ✅ |
+| Dedicated `storage` module | ✅ |
+| Inline tests (`mod test`) | ✅ |
+
+### Key files
+- `contracts/users/src/lib.rs` — contract entry point and public API
+- `contracts/users/src/storage.rs` — all persistent storage helpers
+- `contracts/users/src/test.rs` — unit and integration tests
+
+**New features, bug-fixes, and cross-contract integrations should target this crate.**
+
+---
+
+## `contracts/user` — Legacy stub ⚠️ (deprecated)
+
+This crate is a minimal, early-stage stub that predates the full `users` implementation.
+
+| Feature | Status |
+|---|---|
+| `register_user` (panics on duplicate, no return value) | ✅ (limited) |
+| `user_exists` | ✅ |
+| Admin initialisation | ❌ |
+| Events | ❌ |
+| Storage module | ❌ |
+| Tests | ❌ |
+
+It uses a bare string constant (`"USERS"`) as a storage key and holds no profile data.
+
+**This crate is deprecated.** It is retained only for historical reference and must not
+receive new features or be depended upon by other contracts.
+
+---
+
+## Decision
+
+| Concern | Owner |
+|---|---|
+| Canonical user registry | `contracts/users` |
+| User profile data | `contracts/users` |
+| Cross-contract user checks | `contracts/users` |
+| Legacy reference only | `contracts/user` |
+
+### Why not delete `contracts/user` immediately?
+
+Deletion is out of scope for this issue (see issue #712 acceptance criteria: _no change to
+storage layout_). The stub crate is kept to avoid breaking any downstream reference that
+may still point to it. A follow-up issue should be raised to remove it once all dependents
+have been confirmed clear.
+
+---
+
+## How to test
+
+```bash
+# Canonical crate — must pass
+cargo test -p users
+
+# Legacy stub — must pass (existing behaviour preserved)
+cargo test -p user
+```


### PR DESCRIPTION
## Summary

Resolves the ambiguity between the `contracts/user` and `contracts/users` crates by documenting their distinction and marking the legacy stub as deprecated.

### Changes

- **`docs/user-vs-users-crates.md`** — New decision record that clearly establishes:
  - `contracts/users` is the **canonical** implementation (admin init, full profile, events, storage module, tests)
  - `contracts/user` is a **deprecated legacy stub** with no Cargo package, no tests, no profile data
- **`contracts/user/src/lib.rs`** — Added top-level deprecation notice pointing to the doc and to `contracts/users`
- **`contracts/user/Cargo.toml`** — Created so `cargo test -p user` works as required by the acceptance criteria
- **`Cargo.toml`** — Added `contracts/user` to the workspace members list

### Test results

```
cargo test -p user
running 0 tests
test result: ok. 0 passed; 0 failed  ✅
```

```
cargo test -p users
running 21 tests
test result: FAILED. 10 passed; 11 failed
```

The 11 failures in `users` are **pre-existing on `main`** (auth/storage setup issues in the existing test suite). Verified by running `cargo test -p users` on the unmodified `main` branch — identical failures. No new failures introduced by this PR.

Closes #712