### PR TITLE
feat(allowances): create allowances contract with weekly and monthly recurring support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "contracts/benchmarks",
     "contracts/zk-verifier",
     "contracts/pausable",
+    "contracts/allowances",
 ]
 
 [package]

--- a/contracts/allowances/Cargo.toml
+++ b/contracts/allowances/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "allowances"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -1,0 +1,285 @@
+//! # Allowances Contract
+//!
+//! Manages recurring spending allowances on Stellar/Soroban.
+//!
+//! ## Issues resolved
+//! - #822 Create Allowance Contract — storage schema + contract scaffold
+//! - #823 Add Allowance Creation    — `create_allowance` with event emission
+//! - #824 Implement Weekly Allowances  — `Frequency::Weekly` (7-day interval)
+//! - #825 Implement Monthly Allowances — `Frequency::Monthly` (30-day interval)
+//!
+//! ## Features
+//!
+//! - **`create_allowance`** — owner defines recipient, token, amount, and
+//!   frequency (`Once` / `Weekly` / `Monthly`).
+//! - **`distribute`** — anyone triggers a due distribution; tokens are
+//!   transferred from owner to recipient via `token::Client::transfer_from`.
+//! - **`cancel_allowance`** — owner deactivates the allowance.
+//! - **Query helpers** — `get_allowance`, `get_owner_allowances`,
+//!   `get_recipient_allowances`.
+
+#![no_std]
+
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, symbol_short, token, Address, Env, Vec,
+};
+
+use types::{AllowanceError, Allowance, DataKey, Frequency};
+
+/// Allowance contract.
+#[contract]
+pub struct AllowancesContract;
+
+#[contractimpl]
+impl AllowancesContract {
+    // ── Creation ──────────────────────────────────────────────────────────
+
+    /// Creates a new allowance.
+    ///
+    /// # Arguments
+    /// * `owner`      — Address funding the allowance (must authorize).
+    /// * `recipient`  — Address entitled to receive distributions.
+    /// * `token`      — Token contract for the distribution.
+    /// * `amount`     — Tokens transferred per distribution (must be > 0).
+    /// * `frequency`  — `Once`, `Weekly`, or `Monthly`.
+    /// * `start_time` — Ledger timestamp of the first allowed distribution.
+    ///
+    /// # Returns
+    /// The unique allowance ID.
+    ///
+    /// # Events
+    /// Emits `("allow", "created", id)` → `(owner, recipient, amount, frequency_tag)`.
+    pub fn create_allowance(
+        env: Env,
+        owner: Address,
+        recipient: Address,
+        token: Address,
+        amount: i128,
+        frequency: Frequency,
+        start_time: u64,
+    ) -> u64 {
+        owner.require_auth();
+
+        if amount <= 0 {
+            panic_with_error!(&env, AllowanceError::InvalidAmount);
+        }
+
+        // Validate frequency (Once is always valid; recurring must have a
+        // positive interval, which is guaranteed by the enum itself).
+        let _ = frequency.interval_seconds(); // no-op check, satisfies future extensibility
+
+        let mut count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllowanceCount)
+            .unwrap_or(0);
+        count += 1;
+
+        let allowance = Allowance {
+            owner: owner.clone(),
+            recipient: recipient.clone(),
+            token,
+            amount,
+            frequency: frequency.clone(),
+            next_distribution: start_time,
+            distribution_count: 0,
+            active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Allowance(count), &allowance);
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowanceCount, &count);
+
+        // Update owner index
+        let mut owner_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerAllowances(owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        owner_ids.push_back(count);
+        env.storage()
+            .persistent()
+            .set(&DataKey::OwnerAllowances(owner.clone()), &owner_ids);
+
+        // Update recipient index
+        let mut recip_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecipientAllowances(recipient.clone()))
+            .unwrap_or(Vec::new(&env));
+        recip_ids.push_back(count);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecipientAllowances(recipient.clone()), &recip_ids);
+
+        // Emit creation event
+        let freq_tag = match &frequency {
+            Frequency::Once => symbol_short!("once"),
+            Frequency::Weekly => symbol_short!("weekly"),
+            Frequency::Monthly => symbol_short!("monthly"),
+        };
+        env.events().publish(
+            (symbol_short!("allow"), symbol_short!("created"), count),
+            (owner, recipient, amount, freq_tag),
+        );
+
+        count
+    }
+
+    // ── Distribution ──────────────────────────────────────────────────────
+
+    /// Executes a due distribution for the given allowance.
+    ///
+    /// Callable by anyone once `env.ledger().timestamp() >= next_distribution`.
+    /// For recurring allowances (`Weekly` / `Monthly`) the next distribution
+    /// window is advanced automatically after each successful transfer.
+    ///
+    /// Requires that the owner has pre-approved the contract via the token's
+    /// `approve` method so `transfer_from` can be used trustlessly.
+    ///
+    /// # Events
+    /// Emits `("allow", "distrib", id)` → `(recipient, amount, next_distribution)`.
+    pub fn distribute(env: Env, allowance_id: u64) {
+        let mut allowance: Allowance = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+
+        if !allowance.active {
+            panic_with_error!(&env, AllowanceError::AlreadyInactive);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < allowance.next_distribution {
+            panic_with_error!(&env, AllowanceError::TooEarlyToDistribute);
+        }
+
+        // Transfer tokens from owner → recipient.
+        let token_client = token::Client::new(&env, &allowance.token);
+        let owner_balance = token_client.balance(&allowance.owner);
+        if owner_balance < allowance.amount {
+            panic_with_error!(&env, AllowanceError::InsufficientBalance);
+        }
+
+        // Owner must have pre-approved this contract as spender.
+        token_client.transfer_from(
+            &env.current_contract_address(),
+            &allowance.owner,
+            &allowance.recipient,
+            &allowance.amount,
+        );
+
+        allowance.distribution_count += 1;
+
+        // Advance schedule or deactivate for one-time allowances.
+        match allowance.frequency.interval_seconds() {
+            None => {
+                // Once — mark inactive after first distribution.
+                allowance.active = false;
+                allowance.next_distribution = 0;
+            }
+            Some(interval) => {
+                // Recurring — skip missed cycles and move forward.
+                allowance.next_distribution += interval;
+                if allowance.next_distribution <= now {
+                    let missed = (now - allowance.next_distribution) / interval;
+                    allowance.next_distribution += (missed + 1) * interval;
+                }
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Allowance(allowance_id), &allowance);
+
+        env.events().publish(
+            (
+                symbol_short!("allow"),
+                symbol_short!("distrib"),
+                allowance_id,
+            ),
+            (
+                allowance.recipient,
+                allowance.amount,
+                allowance.next_distribution,
+            ),
+        );
+    }
+
+    // ── Cancellation ──────────────────────────────────────────────────────
+
+    /// Cancels an active allowance.  Only the owner may cancel.
+    ///
+    /// # Events
+    /// Emits `("allow", "canceled", id)` → `owner`.
+    pub fn cancel_allowance(env: Env, allowance_id: u64) {
+        let mut allowance: Allowance = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+
+        allowance.owner.require_auth();
+
+        if !allowance.active {
+            panic_with_error!(&env, AllowanceError::AlreadyInactive);
+        }
+
+        allowance.active = false;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Allowance(allowance_id), &allowance);
+
+        env.events().publish(
+            (
+                symbol_short!("allow"),
+                symbol_short!("canceled"),
+                allowance_id,
+            ),
+            allowance.owner,
+        );
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────
+
+    /// Returns the full record for an allowance.
+    pub fn get_allowance(env: Env, allowance_id: u64) -> Allowance {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound))
+    }
+
+    /// Returns all allowance IDs created by `owner`.
+    pub fn get_owner_allowances(env: Env, owner: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::OwnerAllowances(owner))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns all allowance IDs where `recipient` is the beneficiary.
+    pub fn get_recipient_allowances(env: Env, recipient: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecipientAllowances(recipient))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns the total number of allowances ever created.
+    pub fn allowance_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::AllowanceCount)
+            .unwrap_or(0)
+    }
+}

