### PR TITLE
Implement real business logic in savings, savings-goals, and budget contracts

### DIFF
--- a/contracts/budget/src/lib.rs
+++ b/contracts/budget/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, Address, Env, Symbol, Vec};
 
 mod storage;
 #[cfg(test)]
@@ -8,16 +8,25 @@ mod test;
 pub mod types;
 pub mod validation;
 
+pub use types::Budget;
+
 /// Typed errors for the budget contract.
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Contract has already been initialized.
     AlreadyInitialized = 1,
-    /// Caller is not the administrator.
-    Unauthorized = 2,
-    /// Amount validation failed.
-    InvalidAmount = 3,
+    /// Contract has not been initialized.
+    NotInitialized = 2,
+    /// Caller is not authorized to perform this action on the given
+    /// budget.
+    Unauthorized = 3,
+    /// Amount must be a strictly positive value.
+    InvalidAmount = 4,
+    /// `end_date` must be strictly after `start_date`.
+    InvalidDateRange = 5,
+    /// No budget exists with the given id.
+    BudgetNotFound = 6,
 }
 
 #[contract]
@@ -31,26 +40,94 @@ impl Contract {
             return Err(Error::AlreadyInitialized);
         }
         admin.require_auth();
-        storage::write_config(&env, &types::Config { admin, value: 0 });
+        storage::write_config(
+            &env,
+            &types::Config {
+                admin,
+                last_budget_id: 0,
+            },
+        );
         Ok(())
     }
 
-    /// Updates the contract value after authenticating the administrator.
-    pub fn set_value(env: Env, admin: Address, value: i128) -> Result<(), Error> {
-        admin.require_auth();
-        if value < 0 {
-            return Err(Error::InvalidAmount);
-        }
-        let current = storage::read_config(&env).ok_or(Error::Unauthorized)?;
-        if current.admin != admin {
+    /// Creates a new budget for `user` and returns its id.
+    #[allow(clippy::too_many_arguments)]
+    pub fn create_budget(
+        env: Env,
+        user: Address,
+        name: Symbol,
+        amount: i128,
+        category: Symbol,
+        asset: Symbol,
+        start_date: u64,
+        end_date: u64,
+    ) -> Result<u64, Error> {
+        user.require_auth();
+        validation::validate_amount(amount)?;
+        validation::validate_date_range(start_date, end_date)?;
+
+        let mut config = storage::read_config(&env).ok_or(Error::NotInitialized)?;
+        config.last_budget_id += 1;
+        let budget_id = config.last_budget_id;
+        storage::write_config(&env, &config);
+
+        let budget = Budget {
+            budget_id,
+            user: user.clone(),
+            name,
+            amount,
+            category,
+            asset,
+            start_date,
+            end_date,
+            created_at: env.ledger().timestamp(),
+        };
+        storage::write_budget(&env, &budget);
+        storage::add_user_budget(&env, &user, budget_id);
+
+        Ok(budget_id)
+    }
+
+    /// Updates the amount allocated to an existing budget.
+    pub fn update_budget(
+        env: Env,
+        user: Address,
+        budget_id: u64,
+        amount: i128,
+    ) -> Result<(), Error> {
+        user.require_auth();
+        validation::validate_amount(amount)?;
+
+        let mut budget = storage::read_budget(&env, budget_id).ok_or(Error::BudgetNotFound)?;
+        if budget.user != user {
             return Err(Error::Unauthorized);
         }
-        storage::write_config(&env, &types::Config { admin, value });
+        budget.amount = amount;
+        storage::write_budget(&env, &budget);
         Ok(())
     }
 
-    /// Returns the current configured value.
-    pub fn get_value(env: Env) -> i128 {
-        storage::read_config(&env).map(|c| c.value).unwrap_or(0)
+    /// Deletes a budget owned by `user`.
+    pub fn delete_budget(env: Env, user: Address, budget_id: u64) -> Result<(), Error> {
+        user.require_auth();
+        let budget = storage::read_budget(&env, budget_id).ok_or(Error::BudgetNotFound)?;
+        if budget.user != user {
+            return Err(Error::Unauthorized);
+        }
+        storage::delete_budget(&env, budget_id);
+        storage::remove_user_budget(&env, &user, budget_id);
+        Ok(())
+    }
+
+    /// Returns all budgets belonging to `user`.
+    pub fn get_budgets(env: Env, user: Address) -> Vec<Budget> {
+        let ids = storage::user_budget_ids(&env, &user);
+        let mut budgets = Vec::new(&env);
+        for id in ids.iter() {
+            if let Some(budget) = storage::read_budget(&env, id) {
+                budgets.push_back(budget);
+            }
+        }
+        budgets
     }
 }

--- a/contracts/budget/src/storage.rs
+++ b/contracts/budget/src/storage.rs
@@ -1,21 +1,68 @@
-use crate::types::Config;
-use soroban_sdk::{Address, Env};
-
-const CONFIG: &str = "CONFIG";
+use crate::types::{Budget, Config, DataKey};
+use soroban_sdk::{Address, Env, Vec};
 
 /// Reads contract configuration from instance storage.
 pub fn read_config(env: &Env) -> Option<Config> {
-    // Instance storage is appropriate for contract-wide configuration.
-    env.storage().instance().get(&CONFIG)
+    env.storage().instance().get(&DataKey::Config)
 }
 
 /// Writes contract configuration to instance storage.
 pub fn write_config(env: &Env, config: &Config) {
-    // Instance storage keeps configuration attached to the contract instance.
-    env.storage().instance().set(&CONFIG, config);
+    env.storage().instance().set(&DataKey::Config, config);
 }
 
-/// Returns the configured owner.
-pub fn owner(env: &Env) -> Option<Address> {
-    read_config(env).map(|c| c.admin)
+/// Reads a budget record from persistent storage.
+pub fn read_budget(env: &Env, budget_id: u64) -> Option<Budget> {
+    env.storage().persistent().get(&DataKey::Budget(budget_id))
+}
+
+/// Writes a budget record to persistent storage.
+pub fn write_budget(env: &Env, budget: &Budget) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Budget(budget.budget_id), budget);
+}
+
+/// Removes a budget record from persistent storage.
+pub fn delete_budget(env: &Env, budget_id: u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Budget(budget_id));
+}
+
+/// Appends `budget_id` to the list of budget ids owned by `user`.
+pub fn add_user_budget(env: &Env, user: &Address, budget_id: u64) {
+    let key = DataKey::UserBudgets(user.clone());
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    ids.push_back(budget_id);
+    env.storage().persistent().set(&key, &ids);
+}
+
+/// Removes `budget_id` from the list of budget ids owned by `user`.
+pub fn remove_user_budget(env: &Env, user: &Address, budget_id: u64) {
+    let key = DataKey::UserBudgets(user.clone());
+    let ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    let mut updated = Vec::new(env);
+    for id in ids.iter() {
+        if id != budget_id {
+            updated.push_back(id);
+        }
+    }
+    env.storage().persistent().set(&key, &updated);
+}
+
+/// Returns all budget ids owned by `user`.
+pub fn user_budget_ids(env: &Env, user: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserBudgets(user.clone()))
+        .unwrap_or(Vec::new(env))
 }

