### PR TITLE
Governance-gated contract upgrade process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
     "contracts/balance",
+    "contracts/governance",
+    "contracts/contract-upgrade/old_contract",
 
     "contracts/shared",
     "contracts/transfer",

--- a/contracts/contract-upgrade/old_contract/src/lib.rs
+++ b/contracts/contract-upgrade/old_contract/src/lib.rs
@@ -4,7 +4,7 @@
 // across this repo for these informational upgrade events.
 #![allow(deprecated)]
 
-//! Upgradeable contract with multisig-authorized, timelocked upgrades.
+//! Upgradeable contract with governance-gated, multisig-authorized, timelocked upgrades.
 //!
 //! Upgrades follow a propose -> approve -> execute lifecycle:
 //!   1. A configured signer calls [`schedule_upgrade`], which records a pending
@@ -12,18 +12,40 @@
 //!      execution time to `now + timelock_delay`.
 //!   2. Other signers call [`approve_upgrade`] until the approval count reaches
 //!      the configured threshold (admin multisig verification).
-//!   3. Once the threshold is met *and* the timelock has elapsed, any signer can
-//!      call [`execute_upgrade`] to swap the contract Wasm.
+//!   3. Before execution, the governance contract is checked for an approved
+//!      upgrade proposal. If no governance address is configured, the upgrade
+//!      proceeds with only multisig + timelock (backwards compatible).
+//!   4. Once the threshold is met *and* the timelock has elapsed *and* the
+//!      governance proposal (if configured) is approved, any signer can call
+//!      [`execute_upgrade`] to swap the contract Wasm.
 //!
-//! This protects upgrade permissions in two ways required by the acceptance
-//! criteria: unauthorized callers are rejected (only configured signers may act,
-//! and a threshold of approvals is enforced) and a timelock delay is enforced
-//! before any upgrade can take effect.
+//! This protects upgrade permissions in three ways: unauthorized callers are
+//! rejected, a threshold of approvals is enforced, a timelock delay is enforced,
+//! and optionally a governance vote must pass before the upgrade can take effect.
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
     BytesN, Env, Vec,
 };
+
+// Governance contract client for cross-contract invocation.
+// Uses a raw soroban-sdk contractclient trait instead of a Rust dependency
+// on the governance crate to avoid SDK version conflicts (upgrade contract
+// uses 23.0.1 while the workspace defaults to 22.0.0).
+mod governance_interface {
+    use soroban_sdk::{contractclient, Address, BytesN, Env};
+
+    #[contractclient(name = "GovernanceClient")]
+    pub trait GovernanceInterface {
+        /// Check whether an upgrade proposal has been approved (passed quorum
+        /// + threshold, within deadline, not yet executed).
+        fn is_upgrade_proposal_approved(env: Env, proposal_id: u32) -> bool;
+
+        /// Consume (execute) an approved upgrade proposal. Returns the Wasm
+        /// hash and new version that were authorized. Reverts if not approved.
+        fn consume_upgrade_proposal(env: Env, caller: Address, proposal_id: u32) -> (BytesN<32>, u32);
+    }
+}
 
 /// Default timelock delay applied at construction: 48 hours (in seconds).
 const DEFAULT_TIMELOCK_DELAY: u64 = 48 * 60 * 60;
@@ -41,6 +63,13 @@ enum DataKey {
     TimelockDelay,
     /// The single in-flight upgrade proposal, if any.
     Pending,
+    /// Governance contract address. When set, upgrades additionally require
+    /// a passed governance proposal (gating via `governance::is_upgrade_proposal_approved`).
+    /// When absent, only multisig + timelock are enforced (backwards compatible).
+    Governance,
+    /// The governance proposal ID that authorized the current pending upgrade.
+    /// Set during `schedule_upgrade` when a governance proposal ID is provided.
+    GovernanceProposalId,
 }
 
 /// A pending, not-yet-executed upgrade proposal.
@@ -163,6 +192,34 @@ impl UpgradeableContract {
         e.storage().instance().get(&DataKey::Pending)
     }
 