--- a/contracts/allowances/src/test.rs
+++ b/contracts/allowances/src/test.rs
@@ -1,0 +1,313 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, Ledger as _},
+    token::{StellarAssetClient, TokenClient},
+    Address, Env,
+};
+
+use crate::{AllowancesContract, AllowancesContractClient};
+use crate::types::{AllowanceError, Frequency};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Spin up the contract + a SAC token, mint `initial_balance` to `owner`,
+/// and approve the contract to spend on behalf of `owner`.
+fn setup(
+    initial_balance: i128,
+) -> (
+    Env,
+    AllowancesContractClient<'static>,
+    Address, // owner
+    Address, // recipient
+    Address, // token
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(AllowancesContract, ());
+    let client = AllowancesContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_id = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Fund owner
+    StellarAssetClient::new(&env, &token_id).mint(&owner, &initial_balance);
+
+    // Approve contract to transfer on behalf of owner (large ledger approval)
+    TokenClient::new(&env, &token_id).approve(
+        &owner,
+        &contract_id,
+        &initial_balance,
+        &(env.ledger().sequence() + 10_000),
+    );
+
+    (env, client, owner, recipient, token_id)
+}
+
+// ── Storage schema / contract deploy (#822) ───────────────────────────────────
+
+#[test]
+fn contract_deploys_and_count_starts_at_zero() {
+    let (env, client, _, _, _) = setup(1_000);
+    assert_eq!(client.allowance_count(), 0, "fresh contract must start at 0");
+    let _ = env;
+}
+
+// ── create_allowance (#823) ────────────────────────────────────────────────────
+
+#[test]
+fn create_allowance_increments_count() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    assert_eq!(id, 1);
+    assert_eq!(client.allowance_count(), 1);
+}
+
+#[test]
+fn create_allowance_stores_correct_fields() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &250, &Frequency::Weekly, &now);
+    let a = client.get_allowance(&id);
+
+    assert_eq!(a.owner, owner);
+    assert_eq!(a.recipient, recipient);
+    assert_eq!(a.token, token);
+    assert_eq!(a.amount, 250);
+    assert!(matches!(a.frequency, Frequency::Weekly));
+    assert_eq!(a.next_distribution, now);
+    assert_eq!(a.distribution_count, 0);
+    assert!(a.active);
+}
+
+#[test]
+fn create_allowance_emits_created_event() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+
+    let events = env.events().all();
+    // At least one event should have been emitted
+    assert!(!events.is_empty(), "expected at least one event");
+    let _ = id;
+}
+
+#[test]
+fn create_allowance_rejects_zero_amount() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let err = client
+        .try_create_allowance(&owner, &recipient, &token, &0, &Frequency::Once, &now)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::InvalidAmount.into());
+}
+
+#[test]
+fn create_allowance_rejects_negative_amount() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let err = client
+        .try_create_allowance(&owner, &recipient, &token, &-1, &Frequency::Once, &now)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::InvalidAmount.into());
+}
+
+#[test]
+fn owner_and_recipient_indices_are_populated() {
+    let (env, client, owner, recipient, token) = setup(2_000);
+    let now = env.ledger().timestamp();
+
+    let id1 = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    let id2 = client.create_allowance(&owner, &recipient, &token, &200, &Frequency::Weekly, &now);
+
+    let owner_ids = client.get_owner_allowances(&owner);
+    assert!(owner_ids.contains(&id1));
+    assert!(owner_ids.contains(&id2));
+
+    let recip_ids = client.get_recipient_allowances(&recipient);
+    assert!(recip_ids.contains(&id1));
+    assert!(recip_ids.contains(&id2));
+}
+
+// ── Weekly distribution (#824) ────────────────────────────────────────────────
+
+#[test]
+fn weekly_distribution_transfers_tokens() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_allowance(&owner, &recipient, &token, &300, &Frequency::Weekly, &now);
+
+    // Move ledger past the first weekly window
+    env.ledger().with_mut(|l| l.timestamp = now + 604_800 + 1);
+
+    client.distribute(&id);
+
+    assert_eq!(token_client.balance(&recipient), 300);
+    assert_eq!(token_client.balance(&owner), 700);
+
+    let a = client.get_allowance(&id);
+    assert_eq!(a.distribution_count, 1);
+    assert!(a.active, "weekly allowance must stay active after one distribution");
+    // Next window should be ~2 weeks from start
+    assert!(a.next_distribution > now + 604_800);
+}
+
+#[test]
+fn weekly_interval_is_604800_seconds() {
+    assert_eq!(Frequency::Weekly.interval_seconds(), Some(604_800));
+}
+
+#[test]
+fn weekly_distribute_too_early_is_rejected() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &(now + 10_000));
+
+    let err = client
+        .try_distribute(&id)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::TooEarlyToDistribute.into());
+}
+
+// ── Monthly distribution (#825) ───────────────────────────────────────────────
+
+#[test]
+fn monthly_distribution_transfers_tokens() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_allowance(&owner, &recipient, &token, &500, &Frequency::Monthly, &now);
+
+    // Move ledger past the first monthly window
+    env.ledger().with_mut(|l| l.timestamp = now + 2_592_000 + 1);
+
+    client.distribute(&id);
+
+    assert_eq!(token_client.balance(&recipient), 500);
+    assert_eq!(token_client.balance(&owner), 500);
+
+    let a = client.get_allowance(&id);
+    assert_eq!(a.distribution_count, 1);
+    assert!(a.active, "monthly allowance must stay active after one distribution");
+    assert!(a.next_distribution > now + 2_592_000);
+}
+
+#[test]
+fn monthly_interval_is_2592000_seconds() {
+    assert_eq!(Frequency::Monthly.interval_seconds(), Some(2_592_000));
+}
+
+#[test]
+fn monthly_distribute_too_early_is_rejected() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    // Start 30 days in the future
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Monthly, &(now + 2_592_000));
+
+    let err = client
+        .try_distribute(&id)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::TooEarlyToDistribute.into());
+}
+
+// ── Once frequency ────────────────────────────────────────────────────────────
+
+#[test]
+fn once_allowance_deactivates_after_distribution() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    client.distribute(&id);
+
+    let a = client.get_allowance(&id);
+    assert!(!a.active, "Once allowance must be inactive after distribution");
+}
+
+#[test]
+fn once_interval_is_none() {
+    assert_eq!(Frequency::Once.interval_seconds(), None);
+}
+
+// ── Cancellation ──────────────────────────────────────────────────────────────
+
+#[test]
+fn cancel_allowance_deactivates_it() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+    client.cancel_allowance(&id);
+
+    let a = client.get_allowance(&id);
+    assert!(!a.active);
+}
+
+#[test]
+fn cancel_already_inactive_returns_error() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    client.distribute(&id); // deactivates it
+
+    let err = client
+        .try_cancel_allowance(&id)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::AlreadyInactive.into());
+}
+
+#[test]
+fn distribute_inactive_allowance_returns_error() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+    client.cancel_allowance(&id);
+
+    let err = client
+        .try_distribute(&id)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::AlreadyInactive.into());
+}
+
+#[test]
+fn distribute_nonexistent_returns_error() {
+    let (_env, client, ..) = setup(1_000);
+
+    let err = client
+        .try_distribute(&999)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::NotFound.into());
+}

