### PR TITLE
feat(allowances): add allowance expiration / end date (#839)

### DIFF
--- a/contracts/allowances/src/lib.rs
+++ b/contracts/allowances/src/lib.rs
@@ -11,6 +11,7 @@
 //! - #833 Add Allowance Pause/Resume   — `pause_allowance` / `resume_allowance`
 //! - #834 Add Allowance Cancellation   — `cancel_allowance` (already present, confirmed)
 //! - #835 Add Allowance Beneficiary Update — `update_beneficiary`
+//! - #839 Add Allowance Expiration      — `set_expiration` / `is_expired`; `distribute` stops past `end_date`
 
 #![no_std]
 
@@ -64,6 +65,7 @@ impl AllowancesContract {
             distribution_count: 0,
             active: true,
             paused: false,
+            end_date: 0, // never expires until an owner sets an end date (#839)
         };
 
         env.storage().persistent().set(&DataKey::Allowance(count), &allowance);
@@ -113,6 +115,13 @@ impl AllowancesContract {
         }
 
         let now = env.ledger().timestamp();
+
+        // Past the end date the allowance is expired and distributions stop
+        // automatically (#839). `0` means no expiry.
+        if allowance.end_date != 0 && now >= allowance.end_date {
+            panic_with_error!(&env, AllowanceError::Expired);
+        }
+
         if now < allowance.next_distribution {
             panic_with_error!(&env, AllowanceError::TooEarlyToDistribute);
         }
@@ -241,6 +250,48 @@ impl AllowancesContract {
             (symbol_short!("allow"), symbol_short!("ben_upd"), allowance_id),
             (old_recipient, new_recipient),
         );
+    }
+
+    // ── Expiration (#839) ─────────────────────────────────────────────────
+
+    /// Sets (or clears) the allowance's end date. Only the owner may call.
+    /// Once the ledger time reaches `end_date`, `distribute` stops automatically
+    /// (returns `Expired`). Pass `0` to remove the expiry.
+    ///
+    /// # Errors
+    /// * `AllowanceError::NotFound`          - allowance does not exist
+    /// * `AllowanceError::AlreadyInactive`   - allowance is no longer active
+    /// * `AllowanceError::InvalidExpiration` - `end_date` is non-zero and not in the future
+    pub fn set_expiration(env: Env, allowance_id: u64, end_date: u64) {
+        let mut allowance: Allowance = env
+            .storage().persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+
+        allowance.owner.require_auth();
+        if !allowance.active {
+            panic_with_error!(&env, AllowanceError::AlreadyInactive);
+        }
+        if end_date != 0 && end_date <= env.ledger().timestamp() {
+            panic_with_error!(&env, AllowanceError::InvalidExpiration);
+        }
+
+        allowance.end_date = end_date;
+        env.storage().persistent().set(&DataKey::Allowance(allowance_id), &allowance);
+        env.events().publish(
+            (symbol_short!("allow"), symbol_short!("expiry"), allowance_id),
+            end_date,
+        );
+    }
+
+    /// Returns `true` if the allowance has an end date that the current ledger
+    /// time has reached or passed (#839).
+    pub fn is_expired(env: Env, allowance_id: u64) -> bool {
+        let allowance: Allowance = env
+            .storage().persistent()
+            .get(&DataKey::Allowance(allowance_id))
+            .unwrap_or_else(|| panic_with_error!(&env, AllowanceError::NotFound));
+        allowance.end_date != 0 && env.ledger().timestamp() >= allowance.end_date
     }
 
     // ── Queries ───────────────────────────────────────────────────────────

--- a/contracts/allowances/src/test.rs
+++ b/contracts/allowances/src/test.rs
@@ -311,3 +311,113 @@ fn distribute_nonexistent_returns_error() {
         .expect("contract error");
     assert_eq!(err, AllowanceError::NotFound.into());
 }
