### PR TITLE
feat(budget-allocation): add get_budget_allocation_breakdown view function

### DIFF
--- a/contracts/budget-allocation/src/lib.rs
+++ b/contracts/budget-allocation/src/lib.rs
@@ -215,6 +215,35 @@ impl BudgetAllocationContract {
         env.storage().persistent().get(&DataKey::Budget(user))
     }
 
+    /// Returns a list of category-amount pairs showing how a budget is allocated.
+    ///
+    /// # Arguments
+    /// * `owner` - The address whose budget breakdown to retrieve
+    ///
+    /// # Returns
+    /// A vector of (category_name, amount) pairs, or an empty vector if the
+    /// address has no category allocations.
+    pub fn get_budget_allocation_breakdown(
+        env: Env,
+        owner: Address,
+    ) -> Vec<(Symbol, i128)> {
+        let mut result = Vec::new(&env);
+
+        let user_categories: Option<UserBudgetCategories> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BudgetCategories(owner));
+
+        if let Some(categories) = user_categories {
+            for key in categories.categories.keys() {
+                let amount = categories.categories.get(key.clone()).unwrap();
+                result.push_back((key, amount));
+            }
+        }
+
+        result
+    }
+
     /// Retrieves a summary of the allocation state for a specific user.
     pub fn get_budget_allocation_summary(
         env: Env,

--- a/contracts/budget-allocation/src/test.rs
+++ b/contracts/budget-allocation/src/test.rs
@@ -78,6 +78,18 @@ impl<'a> BudgetAllocationContractClient<'a> {
             )
         })
     }
+
+    pub fn get_budget_allocation_breakdown(
+        &self,
+        owner: &Address,
+    ) -> Vec<(Symbol, i128)> {
+        self.env.as_contract(self.contract_id, || {
+            BudgetAllocationContract::get_budget_allocation_breakdown(
+                self.env.clone(),
+                owner.clone(),
+            )
+        })
+    }
 }
 
 #[test]
@@ -273,4 +285,72 @@ fn test_budget_allocation_summary_zero_total_usage_percentage() {
     assert_eq!(summary.total_allocation, 0);
     assert_eq!(summary.remaining_allocation, 0);
     assert_eq!(summary.usage_percentage, 0);
+}
+
+#[test]
+fn test_budget_allocation_breakdown_returns_correct_pairs() {
+    let (env, contract_id, admin) = create_contract();
+    let client = BudgetAllocationContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+
+    let categories = vec![
+        &env,
+        BudgetCategory {
+            name: soroban_sdk::symbol_short!("food"),
+            amount: 500,
+        },
+        BudgetCategory {
+            name: soroban_sdk::symbol_short!("transport"),
+            amount: 200,
+        },
+        BudgetCategory {
+            name: soroban_sdk::symbol_short!("entertain"),
+            amount: 150,
+        },
+    ];
+
+    let request = CategoryBudgetRequest {
+        user: user.clone(),
+        categories: categories.clone(),
+        total_amount: 850,
+    };
+
+    assert!(client.allocate_budget_by_category(&admin, &request));
+
+    let breakdown = client.get_budget_allocation_breakdown(&user);
+    assert_eq!(breakdown.len(), 3);
+
+    // Build a map for easy lookup since order is not guaranteed
+    let mut found_food = false;
+    let mut found_transport = false;
+    let mut found_entertain = false;
+
+    for (sym, amount) in breakdown.iter() {
+        if sym == soroban_sdk::symbol_short!("food") {
+            found_food = true;
+            assert_eq!(amount, 500);
+        } else if sym == soroban_sdk::symbol_short!("transport") {
+            found_transport = true;
+            assert_eq!(amount, 200);
+        } else if sym == soroban_sdk::symbol_short!("entertain") {
+            found_entertain = true;
+            assert_eq!(amount, 150);
+        }
+    }
+
+    assert!(found_food);
+    assert!(found_transport);
+    assert!(found_entertain);
+}
+
+#[test]
+fn test_budget_allocation_breakdown_empty_for_no_allocations() {
+    let (env, contract_id, _admin) = create_contract();
+    let client = BudgetAllocationContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+
+    let breakdown = client.get_budget_allocation_breakdown(&user);
+    assert!(breakdown.is_empty());
 }


### PR DESCRIPTION
## Summary

Adds a new `get_budget_allocation_breakdown(owner: Address) -> Vec<(Symbol, i128)>` view function to the budget-allocation contract that returns a list of category-amount pairs showing how a user's budget is allocated across categories.

## Changes

### `contracts/budget-allocation/src/lib.rs`
- Added `get_budget_allocation_breakdown` public view function
- Reads from `DataKey::BudgetCategories(owner)` storage
- Iterates over category keys and returns `(Symbol, i128)` pairs
- Returns an empty `Vec` for addresses with no category allocations

### `contracts/budget-allocation/src/test.rs`
- Added client wrapper method `get_budget_allocation_breakdown`
- Added `test_budget_allocation_breakdown_returns_correct_pairs` — verifies correct category-amount pairs for a user with allocations
- Added `test_budget_allocation_breakdown_empty_for_no_allocations` — verifies empty vec for address with no allocations

## Acceptance Criteria

- [x] Returns correct category-amount pairs
- [x] Returns empty vec for address with no allocations
- [x] `cargo test -p budget-allocation` passes

## Related Issue

Closes #986