### PR TITLE
feat(rewards): add reward account statistics tracking

### DIFF
--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -15,8 +15,12 @@ pub mod validation;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, Vec};
 
 use crate::rewards::{credit_reward, debit_reward, register_reward_account};
-use crate::storage::{get_reward_account, get_reward_index};
-pub use crate::types::{DataKey, RewardAccount, RewardStatus, RewardTransaction, RewardType};
+use crate::storage::{
+    get_account_stats as read_account_stats, get_reward_account, get_reward_index,
+};
+pub use crate::types::{
+    DataKey, RewardAccount, RewardAccountStats, RewardStatus, RewardTransaction, RewardType,
+};
 
 /// Error codes for the rewards contract.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -108,6 +112,15 @@ impl RewardsContract {
     /// Returns the `RewardAccount` metadata for `participant`, if registered.
     pub fn get_account(env: Env, participant: Address) -> Option<RewardAccount> {
         get_reward_account(&env, &participant)
+    }
+
+    /// Returns aggregate statistics for `participant`'s reward account.
+    ///
+    /// Tracks total rewards earned, total rewards redeemed, total transactions,
+    /// and the ledger sequence of the most recent reward credit. Returns zeroed
+    /// defaults when the account has no stats yet (including unregistered accounts).
+    pub fn get_account_stats(env: Env, participant: Address) -> RewardAccountStats {
+        read_account_stats(&env, &participant)
     }
 
     /// Credits `amount` reward points to `participant`'s account.

--- a/contracts/rewards/src/rewards.rs
+++ b/contracts/rewards/src/rewards.rs
@@ -8,11 +8,14 @@ use soroban_sdk::{Address, Env};
 
 use crate::events::{emit_account_initialized, emit_reward_credited, emit_reward_debited};
 use crate::storage::{
-    append_reward_index, get_lifetime_claimed, get_lifetime_earned, get_reward_account,
-    get_reward_balance, get_reward_tx_counter, set_lifetime_claimed, set_lifetime_earned,
-    set_reward_account, set_reward_balance, set_reward_transaction, set_reward_tx_counter,
+    append_reward_index, get_account_stats, get_lifetime_claimed, get_lifetime_earned,
+    get_reward_account, get_reward_balance, get_reward_tx_counter, set_account_stats,
+    set_lifetime_claimed, set_lifetime_earned, set_reward_account, set_reward_balance,
+    set_reward_transaction, set_reward_tx_counter,
 };
