### PR TITLE
feat(currency-conversion): add get_conversion_rate view

### DIFF
--- a/contracts/currency-conversion/src/lib.rs
+++ b/contracts/currency-conversion/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-use soroban_sdk::{contract, contractimpl, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Env, String, Symbol, Vec};
 
 pub mod math;
 pub mod types;
@@ -24,6 +24,16 @@ impl CurrencyConversionContract {
         base_currency: String,
     ) -> i128 {
         math::normalize_balances(balances, rates, base_currency)
+    }
+
+    /// Returns the stored conversion rate for a currency pair.
+    ///
+    /// Returns `0` when no rate is stored for `(from, to)`.
+    pub fn get_conversion_rate(env: Env, from: Symbol, to: Symbol) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Rate(from, to))
+            .unwrap_or(0)
     }
 }
 

--- a/contracts/currency-conversion/src/test.rs
+++ b/contracts/currency-conversion/src/test.rs
@@ -1,3 +1,36 @@
 #![cfg(test)]
 
 use super::*;
+use soroban_sdk::{symbol_short, Env};
+
+#[test]
+fn get_conversion_rate_returns_stored_rate() {
+    let env = Env::default();
+    let contract_id = env.register(CurrencyConversionContract, ());
+    let client = CurrencyConversionContractClient::new(&env, &contract_id);
+
+    let from = symbol_short!("USD");
+    let to = symbol_short!("XLM");
+    let stored_rate: i128 = 105;
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Rate(from.clone(), to.clone()), &stored_rate);
+    });
+
+    assert_eq!(client.get_conversion_rate(&from, &to), stored_rate);
+}
+
+#[test]
+fn get_conversion_rate_returns_zero_for_unknown_pair() {
+    let env = Env::default();
+    let contract_id = env.register(CurrencyConversionContract, ());
+    let client = CurrencyConversionContractClient::new(&env, &contract_id);
+
+    let from = symbol_short!("EUR");
+    let to = symbol_short!("GBP");
+
+    // Documented default: unknown pairs return 0.
+    assert_eq!(client.get_conversion_rate(&from, &to), 0);
+}

--- a/contracts/currency-conversion/src/types.rs
+++ b/contracts/currency-conversion/src/types.rs
@@ -1,8 +1,9 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contracttype, Symbol};
 
 #[contracttype]
 pub enum DataKey {
-    Rate(soroban_sdk::String),
+    /// Stored conversion rate keyed by `(from, to)` currency symbols.
+    Rate(Symbol, Symbol),
 }
 
 #[contracttype]


### PR DESCRIPTION
## Overview

This PR adds a **`get_conversion_rate(from, to)`** view to the currency-conversion contract so callers can read the currently stored conversion rate for a currency symbol pair. Unknown pairs return `0`.

## Related Issue

Closes #976

## Changes

### 💱 Conversion Rate View

* **[ADD]** `get_conversion_rate` in `contracts/currency-conversion/src/lib.rs`
  * Reads the persistent rate keyed by `(from, to)` Symbols.
  * Returns the stored `i128` rate for a known pair.
  * Returns `0` (documented default) when no rate is stored.

* **[MODIFY]** `DataKey::Rate` in `contracts/currency-conversion/src/types.rs`
  * Keys rates by `(Symbol, Symbol)` to match the view signature.

* **[ADD]** Tests in `contracts/currency-conversion/src/test.rs`
  * Coverage for stored-pair lookup and unknown-pair default of `0`.

## Verification Results

```
cargo test -p currency-conversion
✅ 2/2 passed

test test::get_conversion_rate_returns_zero_for_unknown_pair ... ok
test test::get_conversion_rate_returns_stored_rate ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

| Acceptance Criteria | Status |
| --- | --- |
| Returns correct rate for a stored pair | ✅ Covered by `get_conversion_rate_returns_stored_rate` |
| Returns 0 or documented default for unknown pair | ✅ Returns `0` for unknown pairs |
| `cargo test -p currency-conversion` passes | ✅ 2/2 passed |


Made with [Cursor](https://cursor.com)