### PR TITLE
feat(contracts): add get_rate_limit_remaining view to rate_limit contract

### DIFF
--- a/contracts/rate_limit.rs
+++ b/contracts/rate_limit.rs
@@ -80,6 +80,25 @@ impl RateLimitContract {
         Ok(())
     }
 
+    pub fn get_rate_limit_remaining(env: Env, wallet: Address) -> u32 {
+        let config: RateLimitConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or(RateLimitConfig::default());
+
+        let now = env.ledger().timestamp();
+        let window_start = now - (now % config.window);
+        let key = DataKey::RateLimitCount(wallet.clone(), window_start);
+        let count: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+
+        if count >= config.max_tx {
+            0
+        } else {
+            config.max_tx - count
+        }
+    }
+
     /// Updates rate limit config. Caller must be authorized (require_auth).
     pub fn set_config(
         env: Env,

--- a/tests/rate_limit_tests.rs
+++ b/tests/rate_limit_tests.rs
@@ -97,3 +97,33 @@ fn test_warning_emitted_and_allows_overspend() {
         assert!(result.is_err());
     });
 }
+
+#[test]
+fn test_get_rate_limit_remaining() {
+    let (env, contract_id) = setup_env();
+    let wallet = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        // Initial state: default limit is 5
+        assert_eq!(RateLimitContract::get_rate_limit_remaining(env.clone(), wallet.clone()), 5);
+
+        // Perform 2 transactions
+        RateLimitContract::check_and_record(env.clone(), wallet.clone()).unwrap();
+        RateLimitContract::check_and_record(env.clone(), wallet.clone()).unwrap();
+
+        // Remaining should be 5 - 2 = 3
+        assert_eq!(RateLimitContract::get_rate_limit_remaining(env.clone(), wallet.clone()), 3);
+
+        // Perform 3 more transactions (total 5)
+        RateLimitContract::check_and_record(env.clone(), wallet.clone()).unwrap();
+        RateLimitContract::check_and_record(env.clone(), wallet.clone()).unwrap();
+        RateLimitContract::check_and_record(env.clone(), wallet.clone()).unwrap();
+
+        // Remaining should be 0
+        assert_eq!(RateLimitContract::get_rate_limit_remaining(env.clone(), wallet.clone()), 0);
+
+        // Next transaction should fail
+        assert!(RateLimitContract::check_and_record(env.clone(), wallet.clone()).is_err());
+        assert_eq!(RateLimitContract::get_rate_limit_remaining(env.clone(), wallet.clone()), 0);
+    });
+}


### PR DESCRIPTION
PR Description

  Summary
  Adds a get_rate_limit_remaining view function to the rate_limit contract. This enables clients to check the remaining transaction quota for a wallet
  within the current rate-limit window before initiating a transaction, improving UX by allowing proactive UI feedback.

  Changes
   - contracts/rate_limit.rs: Added the public get_rate_limit_remaining(env: Env, wallet: Address) -> u32 function. It retrieves the contract
     configuration and current usage count to calculate the remaining allowed transactions.
   - tests/rate_limit_tests.rs: Added a comprehensive unit test test_get_rate_limit_remaining that verifies the remaining quota calculation across
     various scenarios (initial state, partial usage, at limit, and exceeded).

  Acceptance Criteria
   - [x] Returns correct remaining count.
   - [x] Returns 0 when limit is fully consumed.
   - [x] New unit test added and verified.

  Verification
  The feature was verified by adding a new test case to the existing test suite. The implementation reuses the established RateLimitConfig and DataKey
  logic used by check_and_record, ensuring consistency with existing enforcement rules.

  

  Related Issue
  Closes #1000
