### PR TITLE
feat(merchant-tagging): add get_merchant_tag view function

### DIFF
--- a/contracts/merchant-tagging/src/lib.rs
+++ b/contracts/merchant-tagging/src/lib.rs
@@ -364,6 +364,33 @@ impl MerchantTaggingContract {
             .unwrap_or(0)
     }
 
+    /// Retrieve the tag assigned to a merchant address.
+    ///
+    /// Iterates the merchant index to find a merchant whose registered address
+    /// matches the given address, then returns the first category tag.
+    /// Returns `None` if no merchant is found with that address or if the
+    /// merchant has no tags.
+    pub fn get_merchant_tag(env: Env, merchant: Address) -> Option<Symbol> {
+        let index: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::MerchantIndex)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for merchant_id in index.iter() {
+            if let Some(m) = env
+                .storage()
+                .instance()
+                .get::<_, Merchant>(&DataKey::Merchant(merchant_id))
+            {
+                if m.address.as_ref() == Some(&merchant) {
+                    return m.tags.get(0);
+                }
+            }
+        }
+        None
+    }
+
     /// Query all merchants that have a specific category tag.
     ///
     /// Iterates the merchant index and returns matching merchant IDs.

--- a/contracts/merchant-tagging/tests/merchant_tagging_tests.rs
+++ b/contracts/merchant-tagging/tests/merchant_tagging_tests.rs
@@ -353,6 +353,58 @@ fn test_get_merchants_by_tag() {
     assert_eq!(streaming_merchants.len(), 1);
 }
 
+// ── Get merchant tag ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_merchant_tag_returns_correct_tag() {
+    let (env, admin, client) = setup();
+    let merchant_address = Address::generate(&env);
+    let id = symbol_short!("AMAZON");
+    let name = String::from_str(&env, "Amazon");
+    let tags = make_tags(&env, &["retail", "ecommerce"]);
+
+    client.register_merchant(&admin, &id, &name, &tags, &Some(merchant_address.clone()));
+
+    let tag = client
+        .get_merchant_tag(&merchant_address)
+        .expect("should return a tag for a tagged merchant");
+    assert_eq!(tag, soroban_sdk::Symbol::new(&env, "retail"));
+}
+
+#[test]
+fn test_get_merchant_tag_returns_none_for_untagged_address() {
+    let (env, admin, client) = setup();
+    let merchant_address = Address::generate(&env);
+    let unknown_address = Address::generate(&env);
+    let id = symbol_short!("AMAZON");
+    let name = String::from_str(&env, "Amazon");
+
+    client.register_merchant(
+        &admin,
+        &id,
+        &name,
+        &make_tags(&env, &["retail"]),
+        &Some(merchant_address),
+    );
+
+    let tag = client.get_merchant_tag(&unknown_address);
+    assert!(tag.is_none());
+}
+
+#[test]
+fn test_get_merchant_tag_returns_none_for_merchant_without_address() {
+    let (env, admin, client) = setup();
+    let id = symbol_short!("AMAZON");
+    let name = String::from_str(&env, "Amazon");
+
+    // Register merchant without an address
+    client.register_merchant(&admin, &id, &name, &make_tags(&env, &["retail"]), &None);
+
+    let some_address = Address::generate(&env);
+    let tag = client.get_merchant_tag(&some_address);
+    assert!(tag.is_none());
+}
+
 #[test]
 fn test_total_tagged_counter() {
     let (env, admin, client) = setup();


### PR DESCRIPTION
## Overview

This PR adds a **get_merchant_tag** view function to the merchant-tagging contract that retrieves the first category tag assigned to a merchant by their registered Stellar address.

## Related Issue

Closes #964

## Changes

### 🔍 Merchant Tag Query

* **[ADD]** `contracts/merchant-tagging/src/lib.rs` — `get_merchant_tag(merchant: Address) -> Option<Symbol>`
  * Iterates the merchant index to find a merchant whose registered address matches the given address.
  * Returns the first category tag if found, or `None` if no match exists or the merchant has no tags.
  * Pure view function — no storage mutations.

* **[ADD]** `contracts/merchant-tagging/tests/merchant_tagging_tests.rs`
  * `test_get_merchant_tag_returns_correct_tag` — verifies correct tag is returned for a tagged merchant address.
  * `test_get_merchant_tag_returns_none_for_untagged_address` — verifies `None` for an address not matching any merchant.
  * `test_get_merchant_tag_returns_none_for_merchant_without_address` — verifies `None` when the merchant has no registered address.

## Verification Results

```
cargo test -p merchant-tagging -- get_merchant_tag
✅ 3/3 passed
```

| Acceptance Criteria | Status |
| --- | --- |
| Returns correct tag for a tagged merchant | ✅ `test_get_merchant_tag_returns_correct_tag` |
| Returns `None` for an untagged address | ✅ `test_get_merchant_tag_returns_none_for_untagged_address` |
| `cargo test -p merchant-tagging` passes | ✅ 19/20 pass (1 pre-existing failure in `test_remove_tag` unrelated to this change) |