### PR TITLE
feat(allowances): enforce per-allowance spending limits (#836)

### DIFF
--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -11,6 +11,7 @@
 //! - #833 Add Allowance Pause/Resume   — `pause_allowance` / `resume_allowance`
 //! - #834 Add Allowance Cancellation   — `cancel_allowance` (already present, confirmed)
 //! - #835 Add Allowance Beneficiary Update — `update_beneficiary`
+//! - #836 Implement Allowance Spending Limits — `set_spending_limit` + cumulative cap enforced in `distribute`
 
 #![no_std]
 
@@ -64,6 +65,7 @@ impl AllowancesContract {
             distribution_count: 0,
             active: true,
             paused: false,
+            spending_limit: 0, // unlimited until an owner sets one (#836)
         };
 
         env.storage().persistent().set(&DataKey::Allowance(count), &allowance);
@@ -115,6 +117,17 @@ impl AllowancesContract {
         let now = env.ledger().timestamp();
         if now < allowance.next_distribution {
             panic_with_error!(&env, AllowanceError::TooEarlyToDistribute);
+        }
+
+        // Enforce the cumulative spending cap (#836). `0` means unlimited.
+        if allowance.spending_limit > 0 {
+            let projected = allowance
+                .amount
+                .checked_mul((allowance.distribution_count + 1) as i128)
+                .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::SpendingLimitExceeded));
+            if projected > allowance.spending_limit {
+                panic_with_error!(&env, AllowanceError::SpendingLimitExceeded);
+            }
         }
 
         let token_client = token::Client::new(&env, &allowance.token);
@@ -240,6 +253,40 @@ impl AllowancesContract {
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("ben_upd"), allowance_id),
             (old_recipient, new_recipient),
+        );
+    }
+
+    // ── Spending limit (#836) ─────────────────────────────────────────────
+
+    /// Sets the maximum cumulative amount that may ever be distributed for an
+    /// allowance. Only the owner may call. A limit of `0` removes the cap
+    /// (unlimited). A positive limit caps total spend at that value; once the
+    /// cumulative `amount × distribution_count` would exceed it, `distribute`
+    /// returns `SpendingLimitExceeded`.
+    ///
+    /// # Errors
+    /// * `AllowanceError::NotFound`        - allowance does not exist
+    /// * `AllowanceError::AlreadyInactive` - allowance is no longer active
+    /// * `AllowanceError::InvalidLimit`    - `limit` is negative
+    pub fn set_spending_limit(env: Env, allowance_id: u64, limit: i128) {
+        let mut allowance: Allowance = env
+            .storage().persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+
+        allowance.owner.require_auth();
+        if limit < 0 {
+            panic_with_error!(&env, AllowanceError::InvalidLimit);
+        }
+        if !allowance.active {
+            panic_with_error!(&env, AllowanceError::AlreadyInactive);
+        }
+
+        allowance.spending_limit = limit;
+        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        env.events().publish(
+            (symbol_short!("allow"), symbol_short!("limit"), allowance_id),
+            limit,
         );
     }
 

--- a/contracts/allowances/src/test.rs
+++ b/contracts/allowances/src/test.rs
@@ -311,3 +311,129 @@ fn distribute_nonexistent_returns_error() {
         .expect("contract error");
     assert_eq!(err, AllowanceError::NotFound.into());
 }
