### PR TITLE
feat(allowances): record per-distribution payment history (#837)

### DIFF
--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -11,6 +11,7 @@
 //! - #833 Add Allowance Pause/Resume   — `pause_allowance` / `resume_allowance`
 //! - #834 Add Allowance Cancellation   — `cancel_allowance` (already present, confirmed)
 //! - #835 Add Allowance Beneficiary Update — `update_beneficiary`
+//! - #837 Add Allowance History         — per-distribution `PaymentRecord` log + `get_allowance_history`
 
 #![no_std]
 
@@ -23,7 +24,7 @@ use soroban_sdk::{
     contract, contractimpl, panic_with_error, symbol_short, token, Address, Env, Vec,
 };
 
-use types::{AllowanceError, Allowance, DataKey, Frequency};
+use types::{AllowanceError, Allowance, DataKey, Frequency, PaymentRecord};
 
 #[contract]
 pub struct AllowancesContract;
@@ -130,6 +131,19 @@ impl AllowancesContract {
         );
 
         allowance.distribution_count += 1;
+
+        // Append to the allowance's payment history (#837): amount, timestamp,
+        // and the recipient at the time of this payment.
+        let mut history: Vec<PaymentRecord> = env
+            .storage().persistent()
+            .get(&DataKey::AllowanceHistory(allowance_id))
+            .unwrap_or(Vec::new(&env));
+        history.push_back(PaymentRecord {
+            amount: allowance.amount,
+            timestamp: now,
+            recipient: allowance.recipient.clone(),
+        });
+        env.storage().persistent().set(&DataKey::AllowanceHistory(allowance_id), &history);
 
         match allowance.frequency.interval_seconds() {
             None => {
@@ -254,6 +268,14 @@ impl AllowancesContract {
     pub fn get_owner_allowances(env: Env, owner: Address) -> Vec<u64> {
         env.storage().persistent()
             .get(&DataKey::OwnerAllowances(owner))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns the full payment history for an allowance (#837), oldest first.
+    /// Empty if no distributions have occurred (or the allowance does not exist).
+    pub fn get_allowance_history(env: Env, allowance_id: u64) -> Vec<PaymentRecord> {
+        env.storage().persistent()
+            .get(&DataKey::AllowanceHistory(allowance_id))
             .unwrap_or(Vec::new(&env))
     }
 

--- a/contracts/allowances/src/test.rs
+++ b/contracts/allowances/src/test.rs
@@ -311,3 +311,77 @@ fn distribute_nonexistent_returns_error() {
         .expect("contract error");
     assert_eq!(err, AllowanceError::NotFound.into());
 }
+
+// ── Allowance payment history (#837) ────────────────────────────────────────
+
+const HWEEK: u64 = 604_800;
+
+#[test]
+fn history_is_empty_before_any_distribution() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    assert_eq!(client.get_allowance_history(&id).len(), 0);
+}
+
+#[test]
+fn history_records_a_payment() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+
+    client.distribute(&id);
+
+    let history = client.get_allowance_history(&id);
+    assert_eq!(history.len(), 1);
+    let rec = history.get(0).unwrap();
+    assert_eq!(rec.amount, 100);
+    assert_eq!(rec.timestamp, now);
+    assert_eq!(rec.recipient, recipient);
+}
+
+#[test]
+fn history_accumulates_across_recurring_payments() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &50, &Frequency::Weekly, &now);
+
+    client.distribute(&id);
+    env.ledger().with_mut(|l| l.timestamp = now + HWEEK + 1);
+    let t2 = env.ledger().timestamp();
+    client.distribute(&id);
+
+    let history = client.get_allowance_history(&id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().timestamp, now);
+    assert_eq!(history.get(1).unwrap().timestamp, t2);
+    assert_eq!(history.get(0).unwrap().amount, 50);
+    assert_eq!(history.get(1).unwrap().amount, 50);
+}
+
+#[test]
+fn history_captures_recipient_at_payment_time() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let now = env.ledger().timestamp();
+    let new_recipient = Address::generate(&env);
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    // First payment goes to the original recipient.
+    client.distribute(&id);
+
+    // Change beneficiary, then make the next payment.
+    client.update_beneficiary(&id, &new_recipient);
+    env.ledger().with_mut(|l| l.timestamp = now + HWEEK + 1);
+    client.distribute(&id);
+
+    let history = client.get_allowance_history(&id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().recipient, recipient);
+    assert_eq!(history.get(1).unwrap().recipient, new_recipient);
+}
+
+#[test]
+fn history_for_missing_allowance_is_empty() {
+    let (_env, client, _o, _r, _t) = setup(1_000);
+    assert_eq!(client.get_allowance_history(&999).len(), 0);
+}

--- a/contracts/allowances/src/types.rs
+++ b/contracts/allowances/src/types.rs
@@ -55,6 +55,19 @@ pub struct Allowance {
     pub paused: bool,
 }
 
+/// A single recorded payment in an allowance's distribution history (#837).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PaymentRecord {
+    /// Amount transferred in this distribution.
+    pub amount: i128,
+    /// Ledger timestamp at which the payment was made.
+    pub timestamp: u64,
+    /// Recipient who received this payment (captured at payment time, since the
+    /// beneficiary can change between distributions).
+    pub recipient: Address,
+}
+
 /// Persistent storage keys for the allowances contract.
 #[contracttype]
 pub enum DataKey {
@@ -66,6 +79,8 @@ pub enum DataKey {
     OwnerAllowances(Address),
     /// Index: list of allowance IDs a recipient is entitled to.
     RecipientAllowances(Address),
+    /// Ordered payment history for an allowance (#837).
+    AllowanceHistory(u64),
 }
 
 /// Error codes returned by the allowances contract.


### PR DESCRIPTION
No payment history existed, so allowance usage could not be audited.

- types.rs: add `PaymentRecord { amount, timestamp, recipient }` and `DataKey::AllowanceHistory(u64)`.
- lib.rs: `distribute` appends a `PaymentRecord` (capturing the recipient at payment time, since the beneficiary can change between distributions). New `get_allowance_history(allowance_id)` returns the full ordered history (oldest first; empty when none).

Tests: 5 new cases (empty before first payment, single payment fields, accumulation across recurring payments, recipient captured at payment time after update_beneficiary, empty for missing allowance). 24 passed; wasm builds; lib clippy-clean.

closes #837 