--- a/contracts/budget/src/test.rs
+++ b/contracts/budget/src/test.rs
@@ -1,31 +1,268 @@
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::testutils::{Address as _, Ledger};
-    use soroban_sdk::Env;
+    use crate::{Contract, ContractClient, Error};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+    fn setup(env: &Env) -> ContractClient<'static> {
+        env.mock_all_auths();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        client
+    }
+
+    fn category(env: &Env) -> Symbol {
+        Symbol::new(env, "groceries")
+    }
+
+    fn xlm(env: &Env) -> Symbol {
+        Symbol::new(env, "XLM")
+    }
 
     #[test]
-    fn happy_path_environment() {
+    fn create_budget_returns_incrementing_ids() {
         let env = Env::default();
-        env.ledger().set_sequence_number(1);
-        assert_eq!(env.ledger().sequence(), 1);
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+
+        let id1 = client.create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+        let id2 = client.create_budget(
+            &user,
+            &Symbol::new(&env, "fun"),
+            &200_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
     }
+
     #[test]
-    fn unauthorized_boundary_placeholder() {
+    fn get_budgets_returns_all_budgets_for_user() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+        client.create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+        client.create_budget(
+            &user,
+            &Symbol::new(&env, "fun"),
+            &200_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+
+        let budgets = client.get_budgets(&user);
+        assert_eq!(budgets.len(), 2);
+    }
+
+    #[test]
+    fn get_budgets_is_empty_for_a_user_with_no_budgets() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+
+        let budgets = client.get_budgets(&user);
+        assert_eq!(budgets.len(), 0);
+    }
+
+    #[test]
+    fn update_budget_persists_new_amount() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+        let id = client.create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+
+        client.update_budget(&user, &id, &750_i128);
+
+        let budgets = client.get_budgets(&user);
+        assert_eq!(budgets.get(0).unwrap().amount, 750);
+    }
+
+    #[test]
+    fn delete_budget_removes_it_from_get_budgets() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+        let id1 = client.create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+        let id2 = client.create_budget(
+            &user,
+            &Symbol::new(&env, "fun"),
+            &200_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+
+        client.delete_budget(&user, &id1);
+
+        let budgets = client.get_budgets(&user);
+        assert_eq!(budgets.len(), 1);
+        assert_eq!(budgets.get(0).unwrap().budget_id, id2);
+    }
+
+    #[test]
+    fn update_budget_rejects_non_owner() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let other = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+        let id = client.create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+
+        let result = client.try_update_budget(&other, &id, &750_i128);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+        assert_eq!(client.get_budgets(&user).get(0).unwrap().amount, 500);
+    }
+
+    #[test]
+    fn delete_budget_rejects_non_owner() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let other = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+        let id = client.create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+
+        let result = client.try_delete_budget(&other, &id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+        assert_eq!(client.get_budgets(&user).len(), 1);
+    }
+
+    #[test]
+    fn create_budget_rejects_non_positive_amount() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+
+        let result = client.try_create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &0_i128,
+            &cat,
+            &asset,
+            &0_u64,
+            &1000_u64,
+        );
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    }
+
+    #[test]
+    fn create_budget_rejects_invalid_date_range() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let cat = category(&env);
+        let asset = xlm(&env);
+
+        let result = client.try_create_budget(
+            &user,
+            &Symbol::new(&env, "food"),
+            &500_i128,
+            &cat,
+            &asset,
+            &1000_u64,
+            &500_u64,
+        );
+        assert_eq!(result, Err(Ok(Error::InvalidDateRange)));
+    }
+
+    #[test]
+    fn update_budget_rejects_unknown_budget() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+
+        let result = client.try_update_budget(&user, &999_u64, &100_i128);
+        assert_eq!(result, Err(Ok(Error::BudgetNotFound)));
+    }
+
+    #[test]
+    fn delete_budget_rejects_unknown_budget() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+
+        let result = client.try_delete_budget(&user, &999_u64);
+        assert_eq!(result, Err(Ok(Error::BudgetNotFound)));
+    }
+
+    #[test]
+    fn double_initialize_fails() {
         let env = Env::default();
         env.mock_all_auths();
-        assert!(env.ledger().timestamp() >= 0);
-    }
-    #[test]
-    fn address_generation() {
-        let env = Env::default();
-        let _ = soroban_sdk::Address::generate(&env);
-    }
-    #[test]
-    fn zero_boundary() {
-        assert_eq!(0_i128.checked_add(0), Some(0));
-    }
-    #[test]
-    fn overflow_boundary() {
-        assert_eq!(i128::MAX.checked_add(1), None);
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.try_initialize(&admin);
+        assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
     }
 }

--- a/contracts/budget/src/types.rs
+++ b/contracts/budget/src/types.rs
@@ -1,11 +1,37 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contracttype, Address, Symbol};
 
-/// Stored configuration for this StellarSpend contract.
+/// Global contract configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct Config {
-    /// Contract administrator.
-    pub admin: soroban_sdk::Address,
-    /// Current configured value.
-    pub value: i128,
+    /// Contract administrator. Not required for any per-user budget
+    /// operation today; kept for parity with the rest of the StellarSpend
+    /// contracts and as a hook for future admin-gated functionality.
+    pub admin: Address,
+    /// Auto-incrementing counter used to allocate budget ids.
+    pub last_budget_id: u64,
+}
+
+/// A user's budget for a spending category over a time window.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Budget {
+    pub budget_id: u64,
+    pub user: Address,
+    pub name: Symbol,
+    pub amount: i128,
+    pub category: Symbol,
+    pub asset: Symbol,
+    pub start_date: u64,
+    pub end_date: u64,
+    pub created_at: u64,
+}
+
+/// Storage keys used by this contract.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Budget(u64),
+    UserBudgets(Address),
 }