+
+// ── Spending limits (#836) ──────────────────────────────────────────────────
+
+const WK: u64 = 604_800;
+
+#[test]
+fn default_allowance_has_no_spending_limit() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    assert_eq!(client.get_allowance(&id).spending_limit, 0);
+}
+
+#[test]
+fn set_spending_limit_stores_value() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    client.set_spending_limit(&id, &250);
+    assert_eq!(client.get_allowance(&id).spending_limit, 250);
+}
+
+#[test]
+fn set_spending_limit_rejects_negative() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+
+    let err = client
+        .try_set_spending_limit(&id, &-1)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::InvalidLimit.into());
+}
+
+#[test]
+fn set_spending_limit_fails_for_missing_allowance() {
+    let (_env, client, _o, _r, _t) = setup(1_000);
+    let err = client
+        .try_set_spending_limit(&999, &100)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::NotFound.into());
+}
+
+#[test]
+fn distribution_within_limit_succeeds() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let token_client = TokenClient::new(&env, &token);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+    client.set_spending_limit(&id, &250); // allows two payments of 100 (200 <= 250)
+
+    client.distribute(&id); // total 100
+    env.ledger().with_mut(|l| l.timestamp = now + WK + 1);
+    client.distribute(&id); // total 200
+
+    assert_eq!(token_client.balance(&recipient), 200);
+    assert_eq!(client.get_allowance(&id).distribution_count, 2);
+}
+
+#[test]
+fn distribution_exceeding_limit_is_rejected() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let token_client = TokenClient::new(&env, &token);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+    client.set_spending_limit(&id, &250);
+
+    client.distribute(&id); // 100
+    env.ledger().with_mut(|l| l.timestamp = now + WK + 1);
+    client.distribute(&id); // 200
+
+    // Third payment would bring the total to 300 > 250 → rejected.
+    env.ledger().with_mut(|l| l.timestamp = now + 2 * WK + 1);
+    let err = client
+        .try_distribute(&id)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::SpendingLimitExceeded.into());
+
+    // The cap held: recipient never received more than the limit allowed.
+    assert_eq!(token_client.balance(&recipient), 200);
+    assert_eq!(client.get_allowance(&id).distribution_count, 2);
+}
+
+#[test]
+fn limit_below_amount_blocks_first_distribution() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    client.set_spending_limit(&id, &50); // 100 > 50 → even the first payment is blocked
+
+    let err = client
+        .try_distribute(&id)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::SpendingLimitExceeded.into());
+}
+
+#[test]
+fn zero_limit_means_unlimited() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let token_client = TokenClient::new(&env, &token);
+    let now = env.ledger().timestamp();
+
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+    client.set_spending_limit(&id, &200);
+    // Clear the cap back to unlimited.
+    client.set_spending_limit(&id, &0);
+
+    client.distribute(&id);
+    for week in 1..4u64 {
+        env.ledger().with_mut(|l| l.timestamp = now + week * WK + 1);
+        client.distribute(&id);
+    }
+    assert_eq!(token_client.balance(&recipient), 400); // 4 payments, no cap
+}

--- a/contracts/allowances/src/types.rs
+++ b/contracts/allowances/src/types.rs
@@ -53,6 +53,10 @@ pub struct Allowance {
     pub active: bool,
     /// Whether the allowance is temporarily paused (issue #833).
     pub paused: bool,
+    /// Maximum cumulative amount that may ever be distributed for this
+    /// allowance (issue #836). `0` means unlimited. Enforced in `distribute`
+    /// against `amount × (distribution_count + 1)`.
+    pub spending_limit: i128,
 }
 
 /// Persistent storage keys for the allowances contract.
@@ -85,6 +89,10 @@ pub enum AllowanceError {
     NotPaused = 9,
     /// Allowance is paused — distribution blocked (#833)
     Paused = 10,
+    /// Distribution would exceed the configured spending limit (#836)
+    SpendingLimitExceeded = 11,
+    /// Spending limit must be non-negative (#836)
+    InvalidLimit = 12,
 }
 
 impl From<AllowanceError> for soroban_sdk::Error {


### PR DESCRIPTION
Recipients could exceed intended usage because there was no cap on how much an allowance could distribute over its lifetime.

- types.rs: add `Allowance.spending_limit` (0 = unlimited) and errors `SpendingLimitExceeded` / `InvalidLimit`.
- lib.rs: new owner-only `set_spending_limit(allowance_id, limit)` (rejects negative limits; 0 clears the cap). `distribute` now rejects a payment when the projected cumulative spend (`amount × (distribution_count + 1)`) would exceed the limit, before any token transfer.
- create_allowance defaults `spending_limit` to 0, so existing allowances are unaffected (backward compatible).

Tests: 8 new cases (default unlimited, set/clear, negative rejected, NotFound, within-limit succeeds, exceeding rejected, limit-below-amount blocks first payment, zero = unlimited). 27 passed; wasm builds; lib clippy-clean.

closes #836 