### PR TITLE
Implement Programmable Spending Policy Contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "contracts/asset_control",
     "contracts/access-control",
     "contracts/category-analytics",
+    "contracts/spending-policy",
     "contracts/spending-categories",
     "contracts/user",
     "contracts/users",
@@ -45,6 +46,14 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 autotests = false
+
+[dependencies]
+# Pin ed25519-dalek to the 2.x line. soroban-env-host 22.1.3 declares
+# `ed25519-dalek = ">=2.0.0"` (no upper bound), so without this pin the
+# resolver selects the newer 3.x release whose `rand_core`/`TryRng` API is
+# incompatible with the `rand_chacha 0.3`/`rand_core 0.6` used by the env-host
+# testutils. This pin unifies the workspace on a compatible 2.x version.
+ed25519-dalek = "2.2"
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
@@ -74,6 +83,8 @@ path = "contracts/tests/concurrent_spending_tests.rs"
 [[test]]
 name = "storage_key_audit"
 path = "contracts/tests/storage_key_audit.rs"
+
+[[test]]
 name = "savings_goals_test"
 path = "contracts/tests/savings_goals_test.rs"
 

--- a/contracts/spending-policy/Cargo.toml
+++ b/contracts/spending-policy/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "spending-policy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/spending-policy/src/lib.rs
+++ b/contracts/spending-policy/src/lib.rs
@@ -1,0 +1,430 @@
+//! # Spending Policy Contract
+//!
+//! A Soroban smart contract that lets a wallet owner define a programmable
+//! rule set governing **all** outgoing transactions from their wallet.
+//!
+//! The supported rule types — all of which can be freely combined — are:
+//!
+//! | Rule                  | Effect                                                       |
+//! |-----------------------|--------------------------------------------------------------|
+//! | `CategoryLimit`       | Caps total spend per category per rolling period.           |
+//! | `MerchantAllowlist`   | Only permits recipients on the list.                        |
+//! | `MerchantBlocklist`   | Rejects recipients on the list.                             |
+//! | `TimeWindow`          | Only permits transactions within a time-of-day window.      |
+//! | `ApprovalThreshold`   | Transactions `>= threshold` require N-of-M approvals.       |
+//!
+//! ## Ownership model
+//!
+//! Each wallet address owns its own policy. `set_policy` requires the wallet
+//! address to authorise the call (`require_auth`), so only the wallet owner
+//! can create or replace their policy. There is no global admin.
+//!
+//! ## Atomic replacement
+//!
+//! `set_policy` replaces the entire rule set in a single storage write and
+//! bumps the policy `version`. Any pending (approval-bound) transactions
+//! created under a previous version are invalidated immediately: their stored
+//! `policy_version` no longer matches the current version, so a subsequent
+//! `submit_approval` for them panics with `PendingTxExpired`.
+//!
+//! ## Conflict resolution
+//!
+//! If a recipient appears on both a `MerchantAllowlist` and a
+//! `MerchantBlocklist`, the blocklist wins (`MerchantBlocked`). See the
+//! `validation` module docs for the full rationale.
+
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+mod rules;
+mod storage;
+mod types;
+mod validation;
+
+use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Symbol, Vec};
+
+pub use crate::types::{
+    ApprovalOutcome, ApprovalThresholdRule, CategoryLimitRule, DataKey, EvaluationResult,
+    MerchantAllowlistRule, MerchantBlocklistRule, PendingTransaction, Policy, PolicyRule,
+    RejectionReason, TimeWindowRule, MAX_APPROVERS, MAX_RULES, SECONDS_PER_DAY,
+};
+
+use crate::types::{PolicyEvents, PolicyRule::*};
+use crate::validation::validate_policy;
+
+/// Error codes for the spending policy contract.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SpendingPolicyError {
+    /// Caller is not authorised to manage this wallet's policy.
+    Unauthorized = 1,
+    /// No policy found for the wallet.
+    PolicyNotFound = 2,
+    /// The supplied policy rule set is malformed.
+    InvalidPolicy = 3,
+    /// A transaction amount was non-positive.
+    InvalidAmount = 4,
+    /// A `TimeWindow` rule had invalid bounds.
+    InvalidTimeWindow = 5,
+    /// An `ApprovalThreshold` rule had an invalid threshold/quorum.
+    InvalidThreshold = 6,
+    /// A pending transaction id does not exist.
+    PendingTxNotFound = 7,
+    /// An approver has already approved this pending transaction.
+    AlreadyApproved = 8,
+    /// The caller is not in the authorised approver set.
+    NotAnApprover = 9,
+    /// The pending transaction was invalidated by a policy replacement.
+    PendingTxExpired = 10,
+    /// The policy contains too many rules.
+    TooManyRules = 11,
+    /// A `CategoryLimit` rule had invalid parameters.
+    InvalidCategoryLimit = 12,
+    /// An `ApprovalThreshold` rule had an invalid approver list.
+    InvalidApproverList = 13,
+    /// A pending transaction could not be released because the category limit
+    /// would be exceeded (re-checked at release time).
+    CategoryLimitExceeded = 14,
+}
+
+impl From<SpendingPolicyError> for soroban_sdk::Error {
+    fn from(e: SpendingPolicyError) -> Self {
+        soroban_sdk::Error::from_contract_error(e as u32)
+    }
+}
+
+#[contract]
+pub struct SpendingPolicyContract;
+
+#[contractimpl]
+impl SpendingPolicyContract {
+    // -----------------------------------------------------------------------
+    // set_policy
+    // -----------------------------------------------------------------------
+
+    /// Sets the wallet's full policy rule set, atomically replacing any
+    /// existing policy.
+    ///
+    /// The `wallet` address must authorise the call. Replacing a policy bumps
+    /// its `version`, which immediately invalidates every pending transaction
+    /// created under the previous version.
+    ///
+    /// # Panics
+    /// - `Unauthorized` if the wallet does not authorise.
+    /// - A `SpendingPolicyError` if the rule set fails validation.
+    pub fn set_policy(env: Env, wallet: Address, rules: Vec<PolicyRule>) {
+        wallet.require_auth();
+
+        if let Err(e) = validate_policy(&env, &rules) {
+            panic_with_error!(&env, e);
+        }
+
+        let existing = storage::get_policy(&env, &wallet);
+        let new_version = match &existing {
+            Some(p) => p.version.wrapping_add(1),
+            None => 1,
+        };
+        let now = env.ledger().timestamp();
+
+        let policy = Policy {
+            rules,
+            version: new_version,
+            updated_at: now,
+        };
+
+        // Single storage write => atomic replacement.
+        storage::set_policy(&env, &wallet, &policy);
+
+        if existing.is_some() {
+            PolicyEvents::policy_replaced(&env, &wallet, new_version);
+        } else {
+            PolicyEvents::policy_set(&env, &wallet, new_version);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // evaluate_transaction
+    // -----------------------------------------------------------------------
+
+    /// Evaluates a proposed outgoing transaction against the wallet's policy.
+    ///
+    /// Must be called **before** the transaction is executed. On `Approved`
+    /// the category spend (if any matching `CategoryLimit` rule exists) is
+    /// recorded immediately. On `PendingApproval` the transaction is held
+    /// pending until enough approvals are collected via `submit_approval`.
+    ///
+    /// # Evaluation order (deterministic)
+    /// 1. Amount sanity (`> 0`).
+    /// 2. `MerchantBlocklist` — reject if recipient on any blocklist.
+    /// 3. `MerchantAllowlist` — reject if recipient missing from any allowlist.
+    /// 4. `TimeWindow` — reject if outside any window.
+    /// 5. `CategoryLimit` — reject if the category spend would exceed the cap.
+    /// 6. `ApprovalThreshold` — if amount `>= threshold`, hold pending.
+    /// 7. Otherwise `Approved` (and category spend is recorded).
+    ///
+    /// A wallet with no policy has no restrictions and the transaction is
+    /// approved.
+    pub fn evaluate_transaction(
+        env: Env,
+        wallet: Address,
+        recipient: Address,
+        amount: i128,
+        category: Option<Symbol>,
+    ) -> EvaluationResult {
+        wallet.require_auth();
+
+        if amount <= 0 {
+            let reason = RejectionReason::InvalidAmount;
+            PolicyEvents::tx_rejected(&env, &wallet, amount, &reason);
+            return EvaluationResult::Rejected(reason);
+        }
+
+        let policy = match storage::get_policy(&env, &wallet) {
+            Some(p) => p,
+            None => {
+                // No policy => no restrictions.
+                PolicyEvents::tx_approved(&env, &wallet, amount);
+                return EvaluationResult::Approved;
+            }
+        };
+
+        let now = env.ledger().timestamp();
+
+        // 1. Blocklists (union): blocklist wins over allowlist.
+        for rule in policy.rules.iter() {
+            if let MerchantBlocklist(br) = rule {
+                if rules::is_blocked(&recipient, &br) {
+                    let reason = RejectionReason::MerchantBlocked;
+                    PolicyEvents::tx_rejected(&env, &wallet, amount, &reason);
+                    return EvaluationResult::Rejected(reason);
+                }
+            }
+        }
+
+        // 2. Allowlists (intersection): must be present in every allowlist.
+        for rule in policy.rules.iter() {
+            if let MerchantAllowlist(ar) = rule {
+                if !rules::is_allowed(&recipient, &ar) {
+                    let reason = RejectionReason::MerchantNotAllowed;
+                    PolicyEvents::tx_rejected(&env, &wallet, amount, &reason);
+                    return EvaluationResult::Rejected(reason);
+                }
+            }
+        }
+
+        // 3. Time windows: must be inside every window.
+        for rule in policy.rules.iter() {
+            if let TimeWindow(tw) = rule {
+                if !rules::is_in_time_window(now, &tw) {
+                    let reason = RejectionReason::OutsideTimeWindow;
+                    PolicyEvents::tx_rejected(&env, &wallet, amount, &reason);
+                    return EvaluationResult::Rejected(reason);
+                }
+            }
+        }
+
+        // 4. Category limits: check every matching category.
+        if let Some(ref cat) = category {
+            for rule in policy.rules.iter() {
+                if let CategoryLimit(cl) = rule {
+                    if *cat == cl.category
+                        && !rules::is_within_category_limit(&env, &wallet, amount, cat, &cl)
+                    {
+                        let reason = RejectionReason::CategoryLimitExceeded;
+                        PolicyEvents::tx_rejected(&env, &wallet, amount, &reason);
+                        return EvaluationResult::Rejected(reason);
+                    }
+                }
+            }
+        }
+
+        // 5. Approval threshold: the first threshold rule governs. If the
+        //    amount reaches it, hold the transaction pending.
+        let mut threshold: Option<ApprovalThresholdRule> = None;
+        for rule in policy.rules.iter() {
+            if let ApprovalThreshold(at) = rule {
+                threshold = Some(at);
+                break;
+            }
+        }
+
+        if let Some(at) = threshold {
+            if amount >= at.threshold_amount {
+                let pending_id = storage::get_next_pending_id(&env);
+                storage::set_next_pending_id(&env, pending_id + 1);
+
+                let pending = PendingTransaction {
+                    id: pending_id,
+                    wallet: wallet.clone(),
+                    recipient: recipient.clone(),
+                    amount,
+                    category: category.clone(),
+                    created_at: now,
+                    policy_version: policy.version,
+                    authorized_approvers: at.approvers.clone(),
+                    approvers: Vec::new(&env),
+                    required_approvals: at.required_approvals,
+                };
+                storage::set_pending_tx(&env, &pending);
+
+                let mut ids = storage::get_pending_ids_for_wallet(&env, &wallet);
+                ids.push_back(pending_id);
+                storage::set_pending_ids_for_wallet(&env, &wallet, &ids);
+
+                PolicyEvents::tx_pending(&env, &wallet, pending_id, amount);
+                return EvaluationResult::PendingApproval(pending_id);
+            }
+        }
+
+        // 6. All rules passed and no approval required => approved. Record
+        //    category spend for any matching CategoryLimit rule.
+        if let Some(ref cat) = category {
+            for rule in policy.rules.iter() {
+                if let CategoryLimit(cl) = rule {
+                    if *cat == cl.category {
+                        rules::record_category_spend(&env, &wallet, amount, cat, &cl);
+                    }
+                }
+            }
+        }
+
+        PolicyEvents::tx_approved(&env, &wallet, amount);
+        EvaluationResult::Approved
+    }
+
+    // -----------------------------------------------------------------------
+    // submit_approval
+    // -----------------------------------------------------------------------
+
+    /// Submits an approval for a pending (above-threshold) transaction.
+    ///
+    /// Once the number of distinct approvals reaches `required_approvals` the
+    /// transaction is **auto-released**: the category spend is recorded (after
+    /// a final re-check of any matching `CategoryLimit`) and the pending
+    /// record is removed.
+    ///
+    /// # Panics
+    /// - `PendingTxNotFound` if `pending_id` does not exist.
+    /// - `PendingTxExpired` if the policy was replaced since the transaction
+    ///   was created.
+    /// - `NotAnApprover` if the caller is not in the authorised approver set.
+    /// - `AlreadyApproved` if the caller has already approved.
+    /// - `CategoryLimitExceeded` if, at release time, the category limit would
+    ///   be exceeded.
+    pub fn submit_approval(env: Env, approver: Address, pending_id: u64) -> ApprovalOutcome {
+        approver.require_auth();
+
+        let mut pending = storage::get_pending_tx(&env, pending_id)
+            .unwrap_or_else(|| panic_with_error!(&env, SpendingPolicyError::PendingTxNotFound));
+
+        let policy = storage::get_policy(&env, &pending.wallet)
+            .unwrap_or_else(|| panic_with_error!(&env, SpendingPolicyError::PolicyNotFound));
+
+        // Policy replacement invalidates pending transactions from old versions.
+        if pending.policy_version != policy.version {
+            panic_with_error!(&env, SpendingPolicyError::PendingTxExpired);
+        }
+
+        // The caller must be in the authorised approver set.
+        if !pending.authorized_approvers.contains(&approver) {
+            panic_with_error!(&env, SpendingPolicyError::NotAnApprover);
+        }
+
+        // No double-approval.
+        if pending.approvers.contains(&approver) {
+            panic_with_error!(&env, SpendingPolicyError::AlreadyApproved);
+        }
+
+        pending.approvers.push_back(approver.clone());
+        let count = pending.approvers.len();
+
+        if count >= pending.required_approvals {
+            // Auto-release. Re-check category limits before recording spend.
+            if let Some(ref cat) = pending.category {
+                for rule in policy.rules.iter() {
+                    if let CategoryLimit(cl) = rule {
+                        if *cat == cl.category
+                            && !rules::is_within_category_limit(
+                                &env,
+                                &pending.wallet,
+                                pending.amount,
+                                cat,
+                                &cl,
+                            )
+                        {
+                            // Release fails: clean up the pending record and fail.
+                            storage::remove_pending_tx(&env, pending_id);
+                            storage::remove_pending_id_from_wallet(&env, &pending.wallet, pending_id);
+                            panic_with_error!(&env, SpendingPolicyError::CategoryLimitExceeded);
+                        }
+                    }
+                }
+            }
+
+            // Record category spend for matching rules.
+            if let Some(ref cat) = pending.category {
+                for rule in policy.rules.iter() {
+                    if let CategoryLimit(cl) = rule {
+                        if *cat == cl.category {
+                            rules::record_category_spend(
+                                &env,
+                                &pending.wallet,
+                                pending.amount,
+                                cat,
+                                &cl,
+                            );
+                        }
+                    }
+                }
+            }
+
+            storage::remove_pending_tx(&env, pending_id);
+            storage::remove_pending_id_from_wallet(&env, &pending.wallet, pending_id);
+
+            PolicyEvents::pending_released(&env, &pending.wallet, pending_id);
+            PolicyEvents::tx_approved(&env, &pending.wallet, pending.amount);
+            ApprovalOutcome::Approved
+        } else {
+            storage::set_pending_tx(&env, &pending);
+            PolicyEvents::approval_submitted(&env, &pending.wallet, pending_id, &approver);
+            ApprovalOutcome::Pending(count)
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Read-only accessors
+    // -----------------------------------------------------------------------
+
+    /// Returns the current policy for `wallet`, or `None` if none is set.
+    pub fn get_policy(env: Env, wallet: Address) -> Option<Policy> {
+        storage::get_policy(&env, &wallet)
+    }
+
+    /// Returns a pending transaction by id (if it still exists).
+    pub fn get_pending_transaction(env: Env, pending_id: u64) -> Option<PendingTransaction> {
+        storage::get_pending_tx(&env, pending_id)
+    }
+
+    /// Returns the list of pending transaction ids currently held for `wallet`.
+    pub fn get_pending_ids_for_wallet(env: Env, wallet: Address) -> Vec<u64> {
+        storage::get_pending_ids_for_wallet(&env, &wallet)
+    }
+
+    /// Returns the recorded spend for `(wallet, category, period_id)`.
+    ///
+    /// `period_id` should be computed as `floor(ledger_timestamp / period_seconds)`
+    /// for the relevant `CategoryLimitRule`.
+    pub fn get_category_spending(
+        env: Env,
+        wallet: Address,
+        category: Symbol,
+        period_id: u64,
+    ) -> i128 {
+        storage::get_category_spending(&env, &wallet, &category, period_id)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/spending-policy/src/rules.rs
+++ b/contracts/spending-policy/src/rules.rs
@@ -1,0 +1,75 @@
+//! Per-rule evaluation helpers.
+//!
+//! Each helper is pure (with the exception of category-limit checks which read
+//! ledger time and spend tracking from storage) so that the orchestration in
+//! `lib::evaluate_transaction` stays readable and the order of enforcement is
+//! explicit and deterministic.
+
+use soroban_sdk::{Address, Env, Symbol};
+
+use crate::storage;
+use crate::types::{
+    CategoryLimitRule, MerchantAllowlistRule, MerchantBlocklistRule, TimeWindowRule,
+    SECONDS_PER_DAY,
+};
+
+/// Returns `true` if `recipient` is present on the blocklist.
+pub fn is_blocked(recipient: &Address, rule: &MerchantBlocklistRule) -> bool {
+    rule.blocked.contains(recipient)
+}
+
+/// Returns `true` if `recipient` is present on the allowlist.
+pub fn is_allowed(recipient: &Address, rule: &MerchantAllowlistRule) -> bool {
+    rule.allowed.contains(recipient)
+}
+
+/// Returns `true` if `now` (a ledger timestamp) falls within the permitted
+/// time-of-day window.
+pub fn is_in_time_window(now: u64, rule: &TimeWindowRule) -> bool {
+    let time_of_day = now % SECONDS_PER_DAY;
+    if rule.start_seconds <= rule.end_seconds {
+        // Normal range: [start, end)
+        time_of_day >= rule.start_seconds && time_of_day < rule.end_seconds
+    } else {
+        // Wrap-around range spanning midnight: [start, 86400) ∪ [0, end)
+        time_of_day >= rule.start_seconds || time_of_day < rule.end_seconds
+    }
+}
+
+/// Returns `true` if spending `amount` in `category` for `wallet` would remain
+/// within the configured `max_amount` for the current period.
+pub fn is_within_category_limit(
+    env: &Env,
+    wallet: &Address,
+    amount: i128,
+    category: &Symbol,
+    rule: &CategoryLimitRule,
+) -> bool {
+    let period_id = current_period_id(env, rule);
+    let current = storage::get_category_spending(env, wallet, category, period_id);
+    match current.checked_add(amount) {
+        Some(total) => total <= rule.max_amount,
+        None => false, // overflow => exceeds
+    }
+}
+
+/// Records `amount` of spending against `wallet`/`category` for the current
+/// period. Called only once a transaction is definitively approved.
+pub fn record_category_spend(
+    env: &Env,
+    wallet: &Address,
+    amount: i128,
+    category: &Symbol,
+    rule: &CategoryLimitRule,
+) {
+    let period_id = current_period_id(env, rule);
+    let current = storage::get_category_spending(env, wallet, category, period_id);
+    let new_total = current.checked_add(amount).unwrap_or(i128::MAX);
+    storage::set_category_spending(env, wallet, category, period_id, new_total);
+}
+
+/// Computes the current period identifier from the ledger timestamp.
+pub fn current_period_id(env: &Env, rule: &CategoryLimitRule) -> u64 {
+    let now = env.ledger().timestamp();
+    now / rule.period_seconds
+}

--- a/contracts/spending-policy/src/storage.rs
+++ b/contracts/spending-policy/src/storage.rs
@@ -1,0 +1,106 @@
+//! Storage helpers for the spending policy contract.
+//!
+//! All accessors are thin wrappers around the Soroban storage API. Policy and
+//! per-wallet data live in persistent storage; the pending-id counter lives in
+//! instance storage.
+
+use soroban_sdk::{Address, Env, Symbol, Vec};
+
+use crate::types::{DataKey, Policy, PendingTransaction};
+
+// --- Policy -----------------------------------------------------------------
+
+pub fn get_policy(env: &Env, wallet: &Address) -> Option<Policy> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Policy(wallet.clone()))
+}
+
+pub fn set_policy(env: &Env, wallet: &Address, policy: &Policy) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Policy(wallet.clone()), policy);
+}
+
+// --- Pending id counter -----------------------------------------------------
+
+pub fn get_next_pending_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::NextPendingId)
+        .unwrap_or(0)
+}
+
+pub fn set_next_pending_id(env: &Env, id: u64) {
+    env.storage().instance().set(&DataKey::NextPendingId, &id);
+}
+
+// --- Pending transactions ---------------------------------------------------
+
+pub fn get_pending_tx(env: &Env, id: u64) -> Option<PendingTransaction> {
+    env.storage().persistent().get(&DataKey::PendingTx(id))
+}
+
+pub fn set_pending_tx(env: &Env, pending: &PendingTransaction) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::PendingTx(pending.id), pending);
+}
+
+pub fn remove_pending_tx(env: &Env, id: u64) {
+    env.storage().persistent().remove(&DataKey::PendingTx(id));
+}
+
+// --- Per-wallet pending index ----------------------------------------------
+
+pub fn get_pending_ids_for_wallet(env: &Env, wallet: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PendingByWallet(wallet.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_pending_ids_for_wallet(env: &Env, wallet: &Address, ids: &Vec<u64>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::PendingByWallet(wallet.clone()), ids);
+}
+
+/// Remove a pending id from a wallet's pending index (no-op if absent).
+pub fn remove_pending_id_from_wallet(env: &Env, wallet: &Address, id: u64) {
+    let ids = get_pending_ids_for_wallet(env, wallet);
+    let mut new_ids: Vec<u64> = Vec::new(env);
+    for x in ids.iter() {
+        if x != id {
+            new_ids.push_back(x);
+        }
+    }
+    set_pending_ids_for_wallet(env, wallet, &new_ids);
+}
+
+// --- Category spend tracking ------------------------------------------------
+
+pub fn get_category_spending(
+    env: &Env,
+    wallet: &Address,
+    category: &Symbol,
+    period_id: u64,
+) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CategorySpending(wallet.clone(), category.clone(), period_id))
+        .unwrap_or(0)
+}
+
+pub fn set_category_spending(
+    env: &Env,
+    wallet: &Address,
+    category: &Symbol,
+    period_id: u64,
+    amount: i128,
+) {
+    env.storage().persistent().set(
+        &DataKey::CategorySpending(wallet.clone(), category.clone(), period_id),
+        &amount,
+    );
+}

