### PR TITLE
feat(audit): add get_audit_log_count view function

### DIFF
--- a/contracts/audit/src/lib.rs
+++ b/contracts/audit/src/lib.rs
@@ -242,6 +242,14 @@ impl AuditContract {
             .unwrap_or(0)
     }
 
+    /// Get the total number of audit log entries stored.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    pub fn get_audit_log_count(env: Env) -> u32 {
+        Self::get_total_audit_logs(env) as u32
+    }
+
     /// Get a range of audit logs.
     ///
     /// # Arguments

--- a/contracts/audit/src/test.rs
+++ b/contracts/audit/src/test.rs
@@ -278,6 +278,28 @@ fn test_get_audit_logs_range_invalid_range() {
 }
 
 #[test]
+fn test_get_audit_log_count() {
+    let env = setup_env();
+    let (client, admin) = deploy_contract(&env);
+    
+    // Returns 0 on fresh contract
+    assert_eq!(client.get_audit_log_count(), 0);
+
+    client.initialize(&admin, &1000_u32);
+
+    let actor = Address::generate(&env);
+    let operation = Symbol::new(&env, "transfer");
+    let status = Symbol::new(&env, "success");
+
+    // Returns correct count after multiple log entries
+    client.log_audit(&actor, &operation, &status, None);
+    assert_eq!(client.get_audit_log_count(), 1);
+
+    client.log_audit(&actor, &operation, &status, None);
+    assert_eq!(client.get_audit_log_count(), 2);
+}
+
+#[test]
 fn test_set_admin() {
     let env = setup_env();
     let (client, admin) = deploy_contract(&env);


### PR DESCRIPTION
This PR resolves #970 by introducing a lightweight get_audit_log_count() -> u32 view function to the audit contract. Previously, callers had no way of knowing the log count without fetching the entire history. This exposes the size for easier caller integrations.

Changes Included:

contracts/audit/src/lib.rs: Added get_audit_log_count accessor function that casts TotalAuditLogs (u64) to u32 as requested.
contracts/audit/src/test.rs: Added test_get_audit_log_count() asserting that:
A fresh contract returns 0.
Logging an entry successfully increments the count (1, 2, etc.).
Acceptance Criteria Verified:

 Returns correct count after multiple log entries.
 Returns 0 on a fresh contract.
 Tests cover the newly added view function.
 Linked issue correctly.
 closes #970 