-use crate::types::{RewardAccount, RewardStatus, RewardTransaction, RewardType};
+use crate::types::{
+    RewardAccount, RewardAccountStats, RewardStatus, RewardTransaction, RewardType,
+};
 use crate::validation::{
     validate_account_not_registered, validate_account_registered, validate_contract_initialized,
     validate_reward_amount, validate_sufficient_balance,
@@ -48,6 +51,16 @@ pub fn register_reward_account(env: &Env, participant: &Address) -> Result<(), R
     set_reward_balance(env, participant, 0);
     set_lifetime_earned(env, participant, 0);
     set_lifetime_claimed(env, participant, 0);
+    set_account_stats(
+        env,
+        participant,
+        &RewardAccountStats {
+            total_earned: 0,
+            total_redeemed: 0,
+            total_transactions: 0,
+            last_reward_timestamp: 0,
+        },
+    );
 
     emit_account_initialized(env, participant);
 
@@ -96,6 +109,15 @@ pub fn credit_reward(
     set_reward_account(env, participant, &account);
     set_reward_balance(env, participant, new_balance);
     set_lifetime_earned(env, participant, new_lifetime_earned);
+
+    let mut stats = get_account_stats(env, participant);
+    stats.total_earned = new_lifetime_earned;
+    stats.total_transactions = stats
+        .total_transactions
+        .checked_add(1)
+        .ok_or(RewardsError::Overflow)?;
+    stats.last_reward_timestamp = now;
+    set_account_stats(env, participant, &stats);
 
     let tx_id = get_reward_tx_counter(env);
     let tx = RewardTransaction {
@@ -160,6 +182,14 @@ pub fn debit_reward(
     set_reward_account(env, participant, &account);
     set_reward_balance(env, participant, new_balance);
     set_lifetime_claimed(env, participant, new_lifetime_claimed);
+
+    let mut stats = get_account_stats(env, participant);
+    stats.total_redeemed = new_lifetime_claimed;
+    stats.total_transactions = stats
+        .total_transactions
+        .checked_add(1)
+        .ok_or(RewardsError::Overflow)?;
+    set_account_stats(env, participant, &stats);
 
     let tx_id = get_reward_tx_counter(env);
     let tx = RewardTransaction {

--- a/contracts/rewards/src/storage.rs
+++ b/contracts/rewards/src/storage.rs
@@ -6,7 +6,7 @@
 
 use soroban_sdk::{vec, Address, Env, Vec};
 
-use crate::types::{DataKey, RewardAccount, RewardTransaction, PERSISTENT_TTL_BUMP};
+use crate::types::{DataKey, RewardAccount, RewardAccountStats, RewardTransaction, PERSISTENT_TTL_BUMP};
 
 // ── Reward Balance ─────────────────────────────────────────────────────────────
 
@@ -126,6 +126,40 @@ pub fn has_reward_account(env: &Env, account: &Address) -> bool {
     env.storage()
         .persistent()
         .has(&DataKey::RewardAccount(account.clone()))
+}
+
+// ── Reward Account Statistics ──────────────────────────────────────────────────
+
+/// Returns aggregate statistics for `account`.
+///
+/// Returns zeroed defaults if no stats entry exists yet.
+pub fn get_account_stats(env: &Env, account: &Address) -> RewardAccountStats {
+    let key = DataKey::AccountStats(account.clone());
+    let stats = env
+        .storage()
+        .persistent()
+        .get::<DataKey, RewardAccountStats>(&key)
+        .unwrap_or(RewardAccountStats {
+            total_earned: 0,
+            total_redeemed: 0,
+            total_transactions: 0,
+            last_reward_timestamp: 0,
+        });
+    if stats.total_transactions != 0 || stats.total_earned != 0 || stats.total_redeemed != 0 {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, PERSISTENT_TTL_BUMP, PERSISTENT_TTL_BUMP);
+    }
+    stats
+}
+
+/// Persists aggregate statistics for `account`.
+pub fn set_account_stats(env: &Env, account: &Address, stats: &RewardAccountStats) {
+    let key = DataKey::AccountStats(account.clone());
+    env.storage().persistent().set(&key, stats);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, PERSISTENT_TTL_BUMP, PERSISTENT_TTL_BUMP);
 }
 
 // ── Reward Transaction Counter ─────────────────────────────────────────────────

--- a/contracts/rewards/src/test.rs
+++ b/contracts/rewards/src/test.rs
@@ -1,14 +1,15 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env};
 
 use crate::{
     storage::{
-        get_lifetime_claimed, get_lifetime_earned, get_reward_account, get_reward_balance,
-        get_reward_index, get_reward_transaction, get_reward_tx_counter, has_reward_account,
-        set_lifetime_claimed, set_lifetime_earned, set_reward_account, set_reward_balance,
+        get_account_stats, get_lifetime_claimed, get_lifetime_earned, get_reward_account,
+        get_reward_balance, get_reward_index, get_reward_transaction, get_reward_tx_counter,
+        has_reward_account, set_account_stats, set_lifetime_claimed, set_lifetime_earned,
+        set_reward_account, set_reward_balance, set_reward_transaction, set_reward_tx_counter,
     },
-    types::{RewardAccount, RewardStatus, RewardTransaction, RewardType},
+    types::{RewardAccount, RewardAccountStats, RewardStatus, RewardTransaction, RewardType},
     RewardsContract, RewardsContractClient,
 };
 
@@ -869,8 +870,6 @@ fn test_reward_index_storage_helper_directly() {
 
 // ── RewardTransaction / TxCounter storage helpers (#877) ─────────────────────
 
-use crate::storage::{set_reward_transaction, set_reward_tx_counter};
-
 #[test]
 fn test_get_reward_transaction_returns_none_for_missing_id() {
     let env = Env::default();
@@ -1009,4 +1008,160 @@ fn test_reward_tx_counter_increments_correctly() {
         }
         assert_eq!(get_reward_tx_counter(&env), 5);
     });
+}
+
+// ── Reward account statistics tests (#869) ────────────────────────────────────
+
+#[test]
+fn test_account_stats_default_to_zero() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    let contract_id = env.register(RewardsContract, ());
+    env.as_contract(&contract_id, || {
+        let stats = get_account_stats(&env, &user);
+        assert_eq!(stats.total_earned, 0);
+        assert_eq!(stats.total_redeemed, 0);
+        assert_eq!(stats.total_transactions, 0);
+        assert_eq!(stats.last_reward_timestamp, 0);
+    });
+}
+
+#[test]
+fn test_set_and_get_account_stats() {
+    let env = Env::default();
+    let user = Address::generate(&env);
+    let contract_id = env.register(RewardsContract, ());
+    env.as_contract(&contract_id, || {
+        let record = RewardAccountStats {
+            total_earned: 1_000_000,
+            total_redeemed: 250_000,
+            total_transactions: 4,
+            last_reward_timestamp: 42,
+        };
+        set_account_stats(&env, &user, &record);
+        let fetched = get_account_stats(&env, &user);
+        assert_eq!(fetched, record);
+    });
+}
+
+#[test]
+fn test_register_account_initializes_zero_stats() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user = Address::generate(&env);
+    client.register_account(&user);
+
+    let stats = client.get_account_stats(&user);
+    assert_eq!(stats.total_earned, 0);
+    assert_eq!(stats.total_redeemed, 0);
+    assert_eq!(stats.total_transactions, 0);
+    assert_eq!(stats.last_reward_timestamp, 0);
+}
+
+#[test]
+fn test_credit_updates_earned_and_transaction_count() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user = Address::generate(&env);
+    client.register_account(&user);
+
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+    client.credit_reward(&user, &500_000, &RewardType::SpendingLimit);
+    env.ledger().with_mut(|li| li.sequence_number = 150);
+    client.credit_reward(&user, &250_000, &RewardType::Streak);
+
+    let stats = client.get_account_stats(&user);
+    assert_eq!(stats.total_earned, 750_000);
+    assert_eq!(stats.total_redeemed, 0);
+    assert_eq!(stats.total_transactions, 2);
+    assert_eq!(stats.last_reward_timestamp, 150);
+}
+
+#[test]
+fn test_debit_updates_redeemed_and_transaction_count() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user = Address::generate(&env);
+    client.register_account(&user);
+
+    client.credit_reward(&user, &1_000_000, &RewardType::SavingsGoal);
+    client.debit_reward(&user, &400_000, &RewardType::SavingsGoal);
+
+    let stats = client.get_account_stats(&user);
+    assert_eq!(stats.total_earned, 1_000_000);
+    assert_eq!(stats.total_redeemed, 400_000);
+    assert_eq!(stats.total_transactions, 2);
+}
+
+#[test]
+fn test_last_reward_timestamp_updates_on_credit_only() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user = Address::generate(&env);
+    client.register_account(&user);
+
+    env.ledger().with_mut(|li| li.sequence_number = 42);
+    client.credit_reward(&user, &1_000_000, &RewardType::Referral);
+    let after_credit = client.get_account_stats(&user).last_reward_timestamp;
+    assert_eq!(after_credit, 42);
+
+    env.ledger().with_mut(|li| li.sequence_number = 99);
+    client.debit_reward(&user, &100_000, &RewardType::Referral);
+    let after_debit = client.get_account_stats(&user).last_reward_timestamp;
+    assert_eq!(after_debit, 42);
+}
+
+#[test]
+fn test_stats_match_account_lifetime_totals() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user = Address::generate(&env);
+    client.register_account(&user);
+
+    client.credit_reward(&user, &800_000, &RewardType::ManualGrant);
+    client.debit_reward(&user, &300_000, &RewardType::ManualGrant);
+
+    let account = client.get_account(&user).unwrap();
+    let stats = client.get_account_stats(&user);
+    assert_eq!(stats.total_earned, account.lifetime_earned);
+    assert_eq!(stats.total_redeemed, account.lifetime_claimed);
+}
+
+#[test]
+fn test_stats_are_independent_per_user() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    client.register_account(&user_a);
+    client.register_account(&user_b);
+
+    client.credit_reward(&user_a, &1_000, &RewardType::Streak);
+    client.credit_reward(&user_b, &5_000, &RewardType::ManualGrant);
+    client.debit_reward(&user_a, &400, &RewardType::Streak);
+
+    let a = client.get_account_stats(&user_a);
+    let b = client.get_account_stats(&user_b);
+    assert_eq!(a.total_earned, 1_000);
+    assert_eq!(a.total_redeemed, 400);
+    assert_eq!(a.total_transactions, 2);
+    assert_eq!(b.total_earned, 5_000);
+    assert_eq!(b.total_redeemed, 0);
+    assert_eq!(b.total_transactions, 1);
+}
+
+#[test]
+fn test_existing_credit_debit_behavior_unchanged() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin);
+    let user = Address::generate(&env);
+    client.register_account(&user);
+
+    client.credit_reward(&user, &1_000_000, &RewardType::SpendingLimit);
+    client.debit_reward(&user, &250_000, &RewardType::SpendingLimit);
+
+    let account = client.get_account(&user).unwrap();
+    assert_eq!(account.balance, 750_000);
+    assert_eq!(account.lifetime_earned, 1_000_000);
+    assert_eq!(account.lifetime_claimed, 250_000);
 }