--- a/contracts/spending-policy/src/test.rs
+++ b/contracts/spending-policy/src/test.rs
@@ -1,0 +1,905 @@
+//! Comprehensive tests for the spending policy contract.
+//!
+//! Coverage:
+//! - Each rule type in isolation (CategoryLimit, MerchantAllowlist,
+//!   MerchantBlocklist, TimeWindow, ApprovalThreshold).
+//! - Rule combinations (blocklist+allowlist conflict, CategoryLimit +
+//!   ApprovalThreshold running together).
+//! - The full approval flow (pending → approvals → auto-release).
+//! - Policy replacement: atomicity and invalidation of pending approvals.
+
+#![cfg(test)]
+
+use crate::{
+    ApprovalOutcome, EvaluationResult, PolicyRule, RejectionReason, SpendingPolicyContract,
+    SpendingPolicyContractClient,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env, Symbol, Vec,
+};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup() -> (Env, SpendingPolicyContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SpendingPolicyContract, ());
+    let client = SpendingPolicyContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn addr_vec(env: &Env, addrs: &[&Address]) -> Vec<Address> {
+    let mut v = Vec::new(env);
+    for a in addrs {
+        v.push_back((*a).clone());
+    }
+    v
+}
+
+fn category_rule(category: Symbol, max: i128, period: u64) -> PolicyRule {
+    PolicyRule::CategoryLimit(crate::CategoryLimitRule {
+        category,
+        max_amount: max,
+        period_seconds: period,
+    })
+}
+
+fn allowlist_rule(env: &Env, addrs: &[&Address]) -> PolicyRule {
+    PolicyRule::MerchantAllowlist(crate::MerchantAllowlistRule {
+        allowed: addr_vec(env, addrs),
+    })
+}
+
+fn blocklist_rule(env: &Env, addrs: &[&Address]) -> PolicyRule {
+    PolicyRule::MerchantBlocklist(crate::MerchantBlocklistRule {
+        blocked: addr_vec(env, addrs),
+    })
+}
+
+fn time_window_rule(start: u64, end: u64) -> PolicyRule {
+    PolicyRule::TimeWindow(crate::TimeWindowRule {
+        start_seconds: start,
+        end_seconds: end,
+    })
+}
+
+fn threshold_rule(env: &Env, threshold: i128, required: u32, approvers: &[&Address]) -> PolicyRule {
+    PolicyRule::ApprovalThreshold(crate::ApprovalThresholdRule {
+        threshold_amount: threshold,
+        required_approvals: required,
+        approvers: addr_vec(env, approvers),
+    })
+}
+
+fn single_rule(env: &Env, rule: PolicyRule) -> Vec<PolicyRule> {
+    let mut rules: Vec<PolicyRule> = Vec::new(env);
+    rules.push_back(rule);
+    rules
+}
+
+// ---------------------------------------------------------------------------
+// set_policy / get_policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_set_and_get_policy() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let rules = single_rule(
+        &env,
+        blocklist_rule(&env, &[&merchant]),
+    );
+
+    client.set_policy(&wallet, &rules);
+
+    let policy = client.get_policy(&wallet).unwrap();
+    assert_eq!(policy.version, 1);
+    assert_eq!(policy.rules.len(), 1);
+}
+
+#[test]
+fn test_owner_can_set_policy() {
+    // With mock_all_auths the wallet owner (wallet address) authorises and the
+    // call succeeds. This is the positive counterpart to the authorization
+    // test below.
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let rules: Vec<PolicyRule> = Vec::new(&env);
+    client.set_policy(&wallet, &rules);
+    assert!(client.get_policy(&wallet).is_some());
+}
+
+#[test]
+fn test_set_policy_requires_authorization() {
+    // Deliberately do NOT mock auths. The wallet address must authorise the
+    // call, so an unauthorised set_policy must fail. This enforces the
+    // "non-owner cannot set or modify a wallet's policy" requirement.
+    let env = Env::default();
+    let contract_id = env.register(SpendingPolicyContract, ());
+    let client = SpendingPolicyContractClient::new(&env, &contract_id);
+    let wallet = Address::generate(&env);
+    let rules: Vec<PolicyRule> = Vec::new(&env);
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_policy(&wallet, &rules);
+    }));
+    assert!(result.is_err(), "set_policy must require authorization");
+}
+
+#[test]
+fn test_set_policy_replaces_atomically_and_bumps_version() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let merchant_a = Address::generate(&env);
+    let merchant_b = Address::generate(&env);
+
+    // v1: block merchant_a.
+    client.set_policy(&wallet, &single_rule(&env, blocklist_rule(&env, &[&merchant_a])));
+    assert_eq!(client.get_policy(&wallet).unwrap().version, 1);
+
+    // v2: block merchant_b instead.
+    client.set_policy(&wallet, &single_rule(&env, blocklist_rule(&env, &[&merchant_b])));
+    let policy = client.get_policy(&wallet).unwrap();
+    assert_eq!(policy.version, 2);
+    assert_eq!(policy.rules.len(), 1);
+}
+
+#[test]
+fn test_policy_replacement_is_atomic() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    // v1: a valid policy.
+    let v1 = single_rule(&env, blocklist_rule(&env, &[&merchant]));
+    client.set_policy(&wallet, &v1);
+    assert_eq!(client.get_policy(&wallet).unwrap().version, 1);
+
+    // Attempt to set an invalid policy (empty time window). This must panic
+    // and leave v1 completely untouched.
+    let invalid = single_rule(&env, time_window_rule(21_600, 21_600));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_policy(&wallet, &invalid);
+    }));
+    assert!(result.is_err(), "invalid policy must be rejected");
+
+    let policy = client.get_policy(&wallet).unwrap();
+    assert_eq!(policy.version, 1, "version must be unchanged after failed replace");
+    assert_eq!(policy.rules.len(), 1, "rules must be unchanged after failed replace");
+}
+
+#[test]
+fn test_too_many_rules_rejected() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let mut rules: Vec<PolicyRule> = Vec::new(&env);
+    for _ in 0..(crate::MAX_RULES + 1) {
+        rules.push_back(blocklist_rule(&env, &[&merchant]));
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_policy(&wallet, &rules);
+    }));
+    assert!(result.is_err(), "policies exceeding MAX_RULES must be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// No policy / invalid amount
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_policy_approves_transaction() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let result = client.evaluate_transaction(&wallet, &recipient, &100, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Approved);
+}
+
+#[test]
+fn test_invalid_amount_rejected() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Set a policy so we exercise the post-policy path.
+    let merchant = Address::generate(&env);
+    client.set_policy(&wallet, &single_rule(&env, blocklist_rule(&env, &[&merchant])));
+
+    let result = client.evaluate_transaction(&wallet, &recipient, &0, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Rejected(RejectionReason::InvalidAmount));
+
+    let result = client.evaluate_transaction(&wallet, &recipient, &-50, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Rejected(RejectionReason::InvalidAmount));
+}
+
+// ---------------------------------------------------------------------------
+// CategoryLimit
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_category_limit_allows_within_limit() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    env.ledger().set_timestamp(1000);
+
+    client.set_policy(&wallet, &single_rule(&env, category_rule(symbol_short!("groc"), 1000, 3600)));
+
+    let cat = Some(symbol_short!("groc"));
+    let result = client.evaluate_transaction(&wallet, &recipient, &600, &cat);
+    assert_eq!(result, EvaluationResult::Approved);
+
+    // Spend recorded for the current period.
+    let period_id = 1000u64 / 3600;
+    assert_eq!(client.get_category_spending(&wallet, &symbol_short!("groc"), &period_id), 600);
+}
+
+#[test]
+fn test_category_limit_rejects_over_limit() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    env.ledger().set_timestamp(1000);
+
+    client.set_policy(&wallet, &single_rule(&env, category_rule(symbol_short!("groc"), 1000, 3600)));
+
+    let cat = Some(symbol_short!("groc"));
+    // First 600 is fine.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &600, &cat),
+        EvaluationResult::Approved
+    );
+    // 600 + 500 = 1100 > 1000 -> rejected.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &500, &cat),
+        EvaluationResult::Rejected(RejectionReason::CategoryLimitExceeded)
+    );
+}
+
+#[test]
+fn test_category_limit_resets_after_period() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, category_rule(symbol_short!("groc"), 1000, 3600)));
+
+    let cat = Some(symbol_short!("groc"));
+
+    // Period 0.
+    env.ledger().set_timestamp(1000);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &600, &cat),
+        EvaluationResult::Approved
+    );
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &500, &cat),
+        EvaluationResult::Rejected(RejectionReason::CategoryLimitExceeded)
+    );
+
+    // Advance into period 1 -> spending resets.
+    env.ledger().set_timestamp(1000 + 3600);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &500, &cat),
+        EvaluationResult::Approved
+    );
+
+    assert_eq!(client.get_category_spending(&wallet, &symbol_short!("groc"), &0), 600);
+    assert_eq!(client.get_category_spending(&wallet, &symbol_short!("groc"), &1), 500);
+}
+
+#[test]
+fn test_category_limit_does_not_apply_to_other_categories() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    env.ledger().set_timestamp(1000);
+
+    client.set_policy(&wallet, &single_rule(&env, category_rule(symbol_short!("groc"), 1000, 3600)));
+
+    // A transaction in a different category is unaffected.
+    let dining = Some(symbol_short!("dining"));
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &5_000_000, &dining),
+        EvaluationResult::Approved
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MerchantAllowlist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_merchant_allowlist_allows_listed() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, allowlist_rule(&env, &[&merchant])));
+
+    let result = client.evaluate_transaction(&wallet, &merchant, &100, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Approved);
+}
+
+#[test]
+fn test_merchant_allowlist_rejects_unlisted() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let listed = Address::generate(&env);
+    let unknown = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, allowlist_rule(&env, &[&listed])));
+
+    let result = client.evaluate_transaction(&wallet, &unknown, &100, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Rejected(RejectionReason::MerchantNotAllowed));
+}
+
+// ---------------------------------------------------------------------------
+// MerchantBlocklist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_merchant_blocklist_rejects_listed() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let blocked = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, blocklist_rule(&env, &[&blocked])));
+
+    let result = client.evaluate_transaction(&wallet, &blocked, &100, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Rejected(RejectionReason::MerchantBlocked));
+}
+
+#[test]
+fn test_merchant_blocklist_allows_unlisted() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let blocked = Address::generate(&env);
+    let ok = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, blocklist_rule(&env, &[&blocked])));
+
+    let result = client.evaluate_transaction(&wallet, &ok, &100, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Approved);
+}
+
+// ---------------------------------------------------------------------------
+// Conflict: blocklist wins over allowlist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_blocklist_takes_precedence_over_allowlist() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    // Merchant is on BOTH lists. Blocklist must win.
+    let mut rules: Vec<PolicyRule> = Vec::new(&env);
+    rules.push_back(allowlist_rule(&env, &[&merchant]));
+    rules.push_back(blocklist_rule(&env, &[&merchant]));
+    client.set_policy(&wallet, &rules);
+
+    let result = client.evaluate_transaction(&wallet, &merchant, &100, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Rejected(RejectionReason::MerchantBlocked));
+}
+
+#[test]
+fn test_allowlist_and_blocklist_combined() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let allowed = Address::generate(&env);
+    let blocked = Address::generate(&env);
+
+    let mut rules: Vec<PolicyRule> = Vec::new(&env);
+    rules.push_back(allowlist_rule(&env, &[&allowed, &blocked]));
+    rules.push_back(blocklist_rule(&env, &[&blocked]));
+    client.set_policy(&wallet, &rules);
+
+    // `allowed` is on the allowlist and not blocked -> approved.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &allowed, &100, &None::<Symbol>),
+        EvaluationResult::Approved
+    );
+    // `blocked` is on both -> blocked.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &blocked, &100, &None::<Symbol>),
+        EvaluationResult::Rejected(RejectionReason::MerchantBlocked)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TimeWindow
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_time_window_allows_during_window() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Allow 06:00 -> midnight (blocks midnight -> 06:00).
+    client.set_policy(&wallet, &single_rule(&env, time_window_rule(21_600, 86_400)));
+
+    // 12:00 noon -> within window.
+    env.ledger().set_timestamp(43_200);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &100, &None::<Symbol>),
+        EvaluationResult::Approved
+    );
+}
+
+#[test]
+fn test_time_window_rejects_outside_window() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Allow 06:00 -> midnight (blocks midnight -> 06:00).
+    client.set_policy(&wallet, &single_rule(&env, time_window_rule(21_600, 86_400)));
+
+    // 03:00 -> outside window.
+    env.ledger().set_timestamp(10_800);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &100, &None::<Symbol>),
+        EvaluationResult::Rejected(RejectionReason::OutsideTimeWindow)
+    );
+}
+
+#[test]
+fn test_time_window_wrap_around_past_midnight() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    // Allow 22:00 -> 02:00 (wraps midnight).
+    client.set_policy(&wallet, &single_rule(&env, time_window_rule(79_200, 7_200)));
+
+    // 23:00 (82800) -> within.
+    env.ledger().set_timestamp(82_800);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &100, &None::<Symbol>),
+        EvaluationResult::Approved
+    );
+
+    // 01:00 (3600) -> within (wrapped).
+    env.ledger().set_timestamp(3_600);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &100, &None::<Symbol>),
+        EvaluationResult::Approved
+    );
+
+    // 12:00 (43200) -> outside.
+    env.ledger().set_timestamp(43_200);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &100, &None::<Symbol>),
+        EvaluationResult::Rejected(RejectionReason::OutsideTimeWindow)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ApprovalThreshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_approval_threshold_creates_pending() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 2, &[&bob, &carol])));
+
+    let result = client.evaluate_transaction(&wallet, &recipient, &1500, &None::<Symbol>);
+    match result {
+        EvaluationResult::PendingApproval(id) => {
+            let pending = client.get_pending_transaction(&id).unwrap();
+            assert_eq!(pending.wallet, wallet);
+            assert_eq!(pending.recipient, recipient);
+            assert_eq!(pending.amount, 1500);
+            assert_eq!(pending.required_approvals, 2);
+            assert_eq!(pending.approvers.len(), 0);
+            assert_eq!(pending.authorized_approvers.len(), 2);
+        }
+        other => panic!("expected PendingApproval, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_approval_threshold_below_threshold_approved() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 1, &[&bob])));
+
+    // Below threshold -> approved immediately.
+    let result = client.evaluate_transaction(&wallet, &recipient, &500, &None::<Symbol>);
+    assert_eq!(result, EvaluationResult::Approved);
+}
+
+#[test]
+fn test_approval_threshold_auto_releases_after_n_approvals() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 2, &[&bob, &carol])));
+
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &1500, &None::<Symbol>)
+    {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    // First approval -> still pending.
+    assert_eq!(
+        client.submit_approval(&bob, &pending_id),
+        ApprovalOutcome::Pending(1)
+    );
+
+    // Second approval -> auto-released.
+    assert_eq!(client.submit_approval(&carol, &pending_id), ApprovalOutcome::Approved);
+
+    // Pending record removed.
+    assert!(client.get_pending_transaction(&pending_id).is_none());
+    assert_eq!(client.get_pending_ids_for_wallet(&wallet).len(), 0);
+}
+
+#[test]
+fn test_approval_threshold_insufficient_approvals_stay_pending() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    let dave = Address::generate(&env);
+
+    client.set_policy(
+        &wallet,
+        &single_rule(&env, threshold_rule(&env, 1000, 3, &[&bob, &carol, &dave])),
+    );
+
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &2000, &None::<Symbol>)
+    {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    assert_eq!(
+        client.submit_approval(&bob, &pending_id),
+        ApprovalOutcome::Pending(1)
+    );
+    assert_eq!(
+        client.submit_approval(&carol, &pending_id),
+        ApprovalOutcome::Pending(2)
+    );
+
+    // Still pending.
+    assert!(client.get_pending_transaction(&pending_id).is_some());
+}
+
+#[test]
+fn test_approval_threshold_non_approver_fails() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let mallory = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 1, &[&bob])));
+
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &1500, &None::<Symbol>)
+    {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.submit_approval(&mallory, &pending_id);
+    }));
+    assert!(result.is_err(), "non-approver must be rejected");
+
+    // Pending tx unchanged.
+    let pending = client.get_pending_transaction(&pending_id).unwrap();
+    assert_eq!(pending.approvers.len(), 0);
+}
+
+#[test]
+fn test_approval_threshold_double_approval_fails() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 2, &[&bob, &carol])));
+
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &1500, &None::<Symbol>)
+    {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    // First approval ok.
+    client.submit_approval(&bob, &pending_id);
+
+    // Same approver again -> rejected.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.submit_approval(&bob, &pending_id);
+    }));
+    assert!(result.is_err(), "double approval must be rejected");
+
+    let pending = client.get_pending_transaction(&pending_id).unwrap();
+    assert_eq!(pending.approvers.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Combined: CategoryLimit + ApprovalThreshold
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_combined_category_limit_and_approval_threshold() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    let period = 86_400u64;
+    let mut rules: Vec<PolicyRule> = Vec::new(&env);
+    rules.push_back(category_rule(symbol_short!("groc"), 5000, period));
+    rules.push_back(threshold_rule(&env, 1000, 2, &[&bob, &carol]));
+    client.set_policy(&wallet, &rules);
+
+    let ts = 5 * period; // a known period (id = 5)
+    env.ledger().set_timestamp(ts);
+
+    let cat = Some(symbol_short!("groc"));
+
+    // 1500 is within the category limit (0 + 1500 <= 5000) and >= threshold.
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &1500, &cat) {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    // Category spend must NOT be recorded yet (pending until released).
+    let period_id = ts / period;
+    assert_eq!(client.get_category_spending(&wallet, &symbol_short!("groc"), &period_id), 0);
+
+    // Collect approvals -> auto-released, spend recorded.
+    client.submit_approval(&bob, &pending_id);
+    assert_eq!(client.submit_approval(&carol, &pending_id), ApprovalOutcome::Approved);
+    assert_eq!(
+        client.get_category_spending(&wallet, &symbol_short!("groc"), &period_id),
+        1500
+    );
+
+    // Now another 4000 groceries would exceed 5000 -> rejected.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &recipient, &4000, &cat),
+        EvaluationResult::Rejected(RejectionReason::CategoryLimitExceeded)
+    );
+}
+
+#[test]
+fn test_combined_all_rule_types() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let good_merchant = Address::generate(&env);
+    let bad_merchant = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let mut rules: Vec<PolicyRule> = Vec::new(&env);
+    rules.push_back(blocklist_rule(&env, &[&bad_merchant]));
+    rules.push_back(allowlist_rule(&env, &[&good_merchant]));
+    rules.push_back(time_window_rule(21_600, 86_400)); // 06:00 -> midnight
+    rules.push_back(category_rule(symbol_short!("groc"), 5000, 86_400));
+    rules.push_back(threshold_rule(&env, 1000, 1, &[&bob]));
+    client.set_policy(&wallet, &rules);
+
+    // During the allowed window.
+    env.ledger().set_timestamp(43_200); // noon
+
+    let cat = Some(symbol_short!("groc"));
+
+    // Blocked merchant -> rejected even though it is also on the allowlist? No,
+    // good_merchant is the allowlisted one. bad_merchant is blocked.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &bad_merchant, &100, &cat),
+        EvaluationResult::Rejected(RejectionReason::MerchantBlocked)
+    );
+
+    // Unknown merchant -> not on allowlist.
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &stranger, &100, &cat),
+        EvaluationResult::Rejected(RejectionReason::MerchantNotAllowed)
+    );
+
+    // good_merchant, below threshold, within window, within category -> approved.
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &good_merchant, &500, &cat),
+        EvaluationResult::Approved
+    );
+
+    // good_merchant, above threshold -> pending.
+    let pending_id = match client.evaluate_transaction(&wallet, &good_merchant, &1500, &cat) {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    // Outside the time window -> rejected.
+    env.ledger().set_timestamp(10_800); // 03:00
+    assert_eq!(
+        client.evaluate_transaction(&wallet, &good_merchant, &100, &cat),
+        EvaluationResult::Rejected(RejectionReason::OutsideTimeWindow)
+    );
+
+    // The pending tx from before can still be approved (policy unchanged).
+    env.ledger().set_timestamp(43_200); // back to noon for period consistency
+    assert_eq!(client.submit_approval(&bob, &pending_id), ApprovalOutcome::Approved);
+}
+
+// ---------------------------------------------------------------------------
+// Policy replacement invalidates pending approvals
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_policy_replacement_invalidates_pending_approvals() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    // v1: requires 2 approvals.
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 2, &[&bob, &carol])));
+
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &1500, &None::<Symbol>)
+    {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    // One approval collected under v1.
+    client.submit_approval(&bob, &pending_id);
+
+    // Replace the policy (v2). This bumps the version and invalidates the
+    // pending transaction created under v1.
+    let new_rules = single_rule(&env, threshold_rule(&env, 1000, 1, &[&bob]));
+    client.set_policy(&wallet, &new_rules);
+    assert_eq!(client.get_policy(&wallet).unwrap().version, 2);
+
+    // Submitting another approval for the old pending tx must now fail.
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.submit_approval(&carol, &pending_id);
+    }));
+    assert!(
+        result.is_err(),
+        "pending approvals from the old policy must be invalidated"
+    );
+
+    // The pending record itself is still queryable but effectively dead.
+    let pending = client.get_pending_transaction(&pending_id).unwrap();
+    assert_eq!(pending.policy_version, 1, "pending tx retains its original version");
+}
+
+// ---------------------------------------------------------------------------
+// Pending index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pending_index_tracks_wallet_transactions() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 2, &[&bob, &carol])));
+
+    let id1 = match client.evaluate_transaction(&wallet, &recipient1, &1500, &None::<Symbol>) {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+    let id2 = match client.evaluate_transaction(&wallet, &recipient2, &2000, &None::<Symbol>) {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    let ids = client.get_pending_ids_for_wallet(&wallet);
+    assert_eq!(ids.len(), 2);
+    assert!(ids.contains(&id1));
+    assert!(ids.contains(&id2));
+}
+
+#[test]
+fn test_pending_removed_from_index_on_release() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.set_policy(&wallet, &single_rule(&env, threshold_rule(&env, 1000, 1, &[&bob])));
+
+    let pending_id = match client.evaluate_transaction(&wallet, &recipient, &1500, &None::<Symbol>)
+    {
+        EvaluationResult::PendingApproval(id) => id,
+        other => panic!("expected pending, got {:?}", other),
+    };
+
+    assert_eq!(client.get_pending_ids_for_wallet(&wallet).len(), 1);
+
+    client.submit_approval(&bob, &pending_id);
+
+    // Released -> removed from the index.
+    assert_eq!(client.get_pending_ids_for_wallet(&wallet).len(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// set_policy validation edge cases (exercise via the contract entry point)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_set_policy_rejects_invalid_time_window() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+
+    let rules = single_rule(&env, time_window_rule(90_000, 90_000));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_policy(&wallet, &rules);
+    }));
+    assert!(result.is_err(), "invalid time window must be rejected at set_policy");
+    assert!(client.get_policy(&wallet).is_none(), "no policy should be stored on failure");
+}
+
+#[test]
+fn test_set_policy_rejects_unachievable_quorum() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // required=5 but only 1 approver.
+    let rules = single_rule(&env, threshold_rule(&env, 1000, 5, &[&bob]));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_policy(&wallet, &rules);
+    }));
+    assert!(result.is_err(), "unachievable quorum must be rejected");
+}
+
+#[test]
+fn test_set_policy_rejects_empty_allowlist() {
+    let (env, client) = setup();
+    let wallet = Address::generate(&env);
+
+    let rules = single_rule(&env, allowlist_rule(&env, &[]));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        client.set_policy(&wallet, &rules);
+    }));
+    assert!(result.is_err(), "empty allowlist must be rejected");
+}
+
+// A small sanity check to ensure the error type is wired into the Soroban
+// error conversion (keeps `SpendingPolicyError` from being dead code in tests).
+#[test]
+fn test_error_conversion_wired() {
+    let err = crate::SpendingPolicyError::Unauthorized;
+    let sdk_err: soroban_sdk::Error = err.into();
+    assert_eq!(sdk_err, soroban_sdk::Error::from_contract_error(1));
+}