--- a/contracts/budget/src/validation.rs
+++ b/contracts/budget/src/validation.rs
@@ -1,19 +1,18 @@
-use soroban_sdk::contracterror;
+use crate::Error;
 
-/// Errors raised by validation.
-#[contracterror]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Error {
-    /// Amount must be non-negative.
-    InvalidAmount = 1,
-    /// Contract has not been initialized.
-    NotInitialized = 2,
+/// Validates a budget amount: must be strictly positive.
+pub fn validate_amount(amount: i128) -> Result<(), Error> {
+    if amount <= 0 {
+        Err(Error::InvalidAmount)
+    } else {
+        Ok(())
+    }
 }
 
-/// Validates a financial amount.
-pub fn validate_amount(amount: i128) -> Result<(), Error> {
-    if amount < 0 {
-        Err(Error::InvalidAmount)
+/// Validates that a budget's end date is strictly after its start date.
+pub fn validate_date_range(start_date: u64, end_date: u64) -> Result<(), Error> {
+    if end_date <= start_date {
+        Err(Error::InvalidDateRange)
     } else {
         Ok(())
     }

--- a/contracts/savings-goals/src/lib.rs
+++ b/contracts/savings-goals/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, symbol_short, Address, Env, Symbol, Vec};
 
 mod storage;
 #[cfg(test)]
@@ -8,16 +8,27 @@ mod test;
 pub mod types;
 pub mod validation;
 
+pub use types::{Contribution, Goal, ScheduleStatus};
+
 /// Typed errors for the savings_goals contract.
 #[contracterror]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Contract has already been initialized.
     AlreadyInitialized = 1,
-    /// Caller is not the administrator.
-    Unauthorized = 2,
-    /// Amount validation failed.
-    InvalidAmount = 3,
+    /// Contract has not been initialized.
+    NotInitialized = 2,
+    /// Caller is not authorized to perform this action on the given goal.
+    Unauthorized = 3,
+    /// Amount must be a strictly positive value.
+    InvalidAmount = 4,
+    /// Deadline must be strictly in the future.
+    InvalidDeadline = 5,
+    /// No goal exists with the given id.
+    GoalNotFound = 6,
+    /// Round-up "nearest unit" must be a strictly positive value when
+    /// enabling the round-up rule.
+    InvalidRoundUpUnit = 7,
 }
 
 #[contract]
@@ -25,32 +36,188 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
-    /// Initializes the contract with an administrator.
+    /// Initializes the contract with an administrator. None of the
+    /// per-user goal operations below require the admin's authorization;
+    /// this exists so deployments have a consistent init step across all
+    /// StellarSpend contracts, and to guard against double-initialization.
     pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
         if storage::read_config(&env).is_some() {
             return Err(Error::AlreadyInitialized);
         }
         admin.require_auth();
-        storage::write_config(&env, &types::Config { admin, value: 0 });
+        storage::write_config(
+            &env,
+            &types::Config {
+                admin,
+                last_goal_id: 0,
+            },
+        );
         Ok(())
     }
 