--- a/contracts/rewards/src/types.rs
+++ b/contracts/rewards/src/types.rs
@@ -19,6 +19,7 @@ pub const PERSISTENT_TTL_BUMP: u32 = 6_307_200;
 /// | `LifetimeEarned(Address)` | Persistent | Total rewards ever earned (stroops) |
 /// | `LifetimeClaimed(Address)` | Persistent | Total rewards ever claimed (stroops) |
 /// | `RewardAccount(Address)` | Persistent | Full reward account metadata struct |
+/// | `AccountStats(Address)` | Persistent | Aggregate reward account statistics |
 /// | `RewardTransaction(u64)` | Persistent | Individual reward transaction record by ID |
 /// | `RewardIndex(Address)` | Persistent | Ordered list of tx IDs for a participant |
 #[contracttype]
@@ -36,6 +37,8 @@ pub enum DataKey {
     LifetimeClaimed(Address),
     /// Full reward account metadata (persistent storage).
     RewardAccount(Address),
+    /// Aggregate statistics for a reward account (persistent storage).
+    AccountStats(Address),
     /// Individual reward transaction record, keyed by transaction ID (persistent storage).
     RewardTransaction(u64),
     /// Monotonically incrementing counter for reward transaction IDs (instance storage).
@@ -104,6 +107,23 @@ pub struct RewardAccount {
     pub created_at: u64,
     /// Ledger sequence of the most recent balance update.
     pub last_updated: u64,
+}
+
+/// Aggregate statistics for a reward account.
+///
+/// Persisted under `DataKey::AccountStats(address)`. Updated automatically on
+/// every credit and debit so reporting queries stay consistent with balances.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardAccountStats {
+    /// Total rewards earned over the account lifetime (stroops).
+    pub total_earned: i128,
+    /// Total rewards redeemed / claimed over the account lifetime (stroops).
+    pub total_redeemed: i128,
+    /// Total number of reward transactions (credits + debits).
+    pub total_transactions: u64,
+    /// Ledger sequence of the most recent reward credit (`0` if never credited).
+    pub last_reward_timestamp: u64,
 }
 
 /// A record of a single reward issuance or claim event.


