### PR TITLE
feat(transaction-memo): add get_transaction_memo view function - retu…

### DIFF
--- a/contracts/transaction-memo/src/lib.rs
+++ b/contracts/transaction-memo/src/lib.rs
@@ -194,6 +194,17 @@ impl TransactionMemoContract {
         env.storage().instance().set(&DataKey::Admin, &new_admin);
     }
 
+    /// Retrieves the memo text for a transaction by transaction ID.
+    ///
+    /// Returns `Some(String)` with the memo text if a memo exists for the
+    /// given transaction ID, or `None` if no memo is found.
+    pub fn get_transaction_memo(env: Env, transaction_id: Bytes) -> Option<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Memo(transaction_id))
+            .map(|memo: TransactionMemo| memo.text)
+    }
+
     /// Returns the total number of memos stored.
     pub fn get_total_memos(env: Env) -> u64 {
         env.storage()

--- a/contracts/transaction-memo/src/test.rs
+++ b/contracts/transaction-memo/src/test.rs
@@ -175,3 +175,27 @@ fn test_empty_memo_type() {
 
     client.set_memo(&admin, &id, &memo_type, &reference, &text);
 }
+
+#[test]
+fn test_get_transaction_memo_known_tx() {
+    let (env, admin, client) = setup_test_contract();
+
+    let id = tx_id(&env, "tx-memotext");
+    let memo_type = Symbol::new(&env, "payment");
+    let reference = String::from_str(&env, "ref-001");
+    let text = String::from_str(&env, "Payment for coffee");
+
+    client.set_memo(&admin, &id, &memo_type, &reference, &text);
+
+    let memo_text = client.get_transaction_memo(&id);
+    assert_eq!(memo_text, Some(text));
+}
+
+#[test]
+fn test_get_transaction_memo_unknown_tx() {
+    let (env, _, client) = setup_test_contract();
+
+    let id = tx_id(&env, "unknown-tx");
+    let result = client.get_transaction_memo(&id);
+    assert!(result.is_none());
+}


### PR DESCRIPTION
Closes #1062
…rns memo text for a given tx ID, or None if not found. Adds tests for known and unknown tx. Closes #1062

## Summary
<!-- Describe the changes in this PR -->

## Related Issues
<!-- Use "closes #NUMBER" to link issues -->

## Checklist
- [ ] `cargo test` passes locally
- [ ] CI checks pass
- [ ] Screenshot of test results included
- [ ] Screenshot of CI passing included
