### PR TITLE
feat: add get_priority_score method to priority contract, fix queue t…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,10 @@ name = "analytics_indexing_tests"
 path = "tests/analytics_indexing_tests.rs"
 
 [[test]]
+name = "priority_tests"
+path = "tests/priority_tests.rs"
+
+[[test]]
 name = "timelock_tests"
 path = "tests/timelock_tests.rs"
 

--- a/contracts/priority.rs
+++ b/contracts/priority.rs
@@ -127,6 +127,15 @@ impl PriorityContract {
         id
     }
 
+    pub fn get_priority_score(env: Env, tx_id: u64) -> u32 {
+        let item_opt: Option<PendingItem> = env.storage().instance().get(&DataKey::PendingItem(tx_id));
+        if let Some(item) = item_opt {
+            item.priority
+        } else {
+            0
+        }
+    }
+
     pub fn dequeue(env: Env) -> Option<PendingItem> {
         // If any lower-priority item has starved beyond threshold, dequeue it first.
         let now = env.ledger().timestamp();
@@ -166,7 +175,7 @@ impl PriorityContract {
             .instance()
             .get(&key)
             .unwrap_or_else(|| Vec::new(env));
-        q.push_back(&id);
+        q.push_back(id);
         env.storage().instance().set(&key, &q);
     }
 
@@ -189,9 +198,9 @@ impl PriorityContract {
         let mut i = 1u32;
         while (i as usize) < len as usize {
             let v = q
-                .get(i as usize)
+                .get(i)
                 .unwrap_or_else(|| panic_with_error!(env, PriorityError::EmptyQueue));
-            new_q.push_back(&v);
+            new_q.push_back(v);
             i += 1;
         }
         env.storage().instance().set(&key, &new_q);

--- a/tests/priority_tests.rs
+++ b/tests/priority_tests.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{
     symbol_short,
-    testutils::{Address as _, Events as _},
-    Address, Env, Symbol,
+    testutils::{Address as _, Events as _, Ledger},
+    Address, Env,
 };
 
 #[path = "../contracts/priority.rs"]
@@ -43,6 +43,21 @@ fn test_priority_order() {
 }
 
 #[test]
+fn test_get_priority_score() {
+    let (env, _admin, client) = setup();
+    let caller = Address::generate(&env);
+
+    let id1 = client.enqueue(&caller, &symbol_short!("med1"), &1u32);
+    let id2 = client.enqueue(&caller, &symbol_short!("high1"), &2u32);
+
+    assert_eq!(client.get_priority_score(&id1), 1);
+    assert_eq!(client.get_priority_score(&id2), 2);
+    
+    // Unknown ID should return 0
+    assert_eq!(client.get_priority_score(&999), 0);
+}
+
+#[test]
 fn test_starvation_prevention() {
     let (env, _admin, client) = setup();
 
@@ -55,8 +70,8 @@ fn test_starvation_prevention() {
     env.ledger().set_timestamp(env.ledger().timestamp() + 120);
 
     // Enqueue several high-priority items that are fresh
-    client.enqueue(&caller, &symbol_short!("high_fresh1"), &2u32);
-    client.enqueue(&caller, &symbol_short!("high_fresh2"), &2u32);
+    client.enqueue(&caller, &symbol_short!("high_fr1"), &2u32);
+    client.enqueue(&caller, &symbol_short!("high_fr2"), &2u32);
 
     // Now dequeue: starvation prevention should return the old low-priority item first
     let popped: PendingItem = client.dequeue().expect("expected item");


### PR DESCRIPTION
closed #1001 

## Summary
This PR adds the `get_priority_score` view function to the `priority` contract, which returns the assigned priority score for a transaction, or `0` if the transaction is unknown. 

Additionally, it includes several necessary fixes to the priority contract and its test suite:
- **Test Registration**: Added `priority_tests` to `Cargo.toml` as it was previously excluded, causing `cargo test --workspace` to silently skip it.
- **Contract Fixes**: Resolved existing compilation errors in `contracts/priority.rs` where type references were incorrectly used in vector `push_back` and `get` method calls.
- **Test Suite Fixes**: Updated `tests/priority_tests.rs` to fix `symbol_short!` length limits, imported missing `Ledger` traits, and added the new `test_get_priority_score` test case. 
- **Dependency Downgrade**: Downgraded `ed25519-dalek` to `2.2.0` in the lockfile to fix the `CryptoRng` trait conflict introduced by `3.0.0` that was breaking the workspace tests.

## Related Issues
Closes #1001

## Checklist
- [x] `cargo test` passes locally
- [ ] CI checks pass
- [ ] Screenshot of test results included
- [ ] Screenshot of CI passing included
```