-    /// Updates the contract value after authenticating the administrator.
-    pub fn set_value(env: Env, admin: Address, value: i128) -> Result<(), Error> {
-        admin.require_auth();
-        if value < 0 {
-            return Err(Error::InvalidAmount);
-        }
-        let current = storage::read_config(&env).ok_or(Error::Unauthorized)?;
-        if current.admin != admin {
+    /// Creates a new savings goal for `user` and returns its id.
+    pub fn create_goal(
+        env: Env,
+        user: Address,
+        name: Symbol,
+        target: i128,
+        asset: Symbol,
+        deadline: u64,
+    ) -> Result<u64, Error> {
+        user.require_auth();
+        validation::validate_amount(target)?;
+        validation::validate_deadline(&env, deadline)?;
+
+        let mut config = storage::read_config(&env).ok_or(Error::NotInitialized)?;
+        config.last_goal_id += 1;
+        let goal_id = config.last_goal_id;
+        storage::write_config(&env, &config);
+
+        let goal = Goal {
+            goal_id,
+            user: user.clone(),
+            name,
+            target,
+            current_amount: 0,
+            asset,
+            deadline,
+            created_at: env.ledger().timestamp(),
+            is_complete: false,
+            round_up_enabled: false,
+            round_up_nearest_unit: 0,
+            schedule_status: ScheduleStatus::Active,
+        };
+        storage::write_goal(&env, &goal);
+        storage::add_user_goal(&env, &user, goal_id);
+
+        Ok(goal_id)
+    }
+
+    /// Records a contribution toward `goal_id` on behalf of `user`.
+    /// Emits a `milestone` event the first time the goal's target is met
+    /// or exceeded.
+    pub fn contribute(env: Env, user: Address, goal_id: u64, amount: i128) -> Result<(), Error> {
+        user.require_auth();
+        validation::validate_amount(amount)?;
+
+        let mut goal = storage::read_goal(&env, goal_id).ok_or(Error::GoalNotFound)?;
+        if goal.user != user {
             return Err(Error::Unauthorized);
         }
-        storage::write_config(&env, &types::Config { admin, value });
+
+        let contrib_id = storage::next_contribution_id(&env, goal_id);
+        let contribution = Contribution {
+            contribution_id: contrib_id,
+            goal_id,
+            user: user.clone(),
+            amount,
+            timestamp: env.ledger().timestamp(),
+        };
+        storage::add_contribution(&env, goal_id, &contribution);
+
+        let was_complete = goal.is_complete;
+        goal.current_amount += amount;
+        if !was_complete && goal.current_amount >= goal.target {
+            goal.is_complete = true;
+            env.events().publish(
+                (symbol_short!("milestone"), goal_id),
+                (user.clone(), goal.current_amount),
+            );
+        }
+        storage::write_goal(&env, &goal);
+
         Ok(())
     }
 
-    /// Returns the current configured value.
-    pub fn get_value(env: Env) -> i128 {
-        storage::read_config(&env).map(|c| c.value).unwrap_or(0)
+    /// Returns the current state of a goal owned by `user`.
+    pub fn get_goal(env: Env, user: Address, goal_id: u64) -> Result<Goal, Error> {
+        let goal = storage::read_goal(&env, goal_id).ok_or(Error::GoalNotFound)?;
+        if goal.user != user {
+            return Err(Error::Unauthorized);
+        }
+        Ok(goal)
     }
+
+    /// Returns all goals belonging to `user`.
+    pub fn get_all_goals(env: Env, user: Address) -> Vec<Goal> {
+        let goal_ids = storage::user_goal_ids(&env, &user);
+        let mut goals = Vec::new(&env);
+        for goal_id in goal_ids.iter() {
+            if let Some(goal) = storage::read_goal(&env, goal_id) {
+                goals.push_back(goal);
+            }
+        }
+        goals
+    }
+
+    /// Returns the contribution history for a goal owned by `user`.
+    pub fn get_contribution_history(
+        env: Env,
+        goal_id: u64,
+        user: Address,
+    ) -> Result<Vec<Contribution>, Error> {
+        let goal = storage::read_goal(&env, goal_id).ok_or(Error::GoalNotFound)?;
+        if goal.user != user {
+            return Err(Error::Unauthorized);
+        }
+        Ok(storage::goal_contributions(&env, goal_id))
+    }
+
+    /// Enables or disables round-up contributions for a goal and sets the
+    /// unit contributions should be rounded up to. Disabling resets the
+    /// stored unit back to zero.
+    pub fn set_round_up_rule(
+        env: Env,
+        user: Address,
+        goal_id: u64,
+        enabled: bool,
+        nearest_unit: i128,
+    ) -> Result<(), Error> {
+        user.require_auth();
+        if enabled {
+            validation::validate_round_up_unit(nearest_unit)?;
+        }
+
+        let mut goal = storage::read_goal(&env, goal_id).ok_or(Error::GoalNotFound)?;
+        if goal.user != user {
+            return Err(Error::Unauthorized);
+        }
+        goal.round_up_enabled = enabled;
+        goal.round_up_nearest_unit = if enabled { nearest_unit } else { 0 };
+        storage::write_goal(&env, &goal);
+        Ok(())
+    }
+
+    /// Pauses the automated contribution schedule for a goal.
+    pub fn pause_schedule(env: Env, user: Address, goal_id: u64) -> Result<(), Error> {
+        set_schedule_status(&env, &user, goal_id, ScheduleStatus::Paused)
+    }
+
+    /// Resumes a previously paused contribution schedule.
+    pub fn resume_schedule(env: Env, user: Address, goal_id: u64) -> Result<(), Error> {
+        set_schedule_status(&env, &user, goal_id, ScheduleStatus::Active)
+    }
+
+    /// Cancels the automated contribution schedule for a goal. This is a
+    /// terminal state; call `set_round_up_rule` again to start a new one.
+    pub fn cancel_schedule(env: Env, user: Address, goal_id: u64) -> Result<(), Error> {
+        set_schedule_status(&env, &user, goal_id, ScheduleStatus::Cancelled)
+    }
+}
+
+/// Shared implementation for the three schedule-lifecycle endpoints.
+fn set_schedule_status(
+    env: &Env,
+    user: &Address,
+    goal_id: u64,
+    status: ScheduleStatus,
+) -> Result<(), Error> {
+    user.require_auth();
+    let mut goal = storage::read_goal(env, goal_id).ok_or(Error::GoalNotFound)?;
+    if &goal.user != user {
+        return Err(Error::Unauthorized);
+    }
+    goal.schedule_status = status;
+    storage::write_goal(env, &goal);
+    Ok(())
 }

--- a/contracts/savings-goals/src/storage.rs
+++ b/contracts/savings-goals/src/storage.rs
@@ -1,21 +1,72 @@
-use crate::types::Config;
-use soroban_sdk::{Address, Env};
-
-const CONFIG: &str = "CONFIG";
+use crate::types::{Config, Contribution, DataKey, Goal};
+use soroban_sdk::{Address, Env, Vec};
 
 /// Reads contract configuration from instance storage.
 pub fn read_config(env: &Env) -> Option<Config> {
-    // Instance storage is appropriate for contract-wide configuration.
-    env.storage().instance().get(&CONFIG)
+    env.storage().instance().get(&DataKey::Config)
 }
 
 /// Writes contract configuration to instance storage.
 pub fn write_config(env: &Env, config: &Config) {
-    // Instance storage keeps configuration attached to the contract instance.
-    env.storage().instance().set(&CONFIG, config);
+    env.storage().instance().set(&DataKey::Config, config);
 }
 
-/// Returns the configured owner.
-pub fn owner(env: &Env) -> Option<Address> {
-    read_config(env).map(|c| c.admin)
+/// Reads a goal record from persistent storage.
+pub fn read_goal(env: &Env, goal_id: u64) -> Option<Goal> {
+    env.storage().persistent().get(&DataKey::Goal(goal_id))
+}
+
+/// Writes a goal record to persistent storage.
+pub fn write_goal(env: &Env, goal: &Goal) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Goal(goal.goal_id), goal);
+}
+
+/// Appends `goal_id` to the list of goal ids owned by `user`.
+pub fn add_user_goal(env: &Env, user: &Address, goal_id: u64) {
+    let key = DataKey::UserGoals(user.clone());
+    let mut ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    ids.push_back(goal_id);
+    env.storage().persistent().set(&key, &ids);
+}
+
+/// Returns all goal ids owned by `user`.
+pub fn user_goal_ids(env: &Env, user: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserGoals(user.clone()))
+        .unwrap_or(Vec::new(env))
+}
+
+/// Allocates and returns the next contribution id for `goal_id`.
+pub fn next_contribution_id(env: &Env, goal_id: u64) -> u64 {
+    let key = DataKey::LastContribId(goal_id);
+    let next: u64 = env.storage().persistent().get(&key).unwrap_or(0u64) + 1;
+    env.storage().persistent().set(&key, &next);
+    next
+}
+
+/// Appends a contribution record to a goal's contribution history.
+pub fn add_contribution(env: &Env, goal_id: u64, contribution: &Contribution) {
+    let key = DataKey::GoalContributions(goal_id);
+    let mut history: Vec<Contribution> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    history.push_back(contribution.clone());
+    env.storage().persistent().set(&key, &history);
+}
+
+/// Returns the full contribution history for a goal, oldest first.
+pub fn goal_contributions(env: &Env, goal_id: u64) -> Vec<Contribution> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::GoalContributions(goal_id))
+        .unwrap_or(Vec::new(env))
 }