--- a/contracts/spending-policy/src/types.rs
+++ b/contracts/spending-policy/src/types.rs
@@ -1,0 +1,266 @@
+//! Type definitions for the spending policy contract.
+//!
+//! This module defines all rule types, the policy envelope, evaluation
+//! results, pending (approval-bound) transactions, storage keys, events
+//! and the constants that bound policy size.
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol, Vec};
+
+/// Maximum number of rules allowed in a single policy.
+pub const MAX_RULES: u32 = 50;
+
+/// Maximum number of approvers allowed in an `ApprovalThreshold` rule.
+pub const MAX_APPROVERS: u32 = 20;
+
+/// Number of seconds in a single UTC day.
+pub const SECONDS_PER_DAY: u64 = 86_400;
+
+// ---------------------------------------------------------------------------
+// Rule types
+// ---------------------------------------------------------------------------
+
+/// Limits the total amount that may be spent in a given spending category
+/// over a rolling time period.
+///
+/// The period is identified by `floor(ledger_timestamp / period_seconds)`.
+/// Spending is tracked per (wallet, category, period) and resets naturally
+/// when the ledger timestamp advances into a new period.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CategoryLimitRule {
+    /// Spending category this limit applies to (e.g. `symbol_short!("groc")`).
+    pub category: Symbol,
+    /// Maximum cumulative spend allowed within one period (in stroops).
+    pub max_amount: i128,
+    /// Length of the rolling period in seconds (e.g. 604_800 for a week).
+    pub period_seconds: u64,
+}
+
+/// Only permits transactions whose recipient appears in the allowlist.
+///
+/// When multiple `MerchantAllowlistRule`s are present, a recipient must be
+/// present in **every** allowlist to be permitted (intersection semantics).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct MerchantAllowlistRule {
+    /// Addresses that are permitted to receive funds.
+    pub allowed: Vec<Address>,
+}
+
+/// Rejects any transaction whose recipient appears in the blocklist.
+///
+/// When multiple `MerchantBlocklistRule`s are present, a recipient is blocked
+/// if it appears in **any** blocklist (union semantics).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct MerchantBlocklistRule {
+    /// Addresses that are forbidden from receiving funds.
+    pub blocked: Vec<Address>,
+}
+
+/// Restricts transactions to a specific time-of-day window expressed in
+/// seconds since midnight UTC.
+///
+/// The window is half-open: `[start_seconds, end_seconds)`.
+/// When `start_seconds < end_seconds` the window is a normal range
+/// (e.g. `[21_600, 86_400)` = 06:00 → midnight).
+/// When `start_seconds > end_seconds` the window wraps past midnight
+/// (e.g. `[79_200, 7_200)` = 22:00 → 02:00).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct TimeWindowRule {
+    /// Start of the permitted window in seconds since midnight UTC.
+    pub start_seconds: u64,
+    /// End of the permitted window in seconds since midnight UTC (exclusive).
+    pub end_seconds: u64,
+}
+
+/// Requires `required_approvals` signatures from the configured approver set
+/// before any transaction whose amount is `>= threshold_amount` is released.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ApprovalThresholdRule {
+    /// Amount at or above which multi-approval is required (in stroops).
+    pub threshold_amount: i128,
+    /// Number of distinct approvals required to release a pending tx.
+    pub required_approvals: u32,
+    /// Addresses permitted to submit approvals.
+    pub approvers: Vec<Address>,
+}
+
+/// A single combinable policy rule.
+///
+/// All variants are evaluated by `evaluate_transaction`. The order in which
+/// rules are evaluated is deterministic (see `lib::evaluate_transaction`).
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum PolicyRule {
+    CategoryLimit(CategoryLimitRule),
+    MerchantAllowlist(MerchantAllowlistRule),
+    MerchantBlocklist(MerchantBlocklistRule),
+    TimeWindow(TimeWindowRule),
+    ApprovalThreshold(ApprovalThresholdRule),
+}
+
+/// The full policy rule set for a wallet.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Policy {
+    /// Ordered list of rules to enforce.
+    pub rules: Vec<PolicyRule>,
+    /// Monotonically increasing version. Bumped on every `set_policy` call so
+    /// that pending transactions created under an older version are invalidated.
+    pub version: u32,
+    /// Ledger timestamp of the last update.
+    pub updated_at: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation / approval outcomes
+// ---------------------------------------------------------------------------
+
+/// Machine-readable reason a transaction was rejected.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum RejectionReason {
+    /// No amount supplied or amount <= 0.
+    InvalidAmount,
+    /// Spending in the category would exceed the configured `CategoryLimit`.
+    CategoryLimitExceeded,
+    /// Recipient is present on a `MerchantBlocklist`.
+    MerchantBlocked,
+    /// Recipient is not present on a `MerchantAllowlist`.
+    MerchantNotAllowed,
+    /// Transaction was attempted outside the permitted `TimeWindow`.
+    OutsideTimeWindow,
+}
+
+/// Result of evaluating a transaction against a wallet's policy.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum EvaluationResult {
+    /// All rules passed; the transaction may proceed.
+    Approved,
+    /// A rule rejected the transaction.
+    Rejected(RejectionReason),
+    /// The transaction is above an approval threshold and is held pending.
+    /// The enclosed value is the pending transaction id.
+    PendingApproval(u64),
+}
+
+/// Result of submitting an approval for a pending transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum ApprovalOutcome {
+    /// The required quorum was reached and the transaction was released.
+    Approved,
+    /// The transaction remains pending. The enclosed value is the current
+    /// count of collected approvals.
+    Pending(u32),
+}
+
+/// A transaction held pending until enough approvals are collected.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct PendingTransaction {
+    /// Unique id of the pending transaction.
+    pub id: u64,
+    /// Wallet that owns the policy / initiated the transaction.
+    pub wallet: Address,
+    /// Intended recipient of the funds.
+    pub recipient: Address,
+    /// Amount to be transferred (in stroops).
+    pub amount: i128,
+    /// Optional spending category.
+    pub category: Option<Symbol>,
+    /// Ledger timestamp when the pending transaction was created.
+    pub created_at: u64,
+    /// Version of the policy under which the transaction was created.
+    pub policy_version: u32,
+    /// Addresses authorised to approve this transaction (snapshot of the
+    /// threshold rule's approver list at creation time).
+    pub authorized_approvers: Vec<Address>,
+    /// Addresses that have already approved.
+    pub approvers: Vec<Address>,
+    /// Number of approvals required to release the transaction.
+    pub required_approvals: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+/// Storage keys for contract state.
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    /// The policy for a wallet address.
+    Policy(Address),
+    /// A pending transaction by id.
+    PendingTx(u64),
+    /// Monotonic counter for pending transaction ids (instance storage).
+    NextPendingId,
+    /// Per-(wallet, category, period) spend tracking.
+    CategorySpending(Address, Symbol, u64),
+    /// List of pending transaction ids for a wallet.
+    PendingByWallet(Address),
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// Event helpers for the spending policy contract.
+pub struct PolicyEvents;
+
+impl PolicyEvents {
+    /// Emitted when a policy is set for the first time.
+    pub fn policy_set(env: &Env, wallet: &Address, version: u32) {
+        env.events()
+            .publish((symbol_short!("policy"), symbol_short!("set")), (wallet.clone(), version));
+    }
+
+    /// Emitted when an existing policy is replaced.
+    pub fn policy_replaced(env: &Env, wallet: &Address, version: u32) {
+        env.events().publish(
+            (symbol_short!("policy"), symbol_short!("repl")),
+            (wallet.clone(), version),
+        );
+    }
+
+    /// Emitted when a transaction is approved by all rules.
+    pub fn tx_approved(env: &Env, wallet: &Address, amount: i128) {
+        env.events()
+            .publish((symbol_short!("tx"), symbol_short!("apprvd")), (wallet.clone(), amount));
+    }
+
+    /// Emitted when a transaction is rejected.
+    pub fn tx_rejected(env: &Env, wallet: &Address, amount: i128, reason: &RejectionReason) {
+        env.events().publish(
+            (symbol_short!("tx"), symbol_short!("rjctd")),
+            (wallet.clone(), amount, reason.clone()),
+        );
+    }
+
+    /// Emitted when a transaction is held pending approval.
+    pub fn tx_pending(env: &Env, wallet: &Address, pending_id: u64, amount: i128) {
+        env.events()
+            .publish((symbol_short!("tx"), symbol_short!("pend")), (wallet.clone(), pending_id, amount));
+    }
+
+    /// Emitted when an approver signs off on a pending transaction.
+    pub fn approval_submitted(env: &Env, wallet: &Address, pending_id: u64, approver: &Address) {
+        env.events().publish(
+            (symbol_short!("apprv"), symbol_short!("sub")),
+            (wallet.clone(), pending_id, approver.clone()),
+        );
+    }
+
+    /// Emitted when a pending transaction is auto-released after reaching quorum.
+    pub fn pending_released(env: &Env, wallet: &Address, pending_id: u64) {
+        env.events().publish(
+            (symbol_short!("pend"), symbol_short!("rels")),
+            (wallet.clone(), pending_id),
+        );
+    }
+}

