### PR TITLE
feat: add get_streak_count view to streak_reward contract (Closes #975)

### DIFF
--- a/contracts/streak_reward.rs
+++ b/contracts/streak_reward.rs
@@ -466,6 +466,16 @@ impl StreakRewardsContract {
 
     // ── Read-only queries ─────────────────────────────────────────────────────
 
+    /// Return the current streak count for `owner`, or 0 if no record exists.
+    pub fn get_streak_count(env: Env, owner: Address) -> u32 {
+        let key = DataKey::UserStreak(owner);
+        env.storage()
+            .persistent()
+            .get::<_, UserStreakRecord>(&key)
+            .map(|record| record.streak_days)
+            .unwrap_or(0)
+    }
+
     /// Return the current streak record for `user`, or a zeroed default.
     pub fn get_streak(env: Env, user: Address) -> UserStreakRecord {
         Self::load_or_default_streak(&env, &user)
@@ -542,5 +552,26 @@ mod streak_tests {
         env.ledger().set_timestamp(86_400 * 3);
         let streak = client.record_deposit(&user);
         assert_eq!(streak, 1);
+    }
+
+    #[test]
+    fn test_get_streak_count() {
+        let env = make_env();
+        let contract_id = env.register(StreakRewardsContract, ());
+        let client = StreakRewardsContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        client.initialize(&admin, &token, &10i128, &50i128, &200i128);
+        let user = Address::generate(&env);
+        let unused_user = Address::generate(&env);
+
+        assert_eq!(client.get_streak_count(&unused_user), 0);
+
+        client.record_deposit(&user);
+        assert_eq!(client.get_streak_count(&user), 1);
+
+        env.ledger().set_timestamp(86_400 * 2);
+        client.record_deposit(&user);
+        assert_eq!(client.get_streak_count(&user), 2);
     }
 }

--- a/tests/streak_reward_test.rs
+++ b/tests/streak_reward_test.rs
@@ -691,3 +691,20 @@ fn security_claim_reward_requires_auth() {
     let _ = env_no_auth;
     client.claim_reward(&user, &STREAK_TIER_WEEK);
 }
+
+#[test]
+fn happy_get_streak_count() {
+    let ctx = TestCtx::new();
+    let user = Address::generate(&ctx.env);
+    let unused_user = Address::generate(&ctx.env);
+
+    assert_eq!(ctx.client.get_streak_count(&unused_user), 0);
+
+    ctx.set_day(1);
+    ctx.client.record_deposit(&user);
+    assert_eq!(ctx.client.get_streak_count(&user), 1);
+
+    ctx.set_day(2);
+    ctx.client.record_deposit(&user);
+    assert_eq!(ctx.client.get_streak_count(&user), 2);
+}


### PR DESCRIPTION
## Summary
- Added `get_streak_count(env: Env, owner: Address) -> u32` view function to `StreakRewardsContract` in [contracts/streak_reward.rs](file:///c:/Users/Chibuike%20Umeokonkwo/Documents/GithubProjects/stellarspend-contracts/contracts/streak_reward.rs). This allows querying an address's current streak count without triggering state changes or storage TTL updates.
- Returns `0` for an address with no active streak.
- Added unit tests for `get_streak_count` in both [contracts/streak_reward.rs](file:///c:/Users/Chibuike%20Umeokonkwo/Documents/GithubProjects/stellarspend-contracts/contracts/streak_reward.rs) and [tests/streak_reward_test.rs](file:///c:/Users/Chibuike%20Umeokonkwo/Documents/GithubProjects/stellarspend-contracts/tests/streak_reward_test.rs).

## Related Issues
Closes #975

## Checklist
- [x] `cargo test` passes locally
- [ ] CI checks pass
- [ ] Screenshot of test results included
- [ ] Screenshot of CI passing included
