### PR TITLE
Add get_token_balance view function to token contract  Description:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,10 @@ path = "tests/timelock_tests.rs"
 name = "security_e2e_tests"
 path = "tests/security_e2e_tests.rs"
 
+[[test]]
+name = "token_tests"
+path = "tests/token_tests.rs"
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"

--- a/contracts/token.rs
+++ b/contracts/token.rs
@@ -787,4 +787,8 @@ impl TokenContract {
     pub fn token_metrics(env: Env) -> TokenMetrics {
         get_token_metrics(&env)
     }
+
+    pub fn get_token_balance(env: Env, owner: Address) -> i128 {
+        get_balance(&env, &owner)
+    }
 }

--- a/tests/token_tests.rs
+++ b/tests/token_tests.rs
@@ -791,3 +791,26 @@ fn test_event_emission_comprehensive() {
         .iter()
         .any(|ev| { event_topics_contain_symbol(&env, &ev.1, symbol_short!("burn")) }));
 }
+
+#[test]
+fn test_get_token_balance() {
+    let (_env, admin, _token_contract, client) = setup_token_contract();
+
+    let user = Address::generate(&_env);
+    let amount = 1000i128;
+
+    // Test balance for address with no tokens
+    assert_eq!(client.get_token_balance(&user), 0);
+
+    // Mint tokens to user
+    client.mint(&admin, &user, &amount);
+
+    // Test balance for address with tokens
+    assert_eq!(client.get_token_balance(&user), amount);
+
+    // Burn some tokens
+    client.burn(&user, &500i128);
+
+    // Test balance after burn
+    assert_eq!(client.get_token_balance(&user), 500);
+}


### PR DESCRIPTION
Closes #973 
Summary
Adds a get_token_balance(owner: Address) -> i128 view function to the token contract to provide direct balance queries for any address.

Changes
contracts/token.rs: Added get_token_balance function to the TokenContract impl that returns the token balance for a given address tests/token_tests.rs: Added comprehensive test test_get_token_balance covering: Returns 0 for addresses with no balance
Returns correct balance for addresses with tokens
Returns correct balance after burn operations
Cargo.toml: Added token_tests to test targets
Acceptance Criteria
✅ Returns correct balance for addresses with tokens ✅ Returns 0 for addresses with no balance (via existing get_balance with unwrap_or(0)) ✅ Test added and passes syntax check
✅ View function (read-only, no state changes)
Testing

bash
cargo check  # Syntax verification passed

