### PR TITLE
feat(cross-contract): add get_last_caller view (#989)

### DIFF
--- a/contracts/cross-contract/src/lib.rs
+++ b/contracts/cross-contract/src/lib.rs
@@ -84,6 +84,9 @@ impl CrossContractInteraction {
             panic_with_error!(&env, e);
         }
 
+        // Record the last caller for audit purposes
+        env.storage().instance().set(&DataKey::LastCaller, &caller);
+
         // Emit call initiated event
         CrossContractEvents::call_initiated(
             &env,
@@ -132,6 +135,9 @@ impl CrossContractInteraction {
         if let Err(e) = validate_batch_calls(&env, &calls, require_whitelist) {
             panic_with_error!(&env, e);
         }
+
+        // Record the last caller for audit purposes
+        env.storage().instance().set(&DataKey::LastCaller, &caller);
 
         let total_calls = calls.len();
         let mut successful_calls: u32 = 0;
@@ -265,6 +271,12 @@ impl CrossContractInteraction {
             .instance()
             .get(&DataKey::FailedCalls)
             .unwrap_or(0)
+    }
+
+    /// Returns the address of the last contract that made a cross-contract call
+    /// into this crate, or `None` if no call has been made yet.
+    pub fn get_last_caller(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::LastCaller)
     }
 
     // Private helper functions

--- a/contracts/cross-contract/src/test.rs
+++ b/contracts/cross-contract/src/test.rs
@@ -382,3 +382,91 @@ fn test_events_emitted() {
     let events = env.events().all();
     assert!(events.len() > 0);
 }
+
+// --- Issue #989: get_last_caller view ---
+
+#[test]
+fn test_get_last_caller_returns_none_before_any_calls() {
+    let (env, admin, _, _) = create_test_env();
+    let contract_id = env.register_contract(None, CrossContractInteraction);
+    let client = CrossContractInteractionClient::new(&env, &contract_id);
+
+    client.initialize(&admin);
+
+    // No execute_call or execute_batch has been made yet
+    assert_eq!(client.get_last_caller(), None);
+}
+
+#[test]
+fn test_get_last_caller_returns_caller_after_execute_call() {
+    let (env, admin, _, _) = create_test_env();
+    let contract_id = env.register_contract(None, CrossContractInteraction);
+    let client = CrossContractInteractionClient::new(&env, &contract_id);
+
+    let external_id = env.register_contract(None, MockExternalContract);
+
+    client.initialize(&admin);
+
+    let call = CrossContractCall {
+        contract_address: external_id.clone(),
+        function_name: Symbol::new(&env, "no_params"),
+        args: Vec::new(&env),
+        continue_on_failure: false,
+    };
+
+    client.execute_call(&admin, &call, &false);
+
+    assert_eq!(client.get_last_caller(), Some(admin));
+}
+
+#[test]
+fn test_get_last_caller_returns_caller_after_execute_batch() {
+    let (env, admin, _, _) = create_test_env();
+    let contract_id = env.register_contract(None, CrossContractInteraction);
+    let client = CrossContractInteractionClient::new(&env, &contract_id);
+
+    let external_id = env.register_contract(None, MockExternalContract);
+
+    client.initialize(&admin);
+
+    let mut calls: Vec<CrossContractCall> = Vec::new(&env);
+    calls.push_back(CrossContractCall {
+        contract_address: external_id.clone(),
+        function_name: Symbol::new(&env, "no_params"),
+        args: Vec::new(&env),
+        continue_on_failure: false,
+    });
+
+    client.execute_batch(&admin, &calls, &false);
+
+    assert_eq!(client.get_last_caller(), Some(admin));
+}
+
+#[test]
+fn test_get_last_caller_updates_on_successive_calls() {
+    let (env, admin, user, _) = create_test_env();
+    let contract_id = env.register_contract(None, CrossContractInteraction);
+    let client = CrossContractInteractionClient::new(&env, &contract_id);
+
+    let external_id = env.register_contract(None, MockExternalContract);
+
+    client.initialize(&admin);
+
+    let call = CrossContractCall {
+        contract_address: external_id.clone(),
+        function_name: Symbol::new(&env, "no_params"),
+        args: Vec::new(&env),
+        continue_on_failure: false,
+    };
+
+    // First call made by admin
+    client.execute_call(&admin, &call, &false);
+    assert_eq!(client.get_last_caller(), Some(admin.clone()));
+
+    // Promote user to admin so they can make a call
+    client.set_admin(&admin, &user);
+
+    // Second call made by user (now admin)
+    client.execute_call(&user, &call, &false);
+    assert_eq!(client.get_last_caller(), Some(user));
+}

--- a/contracts/cross-contract/src/types.rs
+++ b/contracts/cross-contract/src/types.rs
@@ -19,6 +19,8 @@ pub enum DataKey {
     FailedCalls,
     /// Whitelist of allowed contract addresses
     Whitelist(Address),
+    /// Address of the last contract that made a cross-contract call into this crate
+    LastCaller,
 }
 
 /// Request for a cross-contract call


### PR DESCRIPTION
closes #989 
- Add DataKey::LastCaller variant to types.rs
- Store caller address in execute_call and execute_batch
- Expose get_last_caller() -> Option<Address> public view
- Add tests: returns None before calls, returns correct caller after execute_call, execute_batch, and successive calls

Closes #989

## Summary
<!-- Describe the changes in this PR -->

## Related Issues
<!-- Use "closes #NUMBER" to link issues -->

## Checklist
- [x] `cargo test` passes locally
- [x] CI checks pass
- [x] Screenshot of test results included
- [x] Screenshot of CI passing included