### PR DESCRIPTION
## Overview

This PR adds **Reward Account Statistics** so each reward account maintains aggregate analytics for reporting — total earned, total redeemed, total transactions, and last reward timestamp — updated automatically on credit/debit.

## Related Issue

Closes #869

## Changes

### 📊 Reward Account Statistics

* **[ADD]** `RewardAccountStats` in `contracts/rewards/src/types.rs`
  * Tracks `total_earned`, `total_redeemed`, `total_transactions`, and `last_reward_timestamp`.
  * Stored under new `DataKey::AccountStats(Address)` persistent key.

* **[ADD]** Storage helpers in `contracts/rewards/src/storage.rs`
  * `get_account_stats` / `set_account_stats` with TTL bump on access.

* **[MODIFY]** `contracts/rewards/src/rewards.rs`
  * Initializes zeroed stats on account registration.
  * Credits update earned total, transaction count, and last reward timestamp.
  * Debits update redeemed total and transaction count (without changing last reward timestamp).

* **[ADD]** `get_account_stats` view in `contracts/rewards/src/lib.rs`
  * Query entry point returning accurate aggregate values.

* **[ADD]** Tests in `contracts/rewards/src/test.rs`
  * Coverage for defaults, auto-updates, per-user isolation, and unchanged credit/debit behavior.

## Verification Results

```
cargo test -p rewards
✅ 87/87 passed
```

Acceptance check:
✅ Statistics update automatically on credit/debit
✅ Queries return accurate earned / redeemed / tx totals and last reward timestamp
✅ Existing reward operations remain unaffected

| Acceptance Criteria | Status |
| --- | --- |
| Statistics update automatically | ✅ Updated in `credit_reward` / `debit_reward` |
| Queries return accurate values | ✅ `get_account_stats` covered by unit tests |
| Existing reward operations remain unaffected | ✅ Balance / lifetime / tx flows still pass |


Made with [Cursor](https://cursor.com)