--- a/contracts/allowances/src/types.rs
+++ b/contracts/allowances/src/types.rs
@@ -1,0 +1,82 @@
+use soroban_sdk::{contracttype, Address};
+
+/// How often an allowance is distributed.
+///
+/// Seconds per period:
+/// - `Weekly`  → 7 × 24 × 60 × 60 = 604 800 s
+/// - `Monthly` → 30 × 24 × 60 × 60 = 2 592 000 s  (approximate calendar month)
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Frequency {
+    /// Once-off — no automatic recurrence.
+    Once,
+    /// Repeats every 7 days (604 800 seconds).
+    Weekly,
+    /// Repeats every 30 days (2 592 000 seconds).
+    Monthly,
+}
+
+impl Frequency {
+    /// Returns the interval in seconds, or `None` for `Once`.
+    pub fn interval_seconds(&self) -> Option<u64> {
+        match self {
+            Frequency::Once => None,
+            Frequency::Weekly => Some(604_800),
+            Frequency::Monthly => Some(2_592_000),
+        }
+    }
+}
+
+/// A recurring (or one-time) spending allowance record.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Allowance {
+    /// The address that created and funds the allowance.
+    pub owner: Address,
+    /// The address entitled to spend / claim the allowance.
+    pub recipient: Address,
+    /// Token contract address used for distributions.
+    pub token: Address,
+    /// Amount transferred on each distribution.
+    pub amount: i128,
+    /// Recurrence schedule.
+    pub frequency: Frequency,
+    /// Ledger timestamp of the next allowed distribution.
+    pub next_distribution: u64,
+    /// Total number of successful distributions so far.
+    pub distribution_count: u64,
+    /// Whether the allowance is still active.
+    pub active: bool,
+}
+
+/// Persistent storage keys for the allowances contract.
+#[contracttype]
+pub enum DataKey {
+    /// Total number of allowances created (monotonic counter → unique IDs).
+    AllowanceCount,
+    /// Per-allowance record keyed by ID.
+    Allowance(u64),
+    /// Index: list of allowance IDs owned by an address.
+    OwnerAllowances(Address),
+    /// Index: list of allowance IDs a recipient is entitled to.
+    RecipientAllowances(Address),
+}
+
+/// Error codes returned by the allowances contract.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum AllowanceError {
+    NotFound = 1,
+    Unauthorized = 2,
+    InvalidAmount = 3,
+    InvalidInterval = 4,
+    AlreadyInactive = 5,
+    TooEarlyToDistribute = 6,
+    InsufficientBalance = 7,
+}
+
+impl From<AllowanceError> for soroban_sdk::Error {
+    fn from(e: AllowanceError) -> Self {
+        soroban_sdk::Error::from_contract_error(e as u32)
+    }
+}


