### PR TITLE
Add get_goal_count view function for savings goals

### DIFF
--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -1135,6 +1135,23 @@ impl SavingsGoalsContract {
             .unwrap_or(Vec::new(&env))
     }
 
+    /// Returns the number of savings goals an address has created.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `owner` - The address whose goal count is queried
+    ///
+    /// # Returns
+    /// * `u32` - The number of goals created by `owner`, or 0 if none exist
+    pub fn get_goal_count(env: Env, owner: Address) -> u32 {
+        let goals: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserGoals(owner))
+            .unwrap_or(Vec::new(&env));
+        goals.len()
+    }
+
     /// Returns a previously recorded contribution for a goal.
     pub fn get_contribution_record(
         env: Env,

--- a/contracts/savings-goals/src/test.rs
+++ b/contracts/savings-goals/src/test.rs
@@ -355,6 +355,36 @@ fn test_get_user_goals() {
 }
 
 #[test]
+fn test_get_goal_count_no_goals() {
+    let (env, _admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+
+    assert_eq!(client.get_goal_count(&user), 0);
+}
+
+#[test]
+fn test_get_goal_count_with_goals() {
+    let (env, admin, client) = setup_test_contract();
+    let user = Address::generate(&env);
+    let other_user = Address::generate(&env);
+
+    let mut requests: Vec<SavingsGoalRequest> = Vec::new(&env);
+    requests.push_back(create_valid_request(&env, &user, "vacation", 100_000_000));
+    requests.push_back(create_valid_request(&env, &user, "house", 500_000_000));
+    requests.push_back(create_valid_request(
+        &env,
+        &other_user,
+        "emergency",
+        200_000_000,
+    ));
+
+    client.batch_set_savings_goals(&admin, &requests);
+
+    assert_eq!(client.get_goal_count(&user), 2);
+    assert_eq!(client.get_goal_count(&other_user), 1);
+}
+
+#[test]
 fn test_batch_metrics() {
     let (env, admin, client) = setup_test_contract();
 


### PR DESCRIPTION
Returns the number of savings goals an address has created, avoiding the need to fetch and iterate the full goal list just to get a count.

Closes #960

## Summary
<!-- Describe the changes in this PR -->

## Related Issues
<!-- Use "closes #NUMBER" to link issues -->

## Checklist
- [ ] `cargo test` passes locally
- [ ] CI checks pass
- [ ] Screenshot of test results included
- [ ] Screenshot of CI passing included