+
+// ── Allowance expiration (#839) ─────────────────────────────────────────────
+
+const EWEEK: u64 = 604_800;
+
+#[test]
+fn allowance_has_no_expiry_by_default() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &now);
+    assert_eq!(client.get_allowance(&id).end_date, 0);
+    assert!(!client.is_expired(&id));
+}
+
+#[test]
+fn set_expiration_stores_end_date() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    client.set_expiration(&id, &(now + 10 * EWEEK));
+    assert_eq!(client.get_allowance(&id).end_date, now + 10 * EWEEK);
+    assert!(!client.is_expired(&id));
+}
+
+#[test]
+fn set_expiration_rejects_past_timestamp() {
+    let (env, client, owner, recipient, token) = setup(1_000);
+    let now = env.ledger().timestamp();
+    env.ledger().with_mut(|l| l.timestamp = now + 1_000);
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Once, &(now + 1_000));
+
+    let err = client
+        .try_set_expiration(&id, &(now + 500)) // in the past relative to current ledger time
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::InvalidExpiration.into());
+}
+
+#[test]
+fn distribution_before_expiry_succeeds() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let token_client = TokenClient::new(&env, &token);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    client.set_expiration(&id, &(now + 3 * EWEEK));
+
+    client.distribute(&id); // now < end_date → ok
+    assert_eq!(token_client.balance(&recipient), 100);
+}
+
+#[test]
+fn expired_allowance_stops_distributing() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let token_client = TokenClient::new(&env, &token);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    // Expire after two weeks.
+    client.set_expiration(&id, &(now + 2 * EWEEK));
+
+    client.distribute(&id); // week 0 — ok
+    env.ledger().with_mut(|l| l.timestamp = now + EWEEK + 1);
+    client.distribute(&id); // week 1 — ok (still before end)
+    assert_eq!(token_client.balance(&recipient), 200);
+
+    // Move past the end date → distributions stop automatically.
+    env.ledger().with_mut(|l| l.timestamp = now + 2 * EWEEK + 1);
+    assert!(client.is_expired(&id));
+    let err = client
+        .try_distribute(&id)
+        .err()
+        .expect("expired distribute must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::Expired.into());
+
+    // No further funds moved.
+    assert_eq!(token_client.balance(&recipient), 200);
+}
+
+#[test]
+fn clearing_expiration_resumes_distribution() {
+    let (env, client, owner, recipient, token) = setup(10_000);
+    let token_client = TokenClient::new(&env, &token);
+    let now = env.ledger().timestamp();
+    let id = client.create_allowance(&owner, &recipient, &token, &100, &Frequency::Weekly, &now);
+
+    client.set_expiration(&id, &(now + EWEEK)); // expires in a week
+    env.ledger().with_mut(|l| l.timestamp = now + EWEEK + 1);
+    assert!(client.is_expired(&id));
+
+    // Owner clears the expiry (0) → no longer expired, distribution works.
+    client.set_expiration(&id, &0);
+    assert!(!client.is_expired(&id));
+    client.distribute(&id);
+    assert_eq!(token_client.balance(&recipient), 100);
+}
+
+#[test]
+fn set_expiration_fails_for_missing_allowance() {
+    let (_env, client, _o, _r, _t) = setup(1_000);
+    let err = client
+        .try_set_expiration(&999, &1)
+        .err()
+        .expect("must fail")
+        .expect("contract error");
+    assert_eq!(err, AllowanceError::NotFound.into());
+}

--- a/contracts/allowances/src/types.rs
+++ b/contracts/allowances/src/types.rs
@@ -53,6 +53,9 @@ pub struct Allowance {
     pub active: bool,
     /// Whether the allowance is temporarily paused (issue #833).
     pub paused: bool,
+    /// Ledger timestamp after which the allowance expires and distributions
+    /// stop automatically (issue #839). `0` means it never expires.
+    pub end_date: u64,
 }
 
 /// Persistent storage keys for the allowances contract.
@@ -85,6 +88,10 @@ pub enum AllowanceError {
     NotPaused = 9,
     /// Allowance is paused — distribution blocked (#833)
     Paused = 10,
+    /// Allowance has passed its end date and is expired (#839)
+    Expired = 11,
+    /// Expiration timestamp must be in the future (or 0 to clear) (#839)
+    InvalidExpiration = 12,
 }
 
 impl From<AllowanceError> for soroban_sdk::Error {


### PR DESCRIPTION
Allowances never expired, so they kept distributing indefinitely.

- types.rs: add `Allowance.end_date` (0 = never) and errors `Expired` / `InvalidExpiration`.
- lib.rs: owner-only `set_expiration(allowance_id, end_date)` (future timestamp, or 0 to clear; requires the allowance to be active) and `is_expired` view. `distribute` now rejects with `Expired` once the ledger time reaches `end_date`, so distributions stop automatically. `create_allowance` defaults `end_date` to 0 (backward compatible).

Tests: 7 new cases (default no expiry, set/clear, past-timestamp rejected, distribution before expiry, expired stops distributing, clearing resumes, NotFound). 26 passed; wasm builds; lib clippy-clean.

closes #839 