### PR TITLE
Add get_batch_rewards_total view function to batch-rewards contract

### DIFF
--- a/contracts/batch-rewards/src/lib.rs
+++ b/contracts/batch-rewards/src/lib.rs
@@ -98,6 +98,14 @@ impl BatchRewardsContract {
             .unwrap_or(0)
     }
 
+    /// Gets the total reward amount distributed in a specific batch.
+    pub fn get_batch_rewards_total(env: Env, batch_id: u64) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::BatchRewardTotal(batch_id))
+            .unwrap_or(0)
+    }
+
     /// Sets a new admin address.
     pub fn set_admin(env: Env, caller: Address, new_admin: Address) {
         caller.require_auth();
@@ -249,6 +257,9 @@ impl BatchRewardsContract {
         env.storage()
             .instance()
             .set(&DataKey::TotalBatches, &batch_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::BatchRewardTotal(batch_id), &total_distributed);
 
         // Mark the idempotency token as used for this completed batch.
         env.storage().persistent().set(&token_key, &true);

--- a/contracts/batch-rewards/src/test.rs
+++ b/contracts/batch-rewards/src/test.rs
@@ -501,3 +501,29 @@ fn test_multiple_simultaneous_batch_distributions() {
         assert_eq!(token_client.balance(&recipient), amount * 3);
     }
 }
+
+#[test]
+fn test_get_batch_rewards_total_returns_correct_total() {
+    let (env, admin, token, token_client, client) = setup_test_env();
+
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+    let amount1: i128 = 5_000_000;
+    let amount2: i128 = 3_000_000;
+
+    token_client.mint(&admin, &(amount1 + amount2 + 10_000_000));
+
+    let mut rewards: Vec<RewardRequest> = Vec::new(&env);
+    rewards.push_back(create_reward_request(&env, recipient1.clone(), amount1));
+    rewards.push_back(create_reward_request(&env, recipient2.clone(), amount2));
+
+    client.distribute_rewards(&admin, &token, &idempotency_token(&env, 50), &rewards);
+
+    assert_eq!(client.get_batch_rewards_total(&1), amount1 + amount2);
+}
+
+#[test]
+fn test_get_batch_rewards_total_returns_zero_for_unknown_batch() {
+    let (env, _admin, _token, _token_client, client) = setup_test_env();
+    assert_eq!(client.get_batch_rewards_total(&999), 0);
+}

--- a/contracts/batch-rewards/src/types.rs
+++ b/contracts/batch-rewards/src/types.rs
@@ -34,6 +34,7 @@ pub enum DataKey {
     TotalRewardsProcessed,
     TotalVolumeDistributed,
     IdempotencyToken(Bytes),
+    BatchRewardTotal(u64),
 }
 
 pub struct RewardEvents;


### PR DESCRIPTION
PR #1067  Add `get_batch_rewards_total` view to batch-rewards contract

## Summary

Adds a `get_batch_rewards_total(batch_id: u64) -> i128` view function that returns the total reward amount distributed in a specific completed batch.

## Changes

### `contracts/batch-rewards/src/types.rs`
- Added `BatchRewardTotal(u64)` variant to `DataKey` for per-batch reward total storage

### `contracts/batch-rewards/src/lib.rs`
- Added `get_batch_rewards_total` view function (returns 0 for unknown batch IDs)
- Stores `total_distributed` per batch in `distribute_rewards` using the new `BatchRewardTotal` key

### `contracts/batch-rewards/src/test.rs`
- Added `test_get_batch_rewards_total_returns_correct_total` — verifies correct total for a completed batch
- Added `test_get_batch_rewards_total_returns_zero_for_unknown_batch` — verifies 0 for unknown batch ID

## Acceptance Criteria

- [x] Returns correct total for a completed batch
- [x] Returns 0 for unknown batch id
- [ ] `cargo test -p batch-rewards` passes (blocked by workspace dependency conflict between `soroban-sdk =22.0.0` and `soroban-sdk ^22.0.0`)

## Test Results

> Tests could not be run due to pre-existing workspace dependency resolution conflict (`soroban-sdk =22.0.0` in `contracts/balance` vs `soroban-sdk ^22.0.0` in `contracts/recurring-payment`). This is unrelated to the changes in this PR.

Closes #1067 