### PR TITLE
feat(batch-payment): add ReceiptEvent payload and emit receipt topic …

### DIFF
--- a/contracts/batch-payment/src/lib.rs
+++ b/contracts/batch-payment/src/lib.rs
@@ -3,7 +3,7 @@
 mod test;
 mod types;
 
-use crate::types::Payment;
+use crate::types::{Payment, ReceiptEvent};
 use shared::utils::generate_transaction_reference_id;
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Symbol, Vec};
 
@@ -77,6 +77,18 @@ impl BatchPaymentContract {
             batch_reference_id.clone(),
         );
         env.events().publish(topics, (count, total_amount));
+
+        // Emit receipt event for off-chain reconciliation
+        env.events().publish(
+            (symbol_short!("receipt"),),
+            ReceiptEvent {
+                batch_reference_id: batch_reference_id.clone(),
+                token: token.clone(),
+                from: from.clone(),
+                total_payments: count,
+                total_amount,
+            },
+        );
 
         batch_reference_id
     }

--- a/contracts/batch-payment/src/test.rs
+++ b/contracts/batch-payment/src/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events},
-    Address, Env, Vec,
+    Address, Env, Symbol, Vec,
 };
 
 #[test]
@@ -64,17 +64,13 @@ fn test_batch_transfer() {
     assert_eq!(token_client.balance(&user2), 200);
     std::println!("Balances OK");
 
-    // Test direct event emission
-    env.events().publish((1,), 2);
-    std::println!("Direct event emitted");
-
-    // Verify events
+    // Verify receipt event was emitted
     let events = env.events().all();
-    std::println!("EVENTS: {:?}", events);
-
-    // We expect at least the direct event + contract events + token events
-    // assert!(events.len() > 0);
-    std::println!("Balances verified. Skipping event assertion due to SDK behavior.");
+    let receipt_topic = Symbol::new(&env, "receipt");
+    let receipt_found = events.iter().any(|event| {
+        event.topics.get(0).map_or(false, |topic| topic == receipt_topic.clone().into())
+    });
+    assert!(receipt_found, "Receipt event should be emitted after successful batch payment");
 }
 
 #[test]

--- a/contracts/batch-payment/src/types.rs
+++ b/contracts/batch-payment/src/types.rs
@@ -1,10 +1,20 @@
-use soroban_sdk::{contracttype, Address};
+use soroban_sdk::{contracttype, Address, String};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Payment {
     pub recipient: Address,
     pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReceiptEvent {
+    pub batch_reference_id: String,
+    pub token: Address,
+    pub from: Address,
+    pub total_payments: u32,
+    pub total_amount: i128,
 }
 
 use crate::storage::{bump_instance, DataKey};


### PR DESCRIPTION
Closes #665

# Features: Introduce `ReceiptEvent` for Off-Chain Reconciliation

## Overview
This PR introduces a self-contained `ReceiptEvent` to the `batch-payment` contract. This new event provides off-chain tracking and accounting systems with a consolidated summary of an entire completed batch, eliminating the need to parse and reconstruct data from multiple individual payment events.

---

## Changes

###  Smart Contract Modifications

#### `contracts/batch-payment/src/types.rs`
* Added the `ReceiptEvent` struct with the following fields:
  * `batch_reference_id`
  * `token`
  * `from`
  * `total_payments`
  * `total_amount`
* Updated codebase imports to include `String`.

#### `contracts/batch-payment/src/lib.rs`
* Triggered a `ReceiptEvent` emission immediately following the existing batch completion logic.
* Configured the event with the topic `symbol_short!("receipt")` to carry the full receipt payload.

---

###  Testing & Quality Assurance

#### `contracts/batch-payment/src/test.rs`
* Removed legacy placeholder event debug code.
* Implemented proper test assertions that scan all emitted contract events specifically for the `"receipt"` topic.
* Updated test imports to include `Symbol`.

### How to Run Tests
Verify the contract changes locally by executing:
```bash
cargo test -p batch-payment