### PR TITLE
feat(allowances): emit a dedicated payment event on every distribution (#838)

### DIFF
--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -11,6 +11,7 @@
 //! - #833 Add Allowance Pause/Resume   — `pause_allowance` / `resume_allowance`
 //! - #834 Add Allowance Cancellation   — `cancel_allowance` (already present, confirmed)
 //! - #835 Add Allowance Beneficiary Update — `update_beneficiary`
+//! - #838 Emit Allowance Payment Events  — `("allow","payment",id)` → (recipient, amount) on every payment
 
 #![no_std]
 
@@ -146,6 +147,14 @@ impl AllowancesContract {
         }
 
         env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+
+        // Dedicated payment event for off-chain indexers (#838): a stable
+        // `("allow", "payment", allowance_id)` topic carrying (recipient, amount)
+        // is emitted on every payment, alongside the richer `distrib` event.
+        env.events().publish(
+            (symbol_short!("allow"), symbol_short!("payment"), allowance_id),
+            (allowance.recipient.clone(), allowance.amount),
+        );
         env.events().publish(
             (symbol_short!("allow"), symbol_short!("distrib"), allowance_id),
             (allowance.recipient, allowance.amount, allowance.next_distribution),

--- a/contracts/allowances/src/test.rs
+++ b/contracts/allowances/src/test.rs
@@ -1,9 +1,10 @@
 #![cfg(test)]
 
 use soroban_sdk::{
+    symbol_short,
     testutils::{Address as _, Events as _, Ledger as _},
     token::{StellarAssetClient, TokenClient},
-    Address, Env,
+    Address, Env, IntoVal, Symbol, TryFromVal,
 };
 
 use crate::{AllowancesContract, AllowancesContractClient};
@@ -310,4 +311,85 @@ fn distribute_nonexistent_returns_error() {
         .expect("must fail")
         .expect("contract error");
     assert_eq!(err, AllowanceError::NotFound.into());
+}
+
+// ── Payment events (#838) ───────────────────────────────────────────────────
+
+const PWEEK: u64 = 604_800;
+
+/// Counts emitted events whose topics are `("allow", "payment", _)`.
+fn payment_event_count(env: &Env) -> u32 {
+    let mut count = 0u32;
+    for (_addr, topics, _data) in env.events().all().iter() {
+        if topics.len() == 3 {
+            let t1 = Symbol::try_from_val(env, &topics.get(1).unwrap());
+            if t1.map(|s| s == symbol_short!("payment")).unwrap_or(false) {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+#[test]
+fn distribution_emits_payment_event_with_recipient_and_amount() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+
+    client.distribute(&id);
+
+    // Exact topic/data: ("allow","payment", id) → (recipient, amount).
+    let expected = (
+        client.address.clone(),
+        (symbol_short!("allow"), symbol_short!("payment"), id).into_val(&env),
+        (recipient.clone(), 100i128).into_val(&env),
+    );
+    assert!(
+        env.events().all().contains(expected),
+        "a payment event with (recipient, amount) must be emitted"
+    );
+}
+
+#[test]
+fn payment_event_emitted_on_every_payment() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &50, &Frequency::Weekly, &now);
+
+    // `events().all()` reflects the most recent invocation. Each `distribute`
+    // invocation must emit exactly one payment event; creation emits none.
+    assert_eq!(payment_event_count(&env), 0, "creation emits no payment event");
+
+    client.distribute(&id);
+    assert_eq!(payment_event_count(&env), 1, "first payment emits one event");
+
+    env.ledger().with_mut(|l| l.timestamp = now + PWEEK + 1);
+    client.distribute(&id);
+    assert_eq!(payment_event_count(&env), 1, "second payment emits one event");
+
+    env.ledger().with_mut(|l| l.timestamp = now + 2 * PWEEK + 1);
+    client.distribute(&id);
+    assert_eq!(payment_event_count(&env), 1, "third payment emits one event");
+}
+
+#[test]
+fn payment_event_uses_current_recipient_after_beneficiary_change() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let now = env.ledger().timestamp();
+    let new_recipient = Address::generate(&env);
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    client.update_beneficiary(&id, &new_recipient);
+    client.distribute(&id);
+
+    let expected = (
+        client.address.clone(),
+        (symbol_short!("allow"), symbol_short!("payment"), id).into_val(&env),
+        (new_recipient.clone(), 100i128).into_val(&env),
+    );
+    assert!(
+        env.events().all().contains(expected),
+        "payment event must reflect the updated recipient"
+    );
 }


### PR DESCRIPTION
closes #838

Off-chain services had no clean event to detect allowance payments (only the richer `distrib` event with scheduling data).

- lib.rs: `distribute` now also emits a stable payment event `("allow", "payment", allowance_id)` carrying `(recipient, amount)` on every payment, alongside the existing `distrib` event.

Tests: 3 new cases (exact topic/data shape, one payment event per distribution, and recipient reflects update_beneficiary). 22 passed; wasm builds; lib clippy-clean.