--- a/contracts/savings-goals/src/test.rs
+++ b/contracts/savings-goals/src/test.rs
@@ -1,31 +1,388 @@
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::testutils::{Address as _, Ledger};
-    use soroban_sdk::Env;
+    use crate::{Contract, ContractClient, Error, ScheduleStatus};
+    use soroban_sdk::{
+        testutils::{Address as _, Events, Ledger},
+        Address, Env, Symbol,
+    };
+
+    fn setup(env: &Env) -> (ContractClient<'static>, Address, Address) {
+        env.mock_all_auths();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        let user = Address::generate(env);
+        client.initialize(&admin);
+        (client, admin, user)
+    }
+
+    fn xlm(env: &Env) -> Symbol {
+        Symbol::new(env, "XLM")
+    }
 
     #[test]
-    fn happy_path_environment() {
+    fn create_and_get_goal() {
         let env = Env::default();
-        env.ledger().set_sequence_number(1);
-        assert_eq!(env.ledger().sequence(), 1);
+        let (client, _admin, user) = setup(&env);
+        let name = Symbol::new(&env, "vacation");
+        let asset = xlm(&env);
+
+        let goal_id = client.create_goal(&user, &name, &1000_i128, &asset, &2_000_000_000_u64);
+        assert_eq!(goal_id, 1);
+
+        let goal = client.get_goal(&user, &goal_id);
+        assert_eq!(goal.goal_id, 1);
+        assert_eq!(goal.user, user);
+        assert_eq!(goal.target, 1000);
+        assert_eq!(goal.current_amount, 0);
+        assert!(!goal.is_complete);
+        assert_eq!(goal.schedule_status, ScheduleStatus::Active);
     }
+
     #[test]
-    fn unauthorized_boundary_placeholder() {
+    fn create_goal_ids_increment_per_contract() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+
+        let id1 = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+        let id2 = client.create_goal(
+            &user,
+            &Symbol::new(&env, "car"),
+            &5000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+    }
+
+    #[test]
+    fn contribute_below_target_does_not_complete() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        client.contribute(&user, &goal_id, &600_i128);
+
+        let goal = client.get_goal(&user, &goal_id);
+        assert_eq!(goal.current_amount, 600);
+        assert!(!goal.is_complete);
+    }
+
+    #[test]
+    fn contribute_crossing_target_completes_and_emits_milestone() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        client.contribute(&user, &goal_id, &600_i128);
+        client.contribute(&user, &goal_id, &400_i128);
+
+        let goal = client.get_goal(&user, &goal_id);
+        assert_eq!(goal.current_amount, 1000);
+        assert!(goal.is_complete);
+
+        // A milestone event must have been published when the target was
+        // crossed by the second contribution.
+        let events = env.events().all();
+        assert!(!events.is_empty());
+    }
+
+    #[test]
+    fn milestone_is_only_emitted_once() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        client.contribute(&user, &goal_id, &1000_i128);
+        let events_after_first_completion = env.events().all().len();
+
+        // Contributing again after the goal is already complete must not
+        // publish a second milestone event.
+        client.contribute(&user, &goal_id, &100_i128);
+        let events_after_second_contribution = env.events().all().len();
+
+        assert_eq!(
+            events_after_first_completion,
+            events_after_second_contribution
+        );
+
+        let goal = client.get_goal(&user, &goal_id);
+        assert_eq!(goal.current_amount, 1100);
+        assert!(goal.is_complete);
+    }
+
+    #[test]
+    fn contribution_history_records_each_contribution_in_order() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        client.contribute(&user, &goal_id, &600_i128);
+        client.contribute(&user, &goal_id, &400_i128);
+
+        let history = client.get_contribution_history(&goal_id, &user);
+        assert_eq!(history.len(), 2);
+        assert_eq!(history.get(0).unwrap().amount, 600);
+        assert_eq!(history.get(1).unwrap().amount, 400);
+        assert_eq!(history.get(0).unwrap().contribution_id, 1);
+        assert_eq!(history.get(1).unwrap().contribution_id, 2);
+    }
+
+    #[test]
+    fn get_all_goals_returns_every_goal_for_user() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+        client.create_goal(
+            &user,
+            &Symbol::new(&env, "car"),
+            &5000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        let goals = client.get_all_goals(&user);
+        assert_eq!(goals.len(), 2);
+    }
+
+    #[test]
+    fn get_all_goals_is_empty_for_a_user_with_no_goals() {
+        let env = Env::default();
+        let (client, _admin, _user) = setup(&env);
+        let other = Address::generate(&env);
+
+        let goals = client.get_all_goals(&other);
+        assert_eq!(goals.len(), 0);
+    }
+
+    #[test]
+    fn set_round_up_rule_enables_and_disables() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        client.set_round_up_rule(&user, &goal_id, &true, &5_i128);
+        let goal = client.get_goal(&user, &goal_id);
+        assert!(goal.round_up_enabled);
+        assert_eq!(goal.round_up_nearest_unit, 5);
+
+        client.set_round_up_rule(&user, &goal_id, &false, &5_i128);
+        let goal = client.get_goal(&user, &goal_id);
+        assert!(!goal.round_up_enabled);
+        assert_eq!(goal.round_up_nearest_unit, 0);
+    }
+
+    #[test]
+    fn pause_resume_cancel_schedule_transitions() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        client.pause_schedule(&user, &goal_id);
+        assert_eq!(
+            client.get_goal(&user, &goal_id).schedule_status,
+            ScheduleStatus::Paused
+        );
+
+        client.resume_schedule(&user, &goal_id);
+        assert_eq!(
+            client.get_goal(&user, &goal_id).schedule_status,
+            ScheduleStatus::Active
+        );
+
+        client.cancel_schedule(&user, &goal_id);
+        assert_eq!(
+            client.get_goal(&user, &goal_id).schedule_status,
+            ScheduleStatus::Cancelled
+        );
+    }
+
+    #[test]
+    fn get_goal_rejects_non_owner() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let other = Address::generate(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        let result = client.try_get_goal(&other, &goal_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn contribute_rejects_non_owner() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let other = Address::generate(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        let result = client.try_contribute(&other, &goal_id, &100_i128);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn contribute_rejects_unknown_goal() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+
+        let result = client.try_contribute(&user, &999_u64, &100_i128);
+        assert_eq!(result, Err(Ok(Error::GoalNotFound)));
+    }
+
+    #[test]
+    fn create_goal_rejects_non_positive_target() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+
+        let result = client.try_create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &0_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    }
+
+    #[test]
+    fn create_goal_rejects_past_deadline() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+
+        let result = client.try_create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &500_000_u64,
+        );
+        assert_eq!(result, Err(Ok(Error::InvalidDeadline)));
+    }
+
+    #[test]
+    fn set_round_up_rule_rejects_non_positive_unit_when_enabling() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        let result = client.try_set_round_up_rule(&user, &goal_id, &true, &0_i128);
+        assert_eq!(result, Err(Ok(Error::InvalidRoundUpUnit)));
+
+        // Disabling never validates the unit, even if it is non-positive.
+        client.set_round_up_rule(&user, &goal_id, &false, &0_i128);
+        let goal = client.get_goal(&user, &goal_id);
+        assert!(!goal.round_up_enabled);
+    }
+
+    #[test]
+    fn pause_schedule_rejects_non_owner() {
+        let env = Env::default();
+        let (client, _admin, user) = setup(&env);
+        let other = Address::generate(&env);
+        let asset = xlm(&env);
+        let goal_id = client.create_goal(
+            &user,
+            &Symbol::new(&env, "vacation"),
+            &1000_i128,
+            &asset,
+            &2_000_000_000_u64,
+        );
+
+        let result = client.try_pause_schedule(&other, &goal_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn double_initialize_fails() {
         let env = Env::default();
         env.mock_all_auths();
-        assert!(env.ledger().timestamp() >= 0);
-    }
-    #[test]
-    fn address_generation() {
-        let env = Env::default();
-        let _ = soroban_sdk::Address::generate(&env);
-    }
-    #[test]
-    fn zero_boundary() {
-        assert_eq!(0_i128.checked_add(0), Some(0));
-    }
-    #[test]
-    fn overflow_boundary() {
-        assert_eq!(i128::MAX.checked_add(1), None);
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.try_initialize(&admin);
+        assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
     }
 }

--- a/contracts/savings-goals/src/types.rs
+++ b/contracts/savings-goals/src/types.rs
@@ -1,11 +1,63 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contracttype, Address, Symbol};
 
