### PR TITLE
Feature/875 bootstrap rewards contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "contracts/zk-verifier",
     "contracts/pausable",
     "contracts/allowances",
+    "contracts/rewards",
 ]
 
 [package]
@@ -80,9 +81,10 @@ name = "governance_tests"
 path = "tests/governance_tests.rs"
 
 [[test]]
-Add-integration-test-for-savings-savings-goals-interaction
 name = "throttling_tests"
 path = "tests/throttling_tests.rs"
+
+[[test]]
 name = "throttling_test"
 path = "contracts/tests/throttling_test.rs"
 

--- a/contracts/rewards/Cargo.toml
+++ b/contracts/rewards/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rewards"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Rewards management contract for StellarSpend"
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/rewards/PR_DESCRIPTION.md
+++ b/contracts/rewards/PR_DESCRIPTION.md
@@ -1,0 +1,52 @@
+# Bootstrap the Rewards Smart Contract
+
+**Closes #875**
+
+---
+
+## Summary
+
+Introduces the `rewards` crate — a new, isolated Soroban smart contract that lays the foundation for reward management within the StellarSpend protocol. The contract is intentionally minimal per the issue scope, providing a clean, tested base that future reward functionality can build on top of.
+
+---
+
+## Changes
+
+### New: `contracts/rewards/`
+
+- **`Cargo.toml`** — workspace-inherited manifest (`version`, `edition`, `license`, `repository`); configured as `cdylib` with a `testutils` feature flag, matching the conventions of other contracts in the workspace.
+- **`src/lib.rs`** — `RewardsContract` with three public entry points:
+  - `initialize(env, admin)` — one-shot initialisation guarded against double-calls; emits an `initialized` event.
+  - `get_admin(env)` — returns the current admin address; panics with `NotInitialized` if called before init.
+  - `is_initialized(env)` — lightweight boolean state check.
+  - Internal `require_admin` helper scaffolded for future reward operations.
+- **`src/test.rs`** — 4 unit tests covering all acceptance criteria:
+  - `test_initialize_sets_admin` — init stores and returns the correct admin.
+  - `test_is_initialized_returns_true_after_init` — flag is `false` before init, `true` after.
+  - `test_double_initialize_panics` — second call is rejected.
+  - `test_get_admin_before_init_panics` — getter panics cleanly when uninitialised.
+
+### Modified: `Cargo.toml` (root)
+
+- Registered `contracts/rewards` in the workspace `[members]` list.
+- Fixed a pre-existing malformed `[[test]]` block (stray non-TOML text + duplicate `name`/`path` keys) that was preventing `cargo fetch` and `cargo test --workspace` from running.
+
+---
+
+## Test Results
+
+```
+running 4 tests
+test test::test_get_admin_before_init_panics - should panic ... ok
+test test::test_double_initialize_panics - should panic ... ok
+test test::test_initialize_sets_admin ... ok
+test test::test_is_initialized_returns_true_after_init ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored
+```
+
+---
+
+## Out of Scope
+
+This PR does not implement any reward distribution logic — that is intentionally deferred to follow-on issues. The contract is isolated from existing budgeting and savings contracts as required.

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -1,0 +1,100 @@
+//! # Rewards Contract
+//!
+//! A Soroban smart contract dedicated to reward management for StellarSpend.
+//! Provides the foundation for incentivising responsible financial behaviour
+//! within the protocol.
+
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env};
+
+/// Storage keys for the rewards contract.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    /// Contract administrator address.
+    Admin,
+    /// Whether the contract has been initialised.
+    Initialized,
+}
+
+/// Error codes for the rewards contract.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RewardsError {
+    /// Contract has not been initialised.
+    NotInitialized = 1,
+    /// Caller is not authorised to perform this action.
+    Unauthorized = 2,
+    /// Contract has already been initialised.
+    AlreadyInitialized = 3,
+}
+
+impl From<RewardsError> for soroban_sdk::Error {
+    fn from(e: RewardsError) -> Self {
+        soroban_sdk::Error::from_contract_error(e as u32)
+    }
+}
+
+#[contract]
+pub struct RewardsContract;
+
+#[contractimpl]
+impl RewardsContract {
+    /// Initialises the contract with an admin address.
+    ///
+    /// # Arguments
+    /// * `env`   - The Soroban environment.
+    /// * `admin` - The address that will administer this contract.
+    ///
+    /// # Errors
+    /// Panics with `AlreadyInitialized` if called more than once.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            panic_with_error!(&env, RewardsError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        env.events()
+            .publish(("rewards", "initialized"), admin);
+    }
+
+    /// Returns the current admin address.
+    ///
+    /// # Errors
+    /// Panics with `NotInitialized` if the contract has not been initialised.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, RewardsError::NotInitialized))
+    }
+
+    /// Returns `true` if the contract has been initialised.
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Initialized)
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────
+
+    /// Asserts that `caller` is the contract admin.
+    #[allow(dead_code)]
+    fn require_admin(env: &Env, caller: &Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(env, RewardsError::NotInitialized));
+
+        if *caller != admin {
+            panic_with_error!(env, RewardsError::Unauthorized);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -1,0 +1,44 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{RewardsContract, RewardsContractClient};
+
+fn setup() -> (Env, Address, RewardsContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RewardsContract, ());
+    let client = RewardsContractClient::new(&env, &contract_id);
+    (env, admin, client)
+}
+
+#[test]
+fn test_initialize_sets_admin() {
+    let (_env, admin, client) = setup();
+    client.initialize(&admin);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_is_initialized_returns_true_after_init() {
+    let (_env, admin, client) = setup();
+    assert!(!client.is_initialized());
+    client.initialize(&admin);
+    assert!(client.is_initialized());
+}
+
+#[test]
+#[should_panic]
+fn test_double_initialize_panics() {
+    let (_env, admin, client) = setup();
+    client.initialize(&admin);
+    client.initialize(&admin);
+}
+
+#[test]
+#[should_panic]
+fn test_get_admin_before_init_panics() {
+    let (_env, _admin, client) = setup();
+    client.get_admin();
+}


### PR DESCRIPTION
# Bootstrap the Rewards Smart Contract


---

## Summary

Introduces the `rewards` crate — a new, isolated Soroban smart contract that lays the foundation for reward management within the StellarSpend protocol. The contract is intentionally minimal per the issue scope, providing a clean, tested base that future reward functionality can build on top of.

---

## Changes

### New: `contracts/rewards/`

- **`Cargo.toml`** — workspace-inherited manifest (`version`, `edition`, `license`, `repository`); configured as `cdylib` with a `testutils` feature flag, matching the conventions of other contracts in the workspace.
- **`src/lib.rs`** — `RewardsContract` with three public entry points:
  - `initialize(env, admin)` — one-shot initialisation guarded against double-calls; emits an `initialized` event.
  - `get_admin(env)` — returns the current admin address; panics with `NotInitialized` if called before init.
  - `is_initialized(env)` — lightweight boolean state check.
  - Internal `require_admin` helper scaffolded for future reward operations.
- **`src/test.rs`** — 4 unit tests covering all acceptance criteria:
  - `test_initialize_sets_admin` — init stores and returns the correct admin.
  - `test_is_initialized_returns_true_after_init` — flag is `false` before init, `true` after.
  - `test_double_initialize_panics` — second call is rejected.
  - `test_get_admin_before_init_panics` — getter panics cleanly when uninitialised.

### Modified: `Cargo.toml` (root)

- Registered `contracts/rewards` in the workspace `[members]` list.
- Fixed a pre-existing malformed `[[test]]` block (stray non-TOML text + duplicate `name`/`path` keys) that was preventing `cargo fetch` and `cargo test --workspace` from running.

---

## Test Results

```
running 4 tests
test test::test_get_admin_before_init_panics - should panic ... ok
test test::test_double_initialize_panics - should panic ... ok
test test::test_initialize_sets_admin ... ok
test test::test_is_initialized_returns_true_after_init ... ok

test result: ok. 4 passed; 0 failed; 0 ignored
```

---

## Out of Scope

This PR does not implement any reward distribution logic — that is intentionally deferred to follow-on issues. The contract is isolated from existing budgeting and savings contracts as required.

Closes #875 