### PR TITLE
Clarify fee escrow vs standalone escrow crate

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,7 +1,14 @@
-//! # Escrow Contract with Batch Reversal
+//! # Standalone Escrow Contract
 //!
-//! This contract provides escrow functionality with batch reversal capabilities
-//! for handling failed transactions.
+//! ╔══════════════════════════════════════════════════════════════════════╗
+//! ║  This is the REAL escrow contract for individual depositor↔recipient║
+//! ║  escrows. The Fee crate (`contracts/fee/src/escrow.rs`) has an      ║
+//! ║  **internal** module that shares the "escrow" name but only tracks  ║
+//! ║  pooled fee collection — it is NOT an escrow contract.              ║
+//! ╚══════════════════════════════════════════════════════════════════════╝
+//!
+//! This contract provides per-escrow lifecycle management (create, release,
+//! reverse) with batch operations and full event emission.
 #![no_std]
 
 mod types;

--- a/contracts/fee/src/escrow.rs
+++ b/contracts/fee/src/escrow.rs
@@ -1,3 +1,36 @@
+//! # Fee Escrow — Internal Bookkeeping Module
+//!
+//! ╔══════════════════════════════════════════════════════════════════════╗
+//! ║  THIS IS NOT A REAL ESCROW CONTRACT                                ║
+//! ║  See `contracts/escrow/src/lib.rs` for the standalone escrow       ║
+//! ║  contract that manages individual depositor↔recipient escrows.     ║
+//! ╚══════════════════════════════════════════════════════════════════════╝
+//!
+//! This module is **internal** to the Fee contract (`crate::escrow`). It
+//! provides pooled fee-collection bookkeeping, **not** per-party escrows.
+//!
+//! ## What it does
+//!
+//! - `collect_to_escrow` / `collect_batch_to_escrow` — transfer tokens from
+//!   a payer into the Fee contract and increment internal counters
+//!   (`escrow_balance`, `pending_fees` per cycle, `total_collected`).
+//! - `release_cycle_fees` — sweep a cycle's pending fees to the treasury
+//!   and decrement `escrow_balance`.
+//! - `rollover_cycle_fees` — carry forward pending fees to a later cycle.
+//!
+//! ## Relationship to `contracts/escrow`
+//!
+//! | Aspect              | Fee escrow (this module)      | Standalone escrow crate       |
+//! |---------------------|-------------------------------|-------------------------------|
+//! | Scope               | Internal Fee contract module  | Deployable Soroban contract   |
+//! | Granularity         | Pooled (one balance counter)  | Per-escrow records            |
+//! | Parties             | Payer → Fee treasury          | Depositor → Recipient         |
+//! | Reversal            | No individual reversal        | Batch release/reversal        |
+//! | Lifecycle tracking  | Per-cycle pending fees only   | Per-escrow status (Active/…)  |
+//!
+//! The two are **independent** — the Fee contract never imports or calls
+//! the standalone escrow crate, and vice versa.
+
 use shared::utils::validate_amount as validate_non_negative_amount;
 use soroban_sdk::{panic_with_error, token, Address, Env, Vec};
 

