### PR TITLE
feat(allowances): add allowance usage analytics query (#846)

### DIFF
--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -11,6 +11,7 @@
 //! - #833 Add Allowance Pause/Resume   — `pause_allowance` / `resume_allowance`
 //! - #834 Add Allowance Cancellation   — `cancel_allowance` (already present, confirmed)
 //! - #835 Add Allowance Beneficiary Update — `update_beneficiary`
+//! - #846 Add Allowance Analytics       — `get_allowance_analytics` (total distributed, average payment, remaining)
 
 #![no_std]
 
@@ -23,7 +24,7 @@ use soroban_sdk::{
     contract, contractimpl, panic_with_error, symbol_short, token, Address, Env, Vec,
 };
 
-use types::{AllowanceError, Allowance, DataKey, Frequency};
+use types::{AllowanceError, Allowance, AllowanceAnalytics, DataKey, Frequency};
 
 #[contract]
 pub struct AllowancesContract;
@@ -249,6 +250,32 @@ impl AllowancesContract {
         env.storage().persistent()
             .get(&DataKey::Allowance(allowance_id))
             .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound))
+    }
+
+    /// Returns usage analytics for an allowance (#846): total amount
+    /// distributed, the average payment, and the owner's remaining spendable
+    /// balance in the allowance token.
+    pub fn get_allowance_analytics(env: Env, allowance_id: u64) -> AllowanceAnalytics {
+        let allowance: Allowance = env
+            .storage().persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+
+        let count = allowance.distribution_count as i128;
+        let total_distributed = allowance.amount.saturating_mul(count);
+        let average_payment = if count == 0 {
+            0
+        } else {
+            total_distributed / count
+        };
+        let remaining = token::Client::new(&env, &allowance.token).balance(&allowance.owner);
+
+        AllowanceAnalytics {
+            total_distributed,
+            distribution_count: allowance.distribution_count,
+            average_payment,
+            remaining,
+        }
     }
 
     pub fn get_owner_allowances(env: Env, owner: Address) -> Vec<u64> {

--- a/contracts/allowances/src/test.rs
+++ b/contracts/allowances/src/test.rs
@@ -311,3 +311,66 @@ fn distribute_nonexistent_returns_error() {
         .expect("contract error");
     assert_eq!(err, AllowanceError::NotFound.into());
 }
+
+// ── Allowance analytics (#846) ──────────────────────────────────────────────
+
+#[test]
+fn analytics_for_new_allowance_is_zero() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    let stats = client.get_allowance_analytics(&id);
+
+    assert_eq!(stats.total_distributed, 0);
+    assert_eq!(stats.distribution_count, 0);
+    assert_eq!(stats.average_payment, 0);
+    // Nothing distributed yet → owner still holds the full funded balance.
+    assert_eq!(stats.remaining, 1_000);
+}
+
+#[test]
+fn analytics_after_one_distribution() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    client.distribute(&id);
+
+    let stats = client.get_allowance_analytics(&id);
+    assert_eq!(stats.total_distributed, 100);
+    assert_eq!(stats.distribution_count, 1);
+    assert_eq!(stats.average_payment, 100);
+    assert_eq!(stats.remaining, 900);
+}
+
+#[test]
+fn analytics_across_multiple_recurring_distributions() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &50, &Frequency::Weekly, &now);
+
+    // First distribution at the start window.
+    client.distribute(&id);
+    // Advance one week and distribute again.
+    env.ledger().with_mut(|l| l.timestamp = now + 604_800 + 1);
+    client.distribute(&id);
+
+    let stats = client.get_allowance_analytics(&id);
+    assert_eq!(stats.total_distributed, 100);
+    assert_eq!(stats.distribution_count, 2);
+    assert_eq!(stats.average_payment, 50);
+    assert_eq!(stats.remaining, 900);
+}
+
+#[test]
+fn analytics_for_missing_allowance_fails() {
+    let (_env, client, _owner, _recipient, _token) = setup(1_000);
+    let err = client
+        .try_get_allowance_analytics(&999)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::NotFound.into());
+}

--- a/contracts/allowances/src/types.rs
+++ b/contracts/allowances/src/types.rs
@@ -55,6 +55,22 @@ pub struct Allowance {
     pub paused: bool,
 }
 
+/// Read-only usage analytics for an allowance (issue #846).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AllowanceAnalytics {
+    /// Sum of all amounts distributed so far (`amount` × `distribution_count`).
+    pub total_distributed: i128,
+    /// Number of successful distributions.
+    pub distribution_count: u64,
+    /// Mean payment per distribution
+    /// (`total_distributed` / `distribution_count`, or 0 when none yet).
+    pub average_payment: i128,
+    /// Owner's available balance in the allowance token — the funds that remain
+    /// available to back future distributions.
+    pub remaining: i128,
+}
+
 /// Persistent storage keys for the allowances contract.
 #[contracttype]
 pub enum DataKey {


### PR DESCRIPTION
Users could not monitor allowance usage. Adds a read-only analytics query.

- types.rs: new `AllowanceAnalytics { total_distributed, distribution_count, average_payment, remaining }`.
- lib.rs: `get_allowance_analytics(allowance_id)` computes total_distributed = amount × distribution_count, average_payment = total_distributed / distribution_count (0 when none), and remaining = the owner's current spendable balance in the allowance token.

Tests: 4 new cases (zero state, after one distribution, across multiple recurring distributions, and NotFound). 33 passed; wasm builds; lib is clippy-clean.

closes #846 