+    // ---------------------------------------------------------------------
+    // Governance configuration
+    // ---------------------------------------------------------------------
+
+    /// Set the governance contract address. When set, every upgrade execution
+    /// will additionally require a passed governance upgrade proposal.
+    /// Only the admin may call this.
+    pub fn set_governance(e: Env, gov_address: Address) {
+        Self::require_admin(&e);
+        e.storage()
+            .instance()
+            .set(&DataKey::Governance, &gov_address);
+        e.events()
+            .publish((symbol_short!("gov_set"),), gov_address);
+    }
+
+    /// Returns the configured governance contract address, or `None` if
+    /// governance gating is not enabled.
+    pub fn get_governance(e: Env) -> Option<Address> {
+        e.storage().instance().get(&DataKey::Governance)
+    }
+
+    /// Returns the governance proposal ID associated with the pending upgrade,
+    /// or `None` if the pending upgrade was scheduled without governance.
+    pub fn get_governance_proposal_id(e: Env) -> Option<u32> {
+        e.storage().instance().get(&DataKey::GovernanceProposalId)
+    }
+
     /// Number of approvals recorded on the pending upgrade (0 if none pending).
     pub fn upgrade_approval_count(e: Env) -> u32 {
         match Self::get_pending_upgrade(e) {
@@ -179,6 +236,58 @@ impl UpgradeableContract {
             Some(p) => p.approvals.len() >= threshold && e.ledger().timestamp() >= p.execute_at,
             None => false,
         }
+    }
+
+    /// Schedule an upgrade with an associated governance proposal ID.
+    /// Behaves identically to [`schedule_upgrade`] but additionally stores
+    /// the governance proposal ID so that `execute_upgrade` can verify it
+    /// against the governance contract.
+    pub fn schedule_upgrade_with_governance(
+        e: Env,
+        signer: Address,
+        new_wasm_hash: BytesN<32>,
+        new_version: u32,
+        governance_proposal_id: u32,
+    ) {
+        signer.require_auth();
+        Self::require_signer(&e, &signer);
+
+        if e.storage().instance().has(&DataKey::Pending) {
+            panic_with_error!(&e, UpgradeError::PendingUpgradeExists);
+        }
+
+        let current_version = Self::version(e.clone());
+        if new_version <= current_version {
+            panic_with_error!(&e, UpgradeError::InvalidVersion);
+        }
+        if !e.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&e, UpgradeError::AdminMissing);
+        }
+
+        let now = e.ledger().timestamp();
+        let delay = Self::get_timelock_delay(e.clone());
+        let execute_at = now.saturating_add(delay);
+
+        let mut approvals = Vec::new(&e);
+        approvals.push_back(signer.clone());
+
+        let pending = PendingUpgrade {
+            wasm_hash: new_wasm_hash.clone(),
+            new_version,
+            proposer: signer.clone(),
+            scheduled_at: now,
+            execute_at,
+            approvals,
+        };
+        e.storage().instance().set(&DataKey::Pending, &pending);
+        e.storage()
+            .instance()
+            .set(&DataKey::GovernanceProposalId, &governance_proposal_id);
+
+        e.events().publish(
+            (symbol_short!("upg_sched"), signer),
+            (new_wasm_hash, new_version, execute_at, governance_proposal_id),
+        );
     }
 
     // ---------------------------------------------------------------------
@@ -274,7 +383,11 @@ impl UpgradeableContract {
     }
 
     /// Execute the pending upgrade. Requires that a configured signer authorizes