--- a/contracts/fee/src/test.rs
+++ b/contracts/fee/src/test.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     testutils::{Address as _, Events},
-    Address, Env, IntoVal, String, Symbol,
+    token, Address, Env, IntoVal, String, Symbol,
 };
 
 use crate::{
@@ -278,4 +278,169 @@ fn test_collect_fee_batch_zero_amount_panics() {
     let payer = Address::generate(&env);
     let amounts = soroban_sdk::vec![&env, 100, 0, 200];
     client.collect_fee_batch(&payer, &amounts);
+}
+
+// ─── Fee escrow lifecycle tests ───────────────────────────────────────────
+//
+// These tests verify the **internal fee-escrow bookkeeping** in
+// `contracts/fee/src/escrow.rs`.  The tracked balance (`escrow_balance`)
+// represents pooled fees awaiting release to the treasury.  This is
+// **not** related to the standalone escrow contract at
+// `contracts/escrow/src/lib.rs`, which manages individual depositor↔recipient
+// escrows.
+
+fn setup_with_real_token() -> (Env, Address, token::Client<'static>, token::StellarAssetClient<'static>, FeeContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    // Deploy a real token contract so token transfers actually work
+    let issuer = Address::generate(&env);
+    let stellar_asset = env.register_stellar_asset_contract_v2(issuer.clone());
+    let token_id = stellar_asset.address();
+    let token_client = token::Client::new(&env, &token_id);
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+
+    let contract_id = env.register(FeeContract, ());
+    let client = FeeContractClient::new(&env, &contract_id);
+    client.initialize(&admin, &token_id, &treasury, &500u32, &1u64);
+
+    (env, admin, token_client, token_admin_client, client)
+}
+
+#[test]
+fn test_fee_escrow_collect_tracks_balance() {
+    let (env, _admin, token_client, token_admin, client) = setup_with_real_token();
+
+    let payer = Address::generate(&env);
+    let amount: i128 = 10_000_000;
+
+    // Mint tokens to payer
+    token_admin.mint(&payer, &amount);
+
+    // Initial balance should be zero
+    assert_eq!(client.get_escrow_balance(), 0);
+    assert_eq!(client.get_total_collected(), 0);
+    assert_eq!(client.get_pending_fees(&1), 0);
+
+    // Collect fee — the fee contract transfers tokens from payer to itself
+    // and records the amount in escrow_balance / pending_fees / total_collected
+    let pending = client.collect_fee(&payer, &amount);
+
+    // Payer's tokens moved to the fee contract
+    assert_eq!(token_client.balance(&payer), 0);
+    assert_eq!(token_client.balance(&client.address), amount);
+
+    // Internal bookkeeping updated
+    assert_eq!(client.get_escrow_balance(), amount);
+    assert_eq!(client.get_total_collected(), amount);
+    assert_eq!(pending, amount);
+    assert_eq!(client.get_pending_fees(&1), amount);
+}
+
+#[test]
+fn test_fee_escrow_release_decreases_balance() {
+    let (env, admin, token_client, token_admin, client) = setup_with_real_token();
+
+    let payer = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let amount: i128 = 10_000_000;
+
+    // Override treasury for verification
+    client.set_treasury(&admin, &treasury);
+
+    token_admin.mint(&payer, &amount);
+    client.collect_fee(&payer, &amount);
+
+    assert_eq!(client.get_escrow_balance(), amount);
+
+    // Release cycle 1 — tokens go to treasury, escrow_balance decremented
+    let released = client.release_fees(&admin, &1);
+    assert_eq!(released, amount);
+
+    assert_eq!(client.get_escrow_balance(), 0);
+    assert_eq!(client.get_total_released(), amount);
+    assert_eq!(client.get_pending_fees(&1), 0);
+    assert_eq!(token_client.balance(&treasury), amount);
+    assert_eq!(token_client.balance(&client.address), 0);
+}
+
+#[test]
+fn test_fee_escrow_rollover_moves_pending() {
+    let (env, admin, token_client, token_admin, client) = setup_with_real_token();
+
+    let payer = Address::generate(&env);
+    let amount: i128 = 5_000_000;
+
+    token_admin.mint(&payer, &amount);
+    client.collect_fee(&payer, &amount);
+
+    assert_eq!(client.get_pending_fees(&1), amount);
+
+    // Roll cycle 1 → 5
+    let rolled = client.rollover_fees(&admin, &5);
+    assert_eq!(rolled, amount);
+
+    assert_eq!(client.get_current_cycle(), 5);
+    assert_eq!(client.get_pending_fees(&1), 0);
+    assert_eq!(client.get_pending_fees(&5), amount);
+
+    // escrow_balance is unchanged (tokens still in contract)
+    assert_eq!(client.get_escrow_balance(), amount);
+}
+
+#[test]
+fn test_fee_escrow_batch_collect_tracks_balance() {
+    let (env, _admin, token_client, token_admin, client) = setup_with_real_token();
+
+    let payer = Address::generate(&env);
+    let amounts = soroban_sdk::vec![&env, 1_000_000i128, 2_000_000, 3_000_000];
+    let total: i128 = 6_000_000;
+
+    token_admin.mint(&payer, &total);
+    let result = client.collect_fee_batch(&payer, &amounts);
+
+    assert_eq!(result.total_amount, total);
+    assert_eq!(result.batch_size, 3);
+    assert_eq!(result.cycle, 1);
+
+    assert_eq!(token_client.balance(&client.address), total);
+    assert_eq!(client.get_escrow_balance(), total);
+    assert_eq!(client.get_total_collected(), total);
+    assert_eq!(client.get_pending_fees(&1), total);
+    assert_eq!(client.get_total_batch_calls(), 1);
+}
+
+#[test]
+fn test_fee_escrow_multiple_cycles_independent() {
+    let (env, admin, token_client, token_admin, client) = setup_with_real_token();
+
+    let payer1 = Address::generate(&env);
+    let payer2 = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    client.set_treasury(&admin, &treasury);
+
+    // Cycle 1: collect 5_000_000
+    token_admin.mint(&payer1, &5_000_000);
+    client.collect_fee(&payer1, &5_000_000);
+
+    // Roll to cycle 2
+    client.rollover_fees(&admin, &2);
+
+    // Cycle 2: collect 3_000_000
+    token_admin.mint(&payer2, &3_000_000);
+    client.collect_fee(&payer2, &3_000_000);
+
+    // Cycle 2 has 3_000_000, cycle 1 has 0 (rolled to 2)
+    assert_eq!(client.get_pending_fees(&1), 0);
+    assert_eq!(client.get_pending_fees(&2), 8_000_000);
+    assert_eq!(client.get_escrow_balance(), 8_000_000);
+
+    // Release only cycle 2
+    let released = client.release_fees(&admin, &2);
+    assert_eq!(released, 8_000_000);
+    assert_eq!(client.get_escrow_balance(), 0);
+    assert_eq!(token_client.balance(&treasury), 8_000_000);
 }


### PR DESCRIPTION
## Summary

Clarify the relationship between `contracts/fee/src/escrow.rs` (an internal bookkeeping module) and `contracts/escrow/src/lib.rs` (a deployable Soroban contract). Despite sharing the "escrow" name, these are **independent** code paths with fundamentally different purposes.

## Changes

### Documentation
- **`contracts/fee/src/escrow.rs`**: Added a module-level doc comment explaining this is pooled fee-collection bookkeeping, not a real escrow. Includes a comparison table vs the standalone crate.
- **`contracts/escrow/src/lib.rs`**: Added a module-level doc comment cross-referencing the fee crate's internal module to prevent confusion.

### Tests (5 new)
- `test_fee_escrow_collect_tracks_balance` — collect fee, verify `escrow_balance`, `total_collected`, `pending_fees` increment
- `test_fee_escrow_release_decreases_balance` — release to treasury, verify counters decrement and tokens arrive
- `test_fee_escrow_rollover_moves_pending` — rollover preserves `escrow_balance`, moves `pending_fees` between cycles
- `test_fee_escrow_batch_collect_tracks_balance` — batch collect updates all counters correctly
- `test_fee_escrow_multiple_cycles_independent` — per-cycle accounting is independent after rollover

### No logic duplication
Both code paths were audited and serve distinct roles:
| Aspect | Fee escrow (this module) | Standalone escrow crate |
|---|---|---|
| Scope | Internal Fee contract module | Deployable Soroban contract |
| Granularity | Pooled (one balance counter) | Per-escrow records |
| Parties | Payer → Fee treasury | Depositor → Recipient |
| Reversal | No individual reversal | Batch release/reversal |
| Lifecycle tracking | Per-cycle pending fees only | Per-escrow status (Active/…) |

## Testing
```
cargo test -p fee
cargo test -p escrow
```

Closes #720