-/// Stored configuration for this StellarSpend contract.
+/// Global contract configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct Config {
-    /// Contract administrator.
-    pub admin: soroban_sdk::Address,
-    /// Current configured value.
-    pub value: i128,
+    /// Contract administrator. Not required for any per-user goal
+    /// operation today; kept for parity with the rest of the StellarSpend
+    /// contracts and as a hook for future admin-gated functionality.
+    pub admin: Address,
+    /// Auto-incrementing counter used to allocate goal ids.
+    pub last_goal_id: u64,
+}
+
+/// Lifecycle status of a goal's automated contribution schedule (e.g. a
+/// round-up rule). A newly created goal starts `Active`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum ScheduleStatus {
+    Active,
+    Paused,
+    Cancelled,
+}
+
+/// A user's savings goal.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Goal {
+    pub goal_id: u64,
+    pub user: Address,
+    pub name: Symbol,
+    pub target: i128,
+    pub current_amount: i128,
+    pub asset: Symbol,
+    pub deadline: u64,
+    pub created_at: u64,
+    pub is_complete: bool,
+    pub round_up_enabled: bool,
+    pub round_up_nearest_unit: i128,
+    pub schedule_status: ScheduleStatus,
+}
+
+/// A single contribution recorded against a goal.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Contribution {
+    pub contribution_id: u64,
+    pub goal_id: u64,
+    pub user: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+/// Storage keys used by this contract.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Goal(u64),
+    UserGoals(Address),
+    GoalContributions(u64),
+    LastContribId(u64),
 }

--- a/contracts/savings-goals/src/validation.rs
+++ b/contracts/savings-goals/src/validation.rs
@@ -1,19 +1,30 @@
-use soroban_sdk::contracterror;
+use crate::Error;
+use soroban_sdk::Env;
 
-/// Errors raised by validation.
-#[contracterror]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Error {
-    /// Amount must be non-negative.
-    InvalidAmount = 1,
-    /// Contract has not been initialized.
-    NotInitialized = 2,
+/// Validates a contribution or goal target amount: must be strictly
+/// positive.
+pub fn validate_amount(amount: i128) -> Result<(), Error> {
+    if amount <= 0 {
+        Err(Error::InvalidAmount)
+    } else {
+        Ok(())
+    }
 }
 