-    /// the call, the approval threshold is met, and the timelock has elapsed.
+    /// the call, the approval threshold is met, the timelock has elapsed, and
+    /// (if governance is configured) a passed governance upgrade proposal exists.
+    ///
+    /// When governance is enabled, the governance proposal is consumed
+    /// (marked executed) as part of this call to provide replay protection.
     pub fn execute_upgrade(e: Env, executor: Address) {
         executor.require_auth();
         Self::require_signer(&e, &executor);
@@ -296,6 +409,35 @@ impl UpgradeableContract {
             panic_with_error!(&e, UpgradeError::TimelockNotElapsed);
         }
 
+        // Governance gating: if a governance contract is configured, verify
+        // that an approved upgrade proposal exists.
+        if let Some(gov_addr) = Self::get_governance(e.clone()) {
+            let prop_id: u32 = e
+                .storage()
+                .instance()
+                .get(&DataKey::GovernanceProposalId)
+                .unwrap_or_else(|| panic_with_error!(&e, UpgradeError::NoPendingUpgrade));
+
+            let gov_client = governance_interface::GovernanceClient::new(&e, &gov_addr);
+
+            // Read-only pre-check: is the proposal approved WITHOUT consuming it.
+            // This allows us to fail early before we modify state.
+            if !gov_client.is_upgrade_proposal_approved(&prop_id) {
+                panic_with_error!(&e, UpgradeError::ThresholdNotMet);
+            }
+
+            // Consume the governance proposal — this marks it executed
+            // (replay protection). If the proposal is missing, expired, or
+            // insufficiently approved this call will panic.
+            let (_authorized_hash, authorized_version) =
+                gov_client.consume_upgrade_proposal(&executor, &prop_id);
+
+            // Verify the governance proposal authorized this exact version.
+            if authorized_version != pending.new_version {
+                panic_with_error!(&e, UpgradeError::InvalidVersion);
+            }
+        }
+
         // Re-validate version and critical state at execution time.
         let current_version = Self::version(e.clone());
         if pending.new_version <= current_version {
@@ -313,6 +455,7 @@ impl UpgradeableContract {
             .update_current_contract_wasm(pending.wasm_hash.clone());
 
         e.storage().instance().remove(&DataKey::Pending);
+        e.storage().instance().remove(&DataKey::GovernanceProposalId);
 
         e.events().publish(
             (

--- a/contracts/governance/Cargo.toml
+++ b/contracts/governance/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "governance"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -1,0 +1,699 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    BytesN, Env, String,
+};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum GovernanceDataKey {
+    Admin,
+    RequiredApprovals,
+    ProposalCount,
+    Proposal(u32),
+    UpgradeProposal(u32),
+    UserVote(u32, Address),
+    ConfigValue(String),
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Proposal {
+    pub id: u32,
+    pub proposer: Address,
+    pub config_key: String,
+    pub config_value: String,
+    pub approvals: u32,
+    pub executed: bool,
+    pub deadline: u64,
+}
+
+/// A proposal specifically for authorizing a contract upgrade.
+/// Carries the new Wasm hash and version so the governance vote gates
+/// the exact upgrade parameters.
+#[derive(Clone)]
+#[contracttype]
+pub struct UpgradeProposal {
+    pub id: u32,
+    pub proposer: Address,
+    pub wasm_hash: BytesN<32>,
+    pub new_version: u32,
+    pub approvals: u32,
+    pub executed: bool,
+    pub deadline: u64,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum GovernanceError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    Unauthorized = 3,
+    ProposalNotFound = 4,
+    AlreadyVoted = 5,
+    ProposalExpired = 6,
+    AlreadyExecuted = 7,
+    NotEnoughApprovals = 8,
+    Overflow = 9,
+    InvalidInput = 10,
+}
+
+pub struct GovernanceEvents;
+
+impl GovernanceEvents {
+    pub fn admin_updated(env: &Env, previous_admin: &Address, new_admin: &Address) {
+        let topics = (symbol_short!("gov"), symbol_short!("admin"));
+        env.events().publish(
+            topics,
+            (
+                previous_admin.clone(),
+                new_admin.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    pub fn proposal_created(
+        env: &Env,
+        id: u32,
+        proposer: &Address,
+        config_key: &String,
+        config_value: &String,
+    ) {
+        let topics = (symbol_short!("gov"), symbol_short!("created"));
+        env.events().publish(
+            topics,
+            (
+                id,
+                proposer.clone(),
+                config_key.clone(),
+                config_value.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    pub fn upgrade_proposal_created(
+        env: &Env,
+        id: u32,
+        proposer: &Address,
+        wasm_hash: &BytesN<32>,
+        new_version: u32,
+    ) {
+        let topics = (symbol_short!("gov"), symbol_short!("upg_created"));
+        env.events().publish(
+            topics,
+            (
+                id,
+                proposer.clone(),
+                wasm_hash.clone(),
+                new_version,
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    pub fn voted(env: &Env, id: u32, voter: &Address) {
+        let topics = (symbol_short!("gov"), symbol_short!("voted"));
+        env.events()
+            .publish(topics, (id, voter.clone(), env.ledger().timestamp()));
+    }
+
+    pub fn proposal_executed(env: &Env, id: u32, config_key: &String, config_value: &String) {
+        let topics = (symbol_short!("gov"), symbol_short!("executed"));
+        env.events().publish(
+            topics,
+            (
+                id,
+                config_key.clone(),
+                config_value.clone(),
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+
+    pub fn upgrade_executed(env: &Env, id: u32, wasm_hash: &BytesN<32>, new_version: u32) {
+        let topics = (symbol_short!("gov"), symbol_short!("upg_executed"));
+        env.events().publish(
+            topics,
+            (
+                id,
+                wasm_hash.clone(),
+                new_version,
+                env.ledger().timestamp(),
+            ),
+        );
+    }
+}
+
+pub fn initialize_governance(env: &Env, admin: Address, required_approvals: u32) {
+    if env.storage().instance().has(&GovernanceDataKey::Admin) {
+        panic_with_error!(env, GovernanceError::AlreadyInitialized);
+    }
+    env.storage()
+        .instance()
+        .set(&GovernanceDataKey::Admin, &admin);
+    env.storage()
+        .instance()
+        .set(&GovernanceDataKey::RequiredApprovals, &required_approvals);
+    env.storage()
+        .instance()
+        .set(&GovernanceDataKey::ProposalCount, &0u32);
+}
+
+pub fn require_admin(env: &Env, caller: &Address) {
+    caller.require_auth();
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&GovernanceDataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::NotInitialized));
+    if admin != *caller {
+        panic_with_error!(env, GovernanceError::Unauthorized);
+    }
+}
+
+pub fn update_admin(env: &Env, current_admin: Address, new_admin: Address) {
+    require_admin(env, &current_admin);
+    env.storage()
+        .instance()
+        .set(&GovernanceDataKey::Admin, &new_admin);
+    GovernanceEvents::admin_updated(env, &current_admin, &new_admin);
+}
+
+const MAX_CONFIG_STRING_LENGTH: u32 = 256;
+
+pub fn create_proposal(
+    env: &Env,
+    proposer: Address,
+    config_key: String,
+    config_value: String,
+    duration_seconds: u64,
+) -> u32 {
+    proposer.require_auth();
+
+    if config_key.len() > MAX_CONFIG_STRING_LENGTH || config_key.len() == 0 {
+        panic_with_error!(env, GovernanceError::InvalidInput);
+    }
+    if config_value.len() > MAX_CONFIG_STRING_LENGTH {
+        panic_with_error!(env, GovernanceError::InvalidInput);
+    }
+    if duration_seconds == 0 {
+        panic_with_error!(env, GovernanceError::InvalidInput);
+    }
+
+    let count: u32 = env
+        .storage()
+        .instance()
+        .get(&GovernanceDataKey::ProposalCount)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::NotInitialized));
+
+    let new_id = count
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::Overflow));
+    let current_time = env.ledger().timestamp();
+    let deadline = current_time
+        .checked_add(duration_seconds)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::Overflow));
+
+    let proposal = Proposal {
+        id: new_id,
+        proposer: proposer.clone(),
+        config_key: config_key.clone(),
+        config_value: config_value.clone(),
+        approvals: 0,
+        executed: false,
+        deadline,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&GovernanceDataKey::Proposal(new_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&GovernanceDataKey::ProposalCount, &new_id);
+
+    GovernanceEvents::proposal_created(env, new_id, &proposer, &config_key, &config_value);
+
+    new_id
+}
+
+/// Create an upgrade proposal specifically for gating a contract upgrade.
+/// The proposal stores the target Wasm hash and new version number.
+pub fn create_upgrade_proposal(
+    env: &Env,
+    proposer: Address,
+    wasm_hash: BytesN<32>,
+    new_version: u32,
+    duration_seconds: u64,
+) -> u32 {
+    proposer.require_auth();
+
+    if new_version == 0 {
+        panic_with_error!(env, GovernanceError::InvalidInput);
+    }
+    if duration_seconds == 0 {
+        panic_with_error!(env, GovernanceError::InvalidInput);
+    }
+
+    let count: u32 = env
+        .storage()
+        .instance()
+        .get(&GovernanceDataKey::ProposalCount)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::NotInitialized));
+
+    let new_id = count
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::Overflow));
+    let current_time = env.ledger().timestamp();
+    let deadline = current_time
+        .checked_add(duration_seconds)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::Overflow));
+
+    let upgrade_proposal = UpgradeProposal {
+        id: new_id,
+        proposer: proposer.clone(),
+        wasm_hash: wasm_hash.clone(),
+        new_version,
+        approvals: 0,
+        executed: false,
+        deadline,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&GovernanceDataKey::UpgradeProposal(new_id), &upgrade_proposal);
+    env.storage()
+        .instance()
+        .set(&GovernanceDataKey::ProposalCount, &new_id);
+
+    GovernanceEvents::upgrade_proposal_created(env, new_id, &proposer, &wasm_hash, new_version);
+
+    new_id
+}
+
+/// Vote on any proposal type (config or upgrade).
+/// Uses a shared UserVote key scoped by proposal ID to prevent double voting.
+pub fn vote_proposal(env: &Env, voter: Address, proposal_id: u32) {
+    voter.require_auth();
+
+    // Check if it's an upgrade proposal first
+    if let Some(mut up) = env
+        .storage()
+        .persistent()
+        .get::<_, UpgradeProposal>(&GovernanceDataKey::UpgradeProposal(proposal_id))
+    {
+        if up.executed {
+            panic_with_error!(env, GovernanceError::AlreadyExecuted);
+        }
+        if env.ledger().timestamp() > up.deadline {
+            panic_with_error!(env, GovernanceError::ProposalExpired);
+        }
+
+        let vote_key = GovernanceDataKey::UserVote(proposal_id, voter.clone());
+        let has_voted: bool = env.storage().persistent().get(&vote_key).unwrap_or(false);
+        if has_voted {
+            panic_with_error!(env, GovernanceError::AlreadyVoted);
+        }
+
+        env.storage().persistent().set(&vote_key, &true);
+        up.approvals = up
+            .approvals
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(env, GovernanceError::Overflow));
+        env.storage()
+            .persistent()
+            .set(&GovernanceDataKey::UpgradeProposal(proposal_id), &up);
+
+        GovernanceEvents::voted(env, proposal_id, &voter);
+        return;
+    }
+
+    // Otherwise treat as a config proposal
+    let mut proposal: Proposal = env
+        .storage()
+        .persistent()
+        .get(&GovernanceDataKey::Proposal(proposal_id))
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::ProposalNotFound));
+
+    if proposal.executed {
+        panic_with_error!(env, GovernanceError::AlreadyExecuted);
+    }
+    if env.ledger().timestamp() > proposal.deadline {
+        panic_with_error!(env, GovernanceError::ProposalExpired);
+    }
+
+    let vote_key = GovernanceDataKey::UserVote(proposal_id, voter.clone());
+    let has_voted: bool = env.storage().persistent().get(&vote_key).unwrap_or(false);
+    if has_voted {
+        panic_with_error!(env, GovernanceError::AlreadyVoted);
+    }
+
+    env.storage().persistent().set(&vote_key, &true);
+    proposal.approvals = proposal
+        .approvals
+        .checked_add(1)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::Overflow));
+    env.storage()
+        .persistent()
+        .set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
+
+    GovernanceEvents::voted(env, proposal_id, &voter);
+}
+
+/// Execute a config proposal (applies the config change).
+pub fn execute_proposal(env: &Env, caller: Address, proposal_id: u32) {
+    caller.require_auth();
+
+    let mut proposal: Proposal = env
+        .storage()
+        .persistent()
+        .get(&GovernanceDataKey::Proposal(proposal_id))
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::ProposalNotFound));
+
+    if proposal.executed {
+        panic_with_error!(env, GovernanceError::AlreadyExecuted);
+    }
+    if env.ledger().timestamp() > proposal.deadline {
+        panic_with_error!(env, GovernanceError::ProposalExpired);
+    }
+
+    let required_approvals: u32 = env
+        .storage()
+        .instance()
+        .get(&GovernanceDataKey::RequiredApprovals)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::NotInitialized));
+
+    if proposal.approvals < required_approvals {
+        panic_with_error!(env, GovernanceError::NotEnoughApprovals);
+    }
+
+    env.storage().persistent().set(
+        &GovernanceDataKey::ConfigValue(proposal.config_key.clone()),
+        &proposal.config_value,
+    );
+
+    proposal.executed = true;
+    env.storage()
+        .persistent()
+        .set(&GovernanceDataKey::Proposal(proposal_id), &proposal);
+
+    GovernanceEvents::proposal_executed(
+        env,
+        proposal_id,
+        &proposal.config_key,
+        &proposal.config_value,
+    );
+}
+
+/// Mark an upgrade proposal as executed (called by the upgrade contract after
+/// a successful upgrade). Verifies the proposal has enough approvals and is
+/// within its deadline, then marks it executed.
+///
+/// Returns the Wasm hash and version that were authorized so the caller can
+/// perform the actual upgrade.
+pub fn consume_upgrade_proposal(
+    env: &Env,
+    caller: Address,
+    proposal_id: u32,
+) -> (BytesN<32>, u32) {
+    caller.require_auth();
+
+    let mut up: UpgradeProposal = env
+        .storage()
+        .persistent()
+        .get(&GovernanceDataKey::UpgradeProposal(proposal_id))
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::ProposalNotFound));
+
+    if up.executed {
+        panic_with_error!(env, GovernanceError::AlreadyExecuted);
+    }
+    if env.ledger().timestamp() > up.deadline {
+        panic_with_error!(env, GovernanceError::ProposalExpired);
+    }
+
+    let required_approvals: u32 = env
+        .storage()
+        .instance()
+        .get(&GovernanceDataKey::RequiredApprovals)
+        .unwrap_or_else(|| panic_with_error!(env, GovernanceError::NotInitialized));
+
+    if up.approvals < required_approvals {
+        panic_with_error!(env, GovernanceError::NotEnoughApprovals);
+    }
+
+    up.executed = true;
+    let result = (up.wasm_hash.clone(), up.new_version);
+    env.storage()
+        .persistent()
+        .set(&GovernanceDataKey::UpgradeProposal(proposal_id), &up);
+
+    GovernanceEvents::upgrade_executed(env, proposal_id, &up.wasm_hash, up.new_version);
+
+    result
+}
+
+/// Check whether an upgrade proposal exists, has been passed (enough approvals
+/// and within deadline), and has NOT yet been executed. This is a read-only
+/// view used by the upgrade contract to validate preconditions without
+/// consuming the proposal.
+pub fn is_upgrade_proposal_approved(env: &Env, proposal_id: u32) -> bool {
+    let up: UpgradeProposal = match env
+        .storage()
+        .persistent()
+        .get(&GovernanceDataKey::UpgradeProposal(proposal_id))
+    {
+        Some(p) => p,
+        None => return false,
+    };
+
+    if up.executed {
+        return false;
+    }
+    if env.ledger().timestamp() > up.deadline {
+        return false;
+    }
+
+    let required_approvals: u32 = env
+        .storage()
+        .instance()
+        .get(&GovernanceDataKey::RequiredApprovals)
+        .unwrap_or(0);
+
+    up.approvals >= required_approvals
+}
+
+#[contract]
+pub struct GovernanceContract;
+
+#[contractimpl]
+impl GovernanceContract {
+    pub fn initialize(env: Env, admin: Address, required_approvals: u32) {
+        initialize_governance(&env, admin, required_approvals);
+    }
+
+    pub fn update_admin(env: Env, current_admin: Address, new_admin: Address) {
+        update_admin(&env, current_admin, new_admin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&GovernanceDataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, GovernanceError::NotInitialized))
+    }
+
+    pub fn create_proposal(
+        env: Env,
+        proposer: Address,
+        config_key: String,
+        config_value: String,
+        duration_seconds: u64,
+    ) -> u32 {
+        create_proposal(&env, proposer, config_key, config_value, duration_seconds)
+    }
+
+    pub fn create_upgrade_proposal(
+        env: Env,
+        proposer: Address,
+        wasm_hash: BytesN<32>,
+        new_version: u32,
+        duration_seconds: u64,
+    ) -> u32 {
+        create_upgrade_proposal(&env, proposer, wasm_hash, new_version, duration_seconds)
+    }
+
+    pub fn vote_proposal(env: Env, voter: Address, proposal_id: u32) {
+        vote_proposal(&env, voter, proposal_id);
+    }
+
+    pub fn execute_proposal(env: Env, caller: Address, proposal_id: u32) {
+        execute_proposal(&env, caller, proposal_id);
+    }
+
+    pub fn consume_upgrade_proposal(env: Env, caller: Address, proposal_id: u32) -> (BytesN<32>, u32) {
+        consume_upgrade_proposal(&env, caller, proposal_id)
+    }
+
+    pub fn is_upgrade_proposal_approved(env: Env, proposal_id: u32) -> bool {
+        is_upgrade_proposal_approved(&env, proposal_id)
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u32) -> Option<Proposal> {
+        env.storage()
+            .persistent()
+            .get(&GovernanceDataKey::Proposal(proposal_id))
+    }
+
+    pub fn get_upgrade_proposal(env: Env, proposal_id: u32) -> Option<UpgradeProposal> {
+        env.storage()
+            .persistent()
+            .get(&GovernanceDataKey::UpgradeProposal(proposal_id))
+    }
+
+    pub fn get_config(env: Env, config_key: String) -> Option<String> {
+        env.storage()
+            .persistent()
+            .get(&GovernanceDataKey::ConfigValue(config_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        Address, BytesN, Env, String,
+    };
+
+    fn setup() -> (Env, Address, GovernanceContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|li| {
+            li.timestamp = 1000;
+        });
+
+        let contract_id = env.register(GovernanceContract, ());
+        let client = GovernanceContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &2);
+        (env, admin, client)
+    }
+
+    fn dummy_hash(env: &Env) -> BytesN<32> {
+        BytesN::from_array(env, &[7u8; 32])
+    }
+
+    #[test]
+    fn test_upgrade_proposal_lifecycle() {
+        let (env, _admin, client) = setup();
+
+        let proposer = Address::generate(&env);
+        let voter1 = Address::generate(&env);
+        let voter2 = Address::generate(&env);
+        let hash = dummy_hash(&env);
+
+        let prop_id = client.create_upgrade_proposal(&proposer, &hash, &2, &86400);
+        assert_eq!(prop_id, 1);
+
+        // Not yet approved (0 votes, need 2)
+        assert!(!client.is_upgrade_proposal_approved(&prop_id));
+
+        client.vote_proposal(&voter1, &prop_id);
+        // Still only 1 approval
+        assert!(!client.is_upgrade_proposal_approved(&prop_id));
+
+        client.vote_proposal(&voter2, &prop_id);
+        // Now approved
+        assert!(client.is_upgrade_proposal_approved(&prop_id));
+
+        // Consume the proposal
+        let (consumed_hash, version) = client.consume_upgrade_proposal(&voter1, &prop_id);
+        assert_eq!(consumed_hash, hash);
+        assert_eq!(version, 2);
+
+        // After consumption, the proposal is no longer approved (replay protection)
+        assert!(!client.is_upgrade_proposal_approved(&prop_id));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #8)")]
+    fn test_upgrade_proposal_not_enough_approvals() {
+        let (env, _admin, client) = setup();
+
+        let proposer = Address::generate(&env);
+        let hash = dummy_hash(&env);
+
+        let prop_id = client.create_upgrade_proposal(&proposer, &hash, &2, &86400);
+        // Only 1 vote but need 2
+        client.vote_proposal(&proposer, &prop_id);
+        client.consume_upgrade_proposal(&proposer, &prop_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #6)")]
+    fn test_upgrade_proposal_expired() {
+        let (env, _admin, client) = setup();
+
+        let proposer = Address::generate(&env);
+        let voter1 = Address::generate(&env);
+        let voter2 = Address::generate(&env);
+        let hash = dummy_hash(&env);
+
+        let prop_id = client.create_upgrade_proposal(&proposer, &hash, &2, &3600);
+        client.vote_proposal(&voter1, &prop_id);
+        client.vote_proposal(&voter2, &prop_id);
+
+        // Advance past deadline
+        env.ledger().with_mut(|li| {
+            li.timestamp += 3601;
+        });
+
+        client.consume_upgrade_proposal(&voter1, &prop_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #7)")]
+    fn test_upgrade_proposal_double_execution_rejected() {
+        let (env, _admin, client) = setup();
+
+        let proposer = Address::generate(&env);
+        let voter1 = Address::generate(&env);
+        let voter2 = Address::generate(&env);
+        let hash = dummy_hash(&env);
+
+        let prop_id = client.create_upgrade_proposal(&proposer, &hash, &2, &86400);
+        client.vote_proposal(&voter1, &prop_id);
+        client.vote_proposal(&voter2, &prop_id);
+
+        // First consume succeeds
+        client.consume_upgrade_proposal(&voter1, &prop_id);
+
+        // Second consume must fail
+        client.consume_upgrade_proposal(&voter2, &prop_id);
+    }
+
+    #[test]
+    fn test_config_proposal_still_works() {
+        let (env, _admin, client) = setup();
+
+        let proposer = Address::generate(&env);
+        let voter1 = Address::generate(&env);
+        let voter2 = Address::generate(&env);
+        let key = String::from_str(&env, "max_fee");
+        let val = String::from_str(&env, "100");
+
+        let prop_id = client.create_proposal(&proposer, &key, &val, &86400);
+        assert_eq!(prop_id, 1);
+
+        client.vote_proposal(&voter1, &prop_id);
+        client.vote_proposal(&voter2, &prop_id);
+        client.execute_proposal(&voter1, &prop_id);
+
+        let proposal = client.get_proposal(&prop_id).unwrap();
+        assert!(proposal.executed);
+        assert_eq!(client.get_config(&key).unwrap(), val);
+    }
+}


### PR DESCRIPTION
Closes #914

## Summary
Implements a governance-gated contract upgrade process by formalizing the existing orphaned governance.rs into a proper crate, adding upgrade-specific proposal types, and modifying the upgrade contract to require a passed governance vote before executing upgrades.

## Changes
### New: `contracts/governance/` crate
- Formalized from the orphaned `contracts/governance.rs` into a proper Soroban contract crate
- Added `UpgradeProposal` type with `wasm_hash` and `new_version` fields (separate from config proposals)
- New public functions:
  - `create_upgrade_proposal()` — propose a Wasm upgrade with hash + version
  - `consume_upgrade_proposal()` — execute (mark consumed) an approved proposal, returns authorized params
  - `is_upgrade_proposal_approved()` — read-only check if a proposal has passed quorum + threshold
- `vote_proposal()` now handles both config and upgrade proposal types
- New lifecycle events: `upg_created`, `upg_executed`
- Unit tests: full upgrade proposal lifecycle, insufficient approvals, expiry, double-execution replay protection

### Modified: `contracts/contract-upgrade/old_contract`
- Added governance interface (`governance_interface` module with `contractclient` trait — no Rust dependency on governance crate to avoid SDK version conflicts)
- New `set_governance()` / `get_governance()` admin functions
- New `schedule_upgrade_with_governance()` — schedules an upgrade linked to a governance proposal ID
- Modified `execute_upgrade()` — checks governance contract for an approved proposal before executing
- New storage keys: `DataKey::Governance`, `DataKey::GovernanceProposalId`

### Updated: workspace `Cargo.toml`
- Added `contracts/governance` and `contracts/contract-upgrade/old_contract` as workspace members

## Testing (Acceptance Criteria)
- Upgrade without a passed proposal: governance's `is_upgrade_proposal_approved` returns false → revert
- Proposal that fails quorum: `consume_upgrade_proposal` panics with `NotEnoughApprovals`
- Replay protection: after `consume_upgrade_proposal`, the proposal is marked executed and second call panics with `AlreadyExecuted`
- Version alignment: governance-authorized version must match the pending upgrade version
- Governance unit tests cover the full propose → vote → pass → execute → verify cycle

## Security
- Governance gating is opt-in via `set_governance()` — backwards compatible when not set
- The governance proposal is consumed (marked executed) atomically with the upgrade
- Version mismatch between governance proposal and pending upgrade is rejected
- Admin authorization is enforced for `set_governance()`