--- a/contracts/spending-policy/src/validation.rs
+++ b/contracts/spending-policy/src/validation.rs
@@ -1,0 +1,232 @@
+//! Validation logic for spending policies.
+//!
+//! `validate_policy` is called by `set_policy` **before** any storage write
+//! occurs, which guarantees that policy replacement is atomic: either the new
+//! policy is fully valid and persisted, or the call panics and the previous
+//! policy remains untouched.
+//!
+//! # Conflict resolution (allowlist vs blocklist)
+//!
+//! A single address may legitimately appear in both a `MerchantAllowlist`
+//! and a `MerchantBlocklist` rule. This is **not** a validation error. The
+//! deterministic, documented behaviour at evaluation time is:
+//!
+//! > **Blocklist wins.** If a recipient appears on any blocklist it is
+//! > rejected with `MerchantBlocked`, regardless of whether it also appears
+//! > on an allowlist. This "deny-by-default" rule is the secure choice for a
+//! > programmable spending policy.
+
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{
+    ApprovalThresholdRule, CategoryLimitRule, MerchantAllowlistRule, MerchantBlocklistRule,
+    PolicyRule, TimeWindowRule, MAX_APPROVERS, MAX_RULES, SECONDS_PER_DAY,
+};
+use crate::SpendingPolicyError;
+
+/// Validates a complete policy rule set.
+///
+/// Returns `Ok(())` if every rule is well-formed, otherwise the first
+/// `SpendingPolicyError` encountered.
+pub fn validate_policy(_env: &Env, rules: &Vec<PolicyRule>) -> Result<(), SpendingPolicyError> {
+    if rules.len() > MAX_RULES {
+        return Err(SpendingPolicyError::TooManyRules);
+    }
+
+    for rule in rules.iter() {
+        match rule {
+            PolicyRule::CategoryLimit(cl) => validate_category_limit(&cl)?,
+            PolicyRule::MerchantAllowlist(ar) => validate_allowlist(&ar)?,
+            PolicyRule::MerchantBlocklist(br) => validate_blocklist(&br)?,
+            PolicyRule::TimeWindow(tw) => validate_time_window(&tw)?,
+            PolicyRule::ApprovalThreshold(at) => validate_threshold(&at)?,
+        }
+    }
+
+    // Note: allowlist/blocklist overlap is intentionally *not* rejected here.
+    // See the module docs for the documented "blocklist wins" behaviour.
+
+    Ok(())
+}
+
+fn validate_category_limit(cl: &CategoryLimitRule) -> Result<(), SpendingPolicyError> {
+    if cl.max_amount <= 0 {
+        return Err(SpendingPolicyError::InvalidCategoryLimit);
+    }
+    if cl.period_seconds == 0 {
+        return Err(SpendingPolicyError::InvalidCategoryLimit);
+    }
+    Ok(())
+}
+
+fn validate_allowlist(ar: &MerchantAllowlistRule) -> Result<(), SpendingPolicyError> {
+    if ar.allowed.is_empty() {
+        return Err(SpendingPolicyError::InvalidPolicy);
+    }
+    if has_duplicates(&ar.allowed) {
+        return Err(SpendingPolicyError::InvalidPolicy);
+    }
+    Ok(())
+}
+
+fn validate_blocklist(br: &MerchantBlocklistRule) -> Result<(), SpendingPolicyError> {
+    if br.blocked.is_empty() {
+        return Err(SpendingPolicyError::InvalidPolicy);
+    }
+    if has_duplicates(&br.blocked) {
+        return Err(SpendingPolicyError::InvalidPolicy);
+    }
+    Ok(())
+}
+
+fn validate_time_window(tw: &TimeWindowRule) -> Result<(), SpendingPolicyError> {
+    if !is_valid_time_window(tw.start_seconds, tw.end_seconds) {
+        return Err(SpendingPolicyError::InvalidTimeWindow);
+    }
+    Ok(())
+}
+
+fn validate_threshold(at: &ApprovalThresholdRule) -> Result<(), SpendingPolicyError> {
+    if at.threshold_amount <= 0 {
+        return Err(SpendingPolicyError::InvalidThreshold);
+    }
+    if at.required_approvals == 0 {
+        return Err(SpendingPolicyError::InvalidThreshold);
+    }
+    if at.approvers.is_empty() {
+        return Err(SpendingPolicyError::InvalidApproverList);
+    }
+    if at.approvers.len() > MAX_APPROVERS {
+        return Err(SpendingPolicyError::InvalidApproverList);
+    }
+    // required_approvals must be achievable: <= number of approvers.
+    if at.required_approvals > at.approvers.len() {
+        return Err(SpendingPolicyError::InvalidApproverList);
+    }
+    if has_duplicates(&at.approvers) {
+        return Err(SpendingPolicyError::InvalidApproverList);
+    }
+    Ok(())
+}
+
+/// A time window is valid when both bounds fall within a day and the window is
+/// non-empty. `start == end` would define an empty half-open interval and is
+/// rejected.
+fn is_valid_time_window(start: u64, end: u64) -> bool {
+    start < SECONDS_PER_DAY && end > 0 && end <= SECONDS_PER_DAY && start != end
+}
+
+/// Returns `true` if the vector contains the same address more than once.
+fn has_duplicates(vec: &Vec<Address>) -> bool {
+    let outer = vec.iter();
+    for (i, a) in outer.enumerate() {
+        for b in vec.iter().skip(i + 1) {
+            if a == b {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for validation internals
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    fn env() -> Env {
+        Env::default()
+    }
+
+    #[test]
+    fn test_valid_time_window_normal() {
+        assert!(is_valid_time_window(21_600, 86_400)); // 06:00 -> midnight
+        assert!(is_valid_time_window(0, 21_600)); // midnight -> 06:00
+    }
+
+    #[test]
+    fn test_valid_time_window_wrap_around() {
+        assert!(is_valid_time_window(79_200, 7_200)); // 22:00 -> 02:00
+    }
+
+    #[test]
+    fn test_invalid_time_window_empty() {
+        assert!(!is_valid_time_window(21_600, 21_600));
+    }
+
+    #[test]
+    fn test_invalid_time_window_out_of_range() {
+        assert!(!is_valid_time_window(86_400, 90_000));
+        assert!(!is_valid_time_window(0, 0));
+        assert!(!is_valid_time_window(86_400, 86_400));
+    }
+
+    #[test]
+    fn test_validate_empty_policy_is_valid() {
+        let e = env();
+        let rules: Vec<PolicyRule> = Vec::new(&e);
+        assert!(validate_policy(&e, &rules).is_ok());
+    }
+
+    #[test]
+    fn test_validate_category_limit_rejects_zero_period() {
+        let e = env();
+        let mut rules: Vec<PolicyRule> = Vec::new(&e);
+        rules.push_back(PolicyRule::CategoryLimit(CategoryLimitRule {
+            category: symbol_short!("groc"),
+            max_amount: 1_000,
+            period_seconds: 0,
+        }));
+        assert_eq!(
+            validate_policy(&e, &rules),
+            Err(SpendingPolicyError::InvalidCategoryLimit)
+        );
+    }
+
+    #[test]
+    fn test_validate_threshold_requires_achievable_quorum() {
+        let e = env();
+        let mut approvers: Vec<Address> = Vec::new(&e);
+        approvers.push_back(Address::generate(&e));
+        let mut rules: Vec<PolicyRule> = Vec::new(&e);
+        rules.push_back(PolicyRule::ApprovalThreshold(ApprovalThresholdRule {
+            threshold_amount: 100,
+            required_approvals: 5, // more than approvers (1)
+            approvers,
+        }));
+        assert_eq!(
+            validate_policy(&e, &rules),
+            Err(SpendingPolicyError::InvalidApproverList)
+        );
+    }
+
+    #[test]
+    fn test_validate_allowlist_rejects_empty() {
+        let e = env();
+        let mut rules: Vec<PolicyRule> = Vec::new(&e);
+        rules.push_back(PolicyRule::MerchantAllowlist(MerchantAllowlistRule {
+            allowed: Vec::new(&e),
+        }));
+        assert_eq!(
+            validate_policy(&e, &rules),
+            Err(SpendingPolicyError::InvalidPolicy)
+        );
+    }
+
+    #[test]
+    fn test_validate_blocklist_rejects_empty() {
+        let e = env();
+        let mut rules: Vec<PolicyRule> = Vec::new(&e);
+        rules.push_back(PolicyRule::MerchantBlocklist(MerchantBlocklistRule {
+            blocked: Vec::new(&e),
+        }));
+        assert_eq!(
+            validate_policy(&e, &rules),
+            Err(SpendingPolicyError::InvalidPolicy)
+        );
+    }
+}


### PR DESCRIPTION
Closes #908
## Summary
Here's a summary of what was built.
What was delivered
A new crate at contracts/spending-policy/ with all 7 files from the spec:
[Cargo.toml](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/Cargo.toml) — crate manifest matching the workspace pattern
[src/types.rs](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/src/types.rs) — the 5 rule structs, PolicyRule enum, Policy, EvaluationResult/RejectionReason/ApprovalOutcome, PendingTransaction, DataKey, events, constants
[src/storage.rs](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/src/storage.rs) — storage accessors (policy, pending txs, per-wallet index, category spend tracking)
[src/validation.rs](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/src/validation.rs) — policy validation + documented conflict resolution (blocklist wins)
[src/rules.rs](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/src/rules.rs) — per-rule evaluation helpers
[src/lib.rs](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/src/lib.rs) — the contract: set_policy, evaluate_transaction, submit_approval, get_policy (+ read-only helpers)
[src/test.rs](file:///C:/Users/ADMIN/Desktop/midea-drips/stellarspend-contracts/contracts/spending-policy/src/test.rs) — 45 tests
Acceptance criteria — all met
All five rule types enforced in evaluate_transaction (deterministic order: blocklist → allowlist → time window → category limit → approval threshold).
Conflicting rules handled deterministically — blocklist takes precedence over allowlist (deny wins), documented in validation.rs and tested in test_blocklist_takes_precedence_over_allowlist.
ApprovalThreshold flow — tx held pending, auto-released at N approvals (with a category-limit re-check at release time). Tested in test_approval_threshold_auto_releases_after_n_approvals.
Atomic replacement — single storage write + version bump; an invalid replacement panics and leaves the old policy untouched (test_policy_replacement_is_atomic).
Non-owner rejected — wallet.require_auth() on set_policy (test_set_policy_requires_authorization).
cargo test -p spending-policy passes — 45 passed, 0 failed.
The "replace mid-session invalidates pending approvals" requirement is handled via the monotonic version: pending txs store their policy version, and submit_approval rejects any whose version no longer matches (test_policy_replacement_invalidates_pending_approvals).
Workspace fixes (required to make the build work)
Two pre-existing issues in the root Cargo.toml were blocking all cargo commands:
Duplicate [[test]] keys — one [[test]] table had two name/path pairs, making the workspace unparseable. Split into two separate tables.
ed25519-dalek 3.0.0 incompatibility — soroban-env-host 22.1.3 declares ed25519-dalek = ">=2.0.0" (no upper bound), so the resolver pulled the newly-released 3.0.0, whose rand_core 0.9/TryRng API is incompatible with env-host's testutils. Pinned ed25519-dalek = "2.2" in the root package so the resolver unifies on a compatible 2.x. This is durable (CI-safe, not just a lockfile patch).
Verified a sibling crate (spending-limits) still builds cleanly after these changes.Test results (45/45 passing):
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s
No further changes are needed — the contract is complete, all acceptance criteria are satisfied, and the workspace builds.

## Related Issues

## Checklist
- [ ] `cargo test` passes locally
- [ ] CI checks pass
- [ ] Screenshot of test results included
- [ ] Screenshot of CI passing included
