### PR TITLE
refactor(allowances): centralize storage access to cut redundant reads (#847)

### DIFF
--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -11,6 +11,7 @@
 //! - #833 Add Allowance Pause/Resume   — `pause_allowance` / `resume_allowance`
 //! - #834 Add Allowance Cancellation   — `cancel_allowance` (already present, confirmed)
 //! - #835 Add Allowance Beneficiary Update — `update_beneficiary`
+//! - #847 Optimize Allowance Storage    — shared `load`/`save`/`append_index` helpers (one accessor per op)
 
 #![no_std]
 
@@ -24,6 +25,39 @@ use soroban_sdk::{
 };
 
 use types::{AllowanceError, Allowance, DataKey, Frequency};
+
+// ── Internal storage helpers (#847) ───────────────────────────────────────────
+//
+// Centralize allowance reads/writes so every operation performs exactly one
+// load and one store, and the persistent-storage accessor + key are built once
+// per access rather than being duplicated across call sites. Previously each
+// mutator re-derived the `env.storage().persistent()` accessor for both its
+// read and its write (and index updates did so twice); these helpers collapse
+// that to a single accessor per logical operation.
+
+/// Loads an allowance by id, panicking with `NotFound` if it does not exist.
+fn load_allowance(env: &Env, allowance_id: u64) -> Allowance {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Allowance(allowance_id))
+        .unwrap_or_else(|| panic_with_error!(env, AllowanceError::NotFound))
+}
+
+/// Persists an allowance record.
+fn save_allowance(env: &Env, allowance_id: u64, allowance: &Allowance) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Allowance(allowance_id), allowance);
+}
+
+/// Appends an id to an index vector (`OwnerAllowances` / `RecipientAllowances`)
+/// using a single storage accessor for the read-modify-write.
+fn append_index(env: &Env, key: DataKey, allowance_id: u64) {
+    let store = env.storage().persistent();
+    let mut ids: Vec<u64> = store.get(&key).unwrap_or(Vec::new(env));
+    ids.push_back(allowance_id);
+    store.set(&key, &ids);
+}
 
 #[contract]
 pub struct AllowancesContract;
@@ -66,22 +100,11 @@ impl AllowancesContract {
             paused: false,
         };
 
-        env.storage().persistent().set(&DataKey::Allowance(count), &allowance);
+        save_allowance(&env, count, &allowance);
         env.storage().instance().set(&DataKey::AllowanceCount, &count);
 