### PR DESCRIPTION
Closes #822
Closes #823
Closes #824
Closes #825

## Summary

Adds a new `contracts/allowances/` Soroban crate that implements recurring spending allowances, resolving all four related issues in a single cohesive module.

### #822 — Create Allowance Contract

- New crate at `contracts/allowances/` registered in the workspace `Cargo.toml`
- `src/types.rs` defines the full storage schema:
  - `Allowance` struct: `owner`, `recipient`, `token`, `amount`, `frequency`, `next_distribution`, `distribution_count`, `active`
  - `DataKey` enum: `AllowanceCount`, `Allowance(u64)`, `OwnerAllowances(Address)`, `RecipientAllowances(Address)`
  - `Frequency` enum: `Once`, `Weekly`, `Monthly`
  - `AllowanceError` codes with `From<AllowanceError> for soroban_sdk::Error`
- Contract deploys successfully with initial count of 0

### #823 — Add Allowance Creation

- `create_allowance(owner, recipient, token, amount, frequency, start_time) → u64`
  - Owner must authorize
  - Rejects `amount <= 0`
  - Stores the full `Allowance` record in persistent storage
  - Maintains per-owner and per-recipient index `Vec<u64>` for easy lookup
  - Emits `("allow", "created", id)` event with `(owner, recipient, amount, freq_tag)`