-/// Validates a financial amount.
-pub fn validate_amount(amount: i128) -> Result<(), Error> {
-    if amount < 0 {
-        Err(Error::InvalidAmount)
+/// Validates a round-up "nearest unit": must be strictly positive.
+pub fn validate_round_up_unit(nearest_unit: i128) -> Result<(), Error> {
+    if nearest_unit <= 0 {
+        Err(Error::InvalidRoundUpUnit)
+    } else {
+        Ok(())
+    }
+}
+
+/// Validates that a deadline lies strictly in the future relative to the
+/// current ledger timestamp.
+pub fn validate_deadline(env: &Env, deadline: u64) -> Result<(), Error> {
+    if deadline <= env.ledger().timestamp() {
+        Err(Error::InvalidDeadline)
     } else {
         Ok(())
     }

--- a/contracts/savings/src/lib.rs
+++ b/contracts/savings/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contracterror, contractimpl, Address, Env};
+use soroban_sdk::{contract, contracterror, contractimpl, Address, Env, Symbol};
 
 mod storage;
 #[cfg(test)]
@@ -14,10 +14,12 @@ pub mod validation;
 pub enum Error {
     /// Contract has already been initialized.
     AlreadyInitialized = 1,
-    /// Caller is not the administrator.
-    Unauthorized = 2,
-    /// Amount validation failed.
+    /// Contract has not been initialized.
+    NotInitialized = 2,
+    /// Amount must be a strictly positive value.
     InvalidAmount = 3,
+    /// Withdrawal amount exceeds the caller's current balance.
+    InsufficientBalance = 4,
 }
 
 #[contract]
@@ -31,26 +33,38 @@ impl Contract {
             return Err(Error::AlreadyInitialized);
         }
         admin.require_auth();
-        storage::write_config(&env, &types::Config { admin, value: 0 });
+        storage::write_config(&env, &types::Config { admin });
         Ok(())
     }
 
-    /// Updates the contract value after authenticating the administrator.
-    pub fn set_value(env: Env, admin: Address, value: i128) -> Result<(), Error> {
-        admin.require_auth();
-        if value < 0 {
-            return Err(Error::InvalidAmount);
-        }
-        let current = storage::read_config(&env).ok_or(Error::Unauthorized)?;
-        if current.admin != admin {
-            return Err(Error::Unauthorized);
-        }
-        storage::write_config(&env, &types::Config { admin, value });
+    /// Deposits `amount` of `asset` into `user`'s savings balance. This
+    /// contract tracks internal accounting only — it does not itself move
+    /// any tokens on `user`'s behalf; callers are responsible for the
+    /// corresponding token transfer alongside this call.
+    pub fn deposit(env: Env, user: Address, amount: i128, asset: Symbol) -> Result<(), Error> {
+        user.require_auth();
+        validation::validate_amount(amount)?;
+
+        let balance = storage::read_balance(&env, &user, &asset) + amount;
+        storage::write_balance(&env, &user, &asset, balance);
         Ok(())
     }
 
-    /// Returns the current configured value.
-    pub fn get_value(env: Env) -> i128 {
-        storage::read_config(&env).map(|c| c.value).unwrap_or(0)
+    /// Withdraws `amount` of `asset` from `user`'s savings balance.
+    pub fn withdraw(env: Env, user: Address, amount: i128, asset: Symbol) -> Result<(), Error> {
+        user.require_auth();
+        validation::validate_amount(amount)?;
+
+        let current = storage::read_balance(&env, &user, &asset);
+        if amount > current {
+            return Err(Error::InsufficientBalance);
+        }
+        storage::write_balance(&env, &user, &asset, current - amount);
+        Ok(())
+    }
+
+    /// Returns `user`'s current balance for `asset`.
+    pub fn get_balance(env: Env, user: Address, asset: Symbol) -> i128 {
+        storage::read_balance(&env, &user, &asset)
     }
 }

--- a/contracts/savings/src/storage.rs
+++ b/contracts/savings/src/storage.rs
@@ -1,21 +1,28 @@
-use crate::types::Config;
-use soroban_sdk::{Address, Env};
-
-const CONFIG: &str = "CONFIG";
+use crate::types::{Config, DataKey};
+use soroban_sdk::{Address, Env, Symbol};
 
 /// Reads contract configuration from instance storage.
 pub fn read_config(env: &Env) -> Option<Config> {
-    // Instance storage is appropriate for contract-wide configuration.
-    env.storage().instance().get(&CONFIG)
+    env.storage().instance().get(&DataKey::Config)
 }
 
 /// Writes contract configuration to instance storage.
 pub fn write_config(env: &Env, config: &Config) {
-    // Instance storage keeps configuration attached to the contract instance.
-    env.storage().instance().set(&CONFIG, config);
+    env.storage().instance().set(&DataKey::Config, config);
 }
 
-/// Returns the configured owner.
-pub fn owner(env: &Env) -> Option<Address> {
-    read_config(env).map(|c| c.admin)
+/// Returns `user`'s balance for `asset`, or zero if none has ever been
+/// recorded.
+pub fn read_balance(env: &Env, user: &Address, asset: &Symbol) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(user.clone(), asset.clone()))
+        .unwrap_or(0)
+}
+
+/// Writes `user`'s balance for `asset`.
+pub fn write_balance(env: &Env, user: &Address, asset: &Symbol, balance: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(user.clone(), asset.clone()), &balance);
 }

--- a/contracts/savings/src/test.rs
+++ b/contracts/savings/src/test.rs
@@ -1,31 +1,154 @@
 #[cfg(test)]
 mod tests {
-    use soroban_sdk::testutils::{Address as _, Ledger};
-    use soroban_sdk::Env;
+    use crate::{Contract, ContractClient, Error};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+    fn setup(env: &Env) -> ContractClient<'static> {
+        env.mock_all_auths();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(env, &contract_id);
+        let admin = Address::generate(env);
+        client.initialize(&admin);
+        client
+    }
 
     #[test]