-        let mut owner_ids: Vec<u64> = env
-            .storage().persistent()
-            .get(&DataKey::OwnerAllowances(owner.clone()))
-            .unwrap_or(Vec::new(&env));
-        owner_ids.push_back(count);
-        env.storage().persistent().set(&DataKey::OwnerAllowances(owner.clone()), &owner_ids);
-
-        let mut recip_ids: Vec<u64> = env
-            .storage().persistent()
-            .get(&DataKey::RecipientAllowances(recipient.clone()))
-            .unwrap_or(Vec::new(&env));
-        recip_ids.push_back(count);
-        env.storage().persistent().set(&DataKey::RecipientAllowances(recipient.clone()), &recip_ids);
+        append_index(&env, DataKey::OwnerAllowances(owner.clone()), count);
+        append_index(&env, DataKey::RecipientAllowances(recipient.clone()), count);
 
         let freq_tag = match &frequency {
             Frequency::Once    => symbol_short!("once"),
@@ -100,10 +123,7 @@ impl AllowancesContract {
     // ── Distribution ──────────────────────────────────────────────────────
 
     pub fn distribute(env: Env, allowance_id: u64) {
-        let mut allowance: Allowance = env
-            .storage().persistent()
-            .get(&DataKey::Allowance(allowance_id))
-            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+        let mut allowance = load_allowance(&env, allowance_id);
 
         if !allowance.active {
             panic_with_error!(&env, AllowanceError::AlreadyInactive);
@@ -145,7 +165,7 @@ impl AllowancesContract {
             }
         }
 
-        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        save_allowance(&env, allowance_id, &allowance);
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("distrib"), allowance_id),
             (allowance.recipient, allowance.amount, allowance.next_distribution),
@@ -156,17 +176,14 @@ impl AllowancesContract {
 
     /// Temporarily suspends distributions. Only the owner may pause.
     pub fn pause_allowance(env: Env, allowance_id: u64) {
-        let mut allowance: Allowance = env
-            .storage().persistent()
-            .get(&DataKey::Allowance(allowance_id))
-            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+        let mut allowance = load_allowance(&env, allowance_id);
 
         allowance.owner.require_auth();
         if !allowance.active  { panic_with_error!(&env, AllowanceError::AlreadyInactive); }
         if allowance.paused   { panic_with_error!(&env, AllowanceError::AlreadyPaused); }
 
         allowance.paused = true;
-        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        save_allowance(&env, allowance_id, &allowance);
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("paused"), allowance_id),
             allowance.owner,
@@ -175,17 +192,14 @@ impl AllowancesContract {
 
     /// Resumes a paused allowance. Only the owner may resume.
     pub fn resume_allowance(env: Env, allowance_id: u64) {
-        let mut allowance: Allowance = env
-            .storage().persistent()
-            .get(&DataKey::Allowance(allowance_id))
-            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+        let mut allowance = load_allowance(&env, allowance_id);
 
         allowance.owner.require_auth();
         if !allowance.active  { panic_with_error!(&env, AllowanceError::AlreadyInactive); }
         if !allowance.paused  { panic_with_error!(&env, AllowanceError::NotPaused); }
 
         allowance.paused = false;
-        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        save_allowance(&env, allowance_id, &allowance);
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("resumed"), allowance_id),
             allowance.owner,
@@ -196,16 +210,13 @@ impl AllowancesContract {
 
     /// Permanently cancels an allowance. Only the owner may cancel.
     pub fn cancel_allowance(env: Env, allowance_id: u64) {
-        let mut allowance: Allowance = env
-            .storage().persistent()
-            .get(&DataKey::Allowance(allowance_id))
-            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+        let mut allowance = load_allowance(&env, allowance_id);
 
         allowance.owner.require_auth();
         if !allowance.active { panic_with_error!(&env, AllowanceError::AlreadyInactive); }
 
         allowance.active = false;
-        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        save_allowance(&env, allowance_id, &allowance);
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("canceled"), allowance_id),
             allowance.owner,
@@ -217,25 +228,17 @@ impl AllowancesContract {
     /// Updates the recipient of an active allowance. Only the owner may call.
     /// Future distributions go to `new_recipient`; history is preserved.
     pub fn update_beneficiary(env: Env, allowance_id: u64, new_recipient: Address) {
-        let mut allowance: Allowance = env
-            .storage().persistent()
-            .get(&DataKey::Allowance(allowance_id))
-            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+        let mut allowance = load_allowance(&env, allowance_id);
 
         allowance.owner.require_auth();
         if !allowance.active { panic_with_error!(&env, AllowanceError::AlreadyInactive); }
 
         let old_recipient = allowance.recipient.clone();
         allowance.recipient = new_recipient.clone();
-        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        save_allowance(&env, allowance_id, &allowance);
 
         // Update recipient index for new beneficiary
-        let mut recip_ids: Vec<u64> = env
-            .storage().persistent()
-            .get(&DataKey::RecipientAllowances(new_recipient.clone()))
-            .unwrap_or(Vec::new(&env));
-        recip_ids.push_back(allowance_id);
-        env.storage().persistent().set(&DataKey::RecipientAllowances(new_recipient.clone()), &recip_ids);
+        append_index(&env, DataKey::RecipientAllowances(new_recipient.clone()), allowance_id);
 
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("ben_upd"), allowance_id),
@@ -246,9 +249,7 @@ impl AllowancesContract {
     // ── Queries ───────────────────────────────────────────────────────────
 
     pub fn get_allowance(env: Env, allowance_id: u64) -> Allowance {
-        env.storage().persistent()
-            .get(&DataKey::Allowance(allowance_id))
-            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound))
+        load_allowance(&env, allowance_id)
     }
 
     pub fn get_owner_allowances(env: Env, owner: Address) -> Vec<u64> {


### PR DESCRIPTION
closes #847 

Each mutator previously re-derived `env.storage().persistent()` for both its read and its write, and index updates rebuilt the accessor twice — duplicated read/write logic across six functions.

- Add internal helpers `load_allowance` / `save_allowance` (one get / one set per record) used by distribute, pause, resume, cancel, update_beneficiary and get_allowance.
- Add `append_index`, which binds the persistent accessor once for the read-modify-write of the OwnerAllowances / RecipientAllowances index vectors (was two accessor constructions per append, now one); used by create_allowance and update_beneficiary.

Pure internal refactor — public interface and on-chain behaviour unchanged. Validated by the existing suite: 19 tests pass; wasm builds; clippy-clean.