### #824 — Implement Weekly Allowances

- `Frequency::Weekly` maps to a 604 800-second (7-day) interval
- `distribute(allowance_id)` — callable by anyone once `now >= next_distribution`
  - Transfers `amount` from owner to recipient via `token::Client::transfer_from`
  - Advances `next_distribution` by one week; catches up missed cycles
  - Allowance stays `active` for continued weekly payments

### #825 — Implement Monthly Allowances

- `Frequency::Monthly` maps to a 2 592 000-second (30-day) interval
- Same `distribute` path as weekly, with 30-day window advancement
- Missed-cycle catch-up logic identical to weekly

## Additional

- `cancel_allowance` — owner-only deactivation
- `Frequency::Once` — deactivates automatically after the first distribution
- Query helpers: `get_allowance`, `get_owner_allowances`, `get_recipient_allowances`, `allowance_count`

## Testing

19 unit tests — all pass (`cargo test -p allowances`):
- Contract deploys, count starts at zero
- `create_allowance` stores correct fields, increments count, emits event, rejects invalid amounts
- Weekly: transfer succeeds, interval constant correct, too-early rejected
- Monthly: transfer succeeds, interval constant correct, too-early rejected
- Once: deactivates after distribution
- Cancel: deactivates allowance, errors on already-inactive
- Distribute: errors on inactive / nonexistent allowance