-    fn happy_path_environment() {
+    fn deposit_increases_balance() {
         let env = Env::default();
-        env.ledger().set_sequence_number(1);
-        assert_eq!(env.ledger().sequence(), 1);
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        client.deposit(&user, &500_i128, &asset);
+        assert_eq!(client.get_balance(&user, &asset), 500);
+
+        client.deposit(&user, &250_i128, &asset);
+        assert_eq!(client.get_balance(&user, &asset), 750);
     }
+
     #[test]
-    fn unauthorized_boundary_placeholder() {
+    fn withdraw_decreases_balance() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        client.deposit(&user, &500_i128, &asset);
+        client.withdraw(&user, &200_i128, &asset);
+        assert_eq!(client.get_balance(&user, &asset), 300);
+    }
+
+    #[test]
+    fn withdraw_full_balance_leaves_zero() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        client.deposit(&user, &500_i128, &asset);
+        client.withdraw(&user, &500_i128, &asset);
+        assert_eq!(client.get_balance(&user, &asset), 0);
+    }
+
+    #[test]
+    fn withdraw_rejects_insufficient_balance() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        client.deposit(&user, &100_i128, &asset);
+        let result = client.try_withdraw(&user, &200_i128, &asset);
+        assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+        // Balance must be unchanged after a rejected withdrawal.
+        assert_eq!(client.get_balance(&user, &asset), 100);
+    }
+
+    #[test]
+    fn withdraw_rejects_when_no_balance_exists() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        let result = client.try_withdraw(&user, &1_i128, &asset);
+        assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+    }
+
+    #[test]
+    fn deposit_rejects_non_positive_amount() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        let result = client.try_deposit(&user, &0_i128, &asset);
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+
+        let result = client.try_deposit(&user, &(-10_i128), &asset);
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    }
+
+    #[test]
+    fn withdraw_rejects_non_positive_amount() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+        client.deposit(&user, &100_i128, &asset);
+
+        let result = client.try_withdraw(&user, &0_i128, &asset);
+        assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+    }
+
+    #[test]
+    fn balances_are_tracked_per_asset() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let xlm = Symbol::new(&env, "XLM");
+        let usdc = Symbol::new(&env, "USDC");
+
+        client.deposit(&user, &500_i128, &xlm);
+        client.deposit(&user, &100_i128, &usdc);
+
+        assert_eq!(client.get_balance(&user, &xlm), 500);
+        assert_eq!(client.get_balance(&user, &usdc), 100);
+    }
+
+    #[test]
+    fn balances_are_tracked_per_user() {
+        let env = Env::default();
+        let client = setup(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        client.deposit(&alice, &500_i128, &asset);
+        assert_eq!(client.get_balance(&alice, &asset), 500);
+        assert_eq!(client.get_balance(&bob, &asset), 0);
+    }
+
+    #[test]
+    fn get_balance_defaults_to_zero() {
+        let env = Env::default();
+        let client = setup(&env);
+        let user = Address::generate(&env);
+        let asset = Symbol::new(&env, "XLM");
+
+        assert_eq!(client.get_balance(&user, &asset), 0);
+    }
+
+    #[test]
+    fn double_initialize_fails() {
         let env = Env::default();
         env.mock_all_auths();
-        assert!(env.ledger().timestamp() >= 0);
-    }
-    #[test]
-    fn address_generation() {
-        let env = Env::default();
-        let _ = soroban_sdk::Address::generate(&env);
-    }
-    #[test]
-    fn zero_boundary() {
-        assert_eq!(0_i128.checked_add(0), Some(0));
-    }
-    #[test]
-    fn overflow_boundary() {
-        assert_eq!(i128::MAX.checked_add(1), None);
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.try_initialize(&admin);
+        assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
     }
 }

--- a/contracts/savings/src/types.rs
+++ b/contracts/savings/src/types.rs
@@ -1,11 +1,20 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contracttype, Address, Symbol};
 
-/// Stored configuration for this StellarSpend contract.
+/// Global contract configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct Config {
-    /// Contract administrator.
-    pub admin: soroban_sdk::Address,
-    /// Current configured value.
-    pub value: i128,
+    /// Contract administrator. Not required for any deposit/withdraw
+    /// operation today; kept for parity with the rest of the StellarSpend
+    /// contracts and as a hook for future admin-gated functionality.
+    pub admin: Address,
+}
+
+/// Storage keys used by this contract.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum DataKey {
+    Config,
+    /// Balance for a given (user, asset) pair.
+    Balance(Address, Symbol),
 }

--- a/contracts/savings/src/validation.rs
+++ b/contracts/savings/src/validation.rs
@@ -1,18 +1,8 @@
-use soroban_sdk::contracterror;
+use crate::Error;
 
-/// Errors raised by validation.
-#[contracterror]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Error {
-    /// Amount must be non-negative.
-    InvalidAmount = 1,
-    /// Contract has not been initialized.
-    NotInitialized = 2,
-}
-
-/// Validates a financial amount.
+/// Validates a deposit/withdrawal amount: must be strictly positive.
 pub fn validate_amount(amount: i128) -> Result<(), Error> {
-    if amount < 0 {
+    if amount <= 0 {
         Err(Error::InvalidAmount)
     } else {
         Ok(())

--- a/contracts/shared/src/sanitizer.rs
+++ b/contracts/shared/src/sanitizer.rs
@@ -1,3 +1,5 @@
+use alloc::string::String;
+
 /// Removes null bytes and control characters from a memo.
 pub fn sanitize_memo(input: String) -> String {
     input


### PR DESCRIPTION
Closes #1112

Hey, so this issue was about three contracts — savings, savings-goals, and budget — that were all just identical placeholder scaffolds with only initialize/set_value/get_value, while the frontend was already trying to call real functions on them like fetchGoals, contributeToGoal, createBudget, and so on, which don't exist yet. Every one of those calls was silently falling back to mock data.

I built out the real implementation for all three, matching the exact function names and signatures listed in the issue.

For savings-goals: you can create a goal with a target and deadline, contribute toward it, read a single goal or all of a user's goals, pull the full contribution history, and set up a round-up rule that can be paused, resumed, or cancelled. When a contribution pushes the goal's total at or past its target, it fires a milestone event, and it only fires once even if you keep contributing after that.

For savings: straightforward deposit, withdraw, and balance lookup, tracked separately per user and per asset.

For budget: create, update, and delete a budget, plus list all of a user's budgets.

Every function checks that the caller actually owns the goal or budget they're trying to touch, and every input gets validated (positive amounts only, deadlines that are actually in the future, end dates that come after start dates), all through typed errors rather than generic panics.

While getting this to actually build, I also ran into two pre-existing bugs in the shared crate that had nothing to do with this issue but were blocking compilation entirely for any contract that depends on it — sanitizer.rs was using String without importing it (this crate is #![no_std], so that doesn't come for free), and lib.rs was missing the extern crate alloc; declaration that import needs. I fixed both with minimal one-line changes since there was no way to get any of the three contracts building without them.

I wrote 41 tests across the three contracts covering the normal paths, the exact milestone scenario from the issue's "How to Test" section (creating a goal for 1000, contributing 600 then 400, checking it completes), and the failure paths (wrong user trying to touch someone else's goal or budget, non-positive amounts, past deadlines, invalid date ranges, unknown ids).

cargo fmt, cargo clippy --all-targets -- -D warnings, and cargo test all pass clean for all three packages — screenshots below.

SCREENSHOTS
<img width="1308" height="69" alt="image" src="https://github.com/user-attachments/assets/2399238e-0d0c-453b-822d-c4902a9de0bb" />

<img width="1307" height="641" alt="image" src="https://github.com/user-attachments/assets/be5e5d72-b46e-45d4-8b9c-7aa7cb3eb363" />

<img width="1303" height="508" alt="image" src="https://github.com/user-attachments/assets/3dbd1fba-891a-4157-8a6b-713bb8484851" />

<img width="1203" height="487" alt="image" src="https://github.com/user-attachments/assets/dee2b774-5f00-499f-876a-7f512e7b79ea" />

