### PR TITLE
feat(batch-notifications): add get_batch_notification_count view

### DIFF
--- a/contracts/batch-notifications/src/lib.rs
+++ b/contracts/batch-notifications/src/lib.rs
@@ -17,12 +17,19 @@ impl BatchNotificationContract {
     pub fn batch_notify(
         env: Env,
         admin: Address,
+        batch_id: u64,
         payloads: Vec<NotificationPayload>,
     ) -> BatchResult {
         // Requirement: Validate user/admin addresses
         admin.require_auth();
 
         // Run the batch logic
-        logic::execute_dispatch(env, payloads)
+        logic::execute_dispatch(env, batch_id, payloads)
+    }
+
+    /// Returns the number of notifications dispatched in a given batch.
+    /// Returns 0 if the batch ID is unknown.
+    pub fn get_batch_notification_count(env: Env, batch_id: u64) -> u32 {
+        logic::read_batch_count(&env, batch_id)
     }
 }

--- a/contracts/batch-notifications/src/logic.rs
+++ b/contracts/batch-notifications/src/logic.rs
@@ -1,7 +1,11 @@
 use crate::types::{BatchResult, NotificationPayload};
 use soroban_sdk::{symbol_short, Env, Vec};
 
-pub fn execute_dispatch(env: Env, payloads: Vec<NotificationPayload>) -> BatchResult {
+pub fn execute_dispatch(
+    env: Env,
+    batch_id: u64,
+    payloads: Vec<NotificationPayload>,
+) -> BatchResult {
     let mut success_count = 0;
     let mut failures = Vec::new(&env);
 
@@ -21,8 +25,23 @@ pub fn execute_dispatch(env: Env, payloads: Vec<NotificationPayload>) -> BatchRe
         }
     }
 
+    // Persist the count of notifications in this batch
+    let count: u32 = payloads.len() as u32;
+    let key = (symbol_short!("batch_cnt"), batch_id);
+    env.storage().persistent().set(&key, &count);
+
     BatchResult {
         successful_count: success_count,
         failed_addresses: failures,
     }
+}
+
+/// Reads the notification count for a given batch from storage.
+/// Returns 0 if no entry exists for the batch_id.
+pub fn read_batch_count(env: &Env, batch_id: u64) -> u32 {
+    let key = (symbol_short!("batch_cnt"), batch_id);
+    env.storage()
+        .persistent()
+        .get::<_, u32>(&key)
+        .unwrap_or(0)
 }

--- a/contracts/batch-notifications/src/test.rs
+++ b/contracts/batch-notifications/src/test.rs
@@ -14,6 +14,8 @@ fn test_batch_dispatch_mixed_results() {
     let user_1 = Address::generate(&env);
     let user_2 = Address::generate(&env);
 
+    let batch_id = 1u64;
+
     let payloads = vec![
         &env,
         NotificationPayload {
@@ -26,9 +28,56 @@ fn test_batch_dispatch_mixed_results() {
         },
     ];
 
-    let result = client.batch_notify(&admin, &payloads);
+    let result = client.batch_notify(&admin, &batch_id, &payloads);
 
     assert_eq!(result.successful_count, 1);
     assert_eq!(result.failed_addresses.len(), 1);
     assert_eq!(result.failed_addresses.get(0).unwrap(), user_2);
+}
+
+#[test]
+fn test_get_batch_notification_count_known_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(BatchNotificationContract, ());
+    let client = BatchNotificationContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let batch_id = 42u64;
+
+    let payloads = vec![
+        &env,
+        NotificationPayload {
+            user: user.clone(),
+            message: String::from_str(&env, "Hello"),
+        },
+        NotificationPayload {
+            user: user.clone(),
+            message: String::from_str(&env, "World"),
+        },
+        NotificationPayload {
+            user: user.clone(),
+            message: String::from_str(&env, "!"),
+        },
+    ];
+
+    client.batch_notify(&admin, &batch_id, &payloads);
+
+    let count = client.get_batch_notification_count(&batch_id);
+    assert_eq!(count, 3);
+}
+
+#[test]
+fn test_get_batch_notification_count_unknown_batch() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(BatchNotificationContract, ());
+    let client = BatchNotificationContractClient::new(&env, &contract_id);
+
+    // Query a batch ID that has never been used
+    let count = client.get_batch_notification_count(&999u64);
+    assert_eq!(count, 0);
 }


### PR DESCRIPTION
## Summary

This PR adds a new `get_batch_notification_count(batch_id: u64) -> u32` view function to the batch-notifications contract, addressing the missing count capability for notifications within a batch.

### Problem
No count function existed for notifications within a batch. Consumers of the contract had no way to query how many notifications were dispatched in a given batch operation.

### Solution
Added a `get_batch_notification_count` view function that reads from persistent contract storage to return the notification count for a given `batch_id`. The count is persisted during `batch_notify` execution, and unknown batch IDs return `0`.

## Changes

### `contracts/batch-notifications/src/lib.rs`
- Added `batch_id: u64` parameter to the `batch_notify` function for batch tracking
- Added new public view: `get_batch_notification_count(env: Env, batch_id: u64) -> u32`
- Delegates to `logic::read_batch_count`

### `contracts/batch-notifications/src/logic.rs`
- Updated `execute_dispatch` to accept `batch_id` and persist the notification count to persistent storage under key `(symbol_short!("batch_cnt"), batch_id)`
- Added `read_batch_count(env: &Env, batch_id: u64) -> u32` helper that returns the stored count or `0` for unknown batch IDs

### `contracts/batch-notifications/src/test.rs`
- Updated existing `test_batch_dispatch_mixed_results` to pass `batch_id` parameter
- Added `test_get_batch_notification_count_known_batch`: dispatches 3 notifications and verifies count returns 3
- Added `test_get_batch_notification_count_unknown_batch`: verifies unknown batch ID (999) returns 0

## Design Decisions

| Decision | Rationale |
|---|---|
| Added `batch_id` to `batch_notify` signature | Without a batch ID, there is no way to associate stored counts with specific batches. The `get_batch_notification_count` view would always return 0 for every query, making it useless. |
| Persistent storage over temporary/instance | Batch notification counts should survive contract upgrades and instance bumps. Using `persistent()` ensures durability. |
| Composite storage key `(Symbol, u64)` | Provides clean namespacing — the `"batch_cnt"` symbol prefix prevents key collisions with any future storage entries. |
| Return `0` for unknown batch IDs | Follows the principle of least surprise — an unrecorded batch is indistinguishable from an empty batch. |
| Count stored as `payloads.len()` (total payloads) rather than `successful_count` | The count reflects the full batch size, matching the intuitive interpretation of "how many notifications were in this batch." This is consistent regardless of partial failures. |

## Related Issues

Closes #995

## Checklist

- [x] `cargo test` passes locally
- [ ] CI checks pass (awaiting CI run)
- [ ] Screenshot of test results included
- [ ] Screenshot of CI passing included

## How to Test

```bash
cargo test -p batch-notifications
```

## Screenshots

<!-- Add screenshots of test results and CI passing here -->