### PR TITLE
docs: add doc comments to budget types (#1163)

### DIFF
--- a/contracts/budget/src/types.rs
+++ b/contracts/budget/src/types.rs
@@ -16,14 +16,23 @@ pub struct Config {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct Budget {
+    /// Unique identifier for this budget.
     pub budget_id: u64,
+    /// Address of the user who owns this budget.
     pub user: Address,
+    /// Human-readable name for this budget (e.g. "Monthly groceries").
     pub name: Symbol,
+    /// Allocated spending amount in the budget's asset.
     pub amount: i128,
+    /// Spending category this budget belongs to (e.g. "groceries").
     pub category: Symbol,
+    /// Asset symbol the budget is denominated in (e.g. "XLM").
     pub asset: Symbol,
+    /// Unix timestamp when the budget becomes active.
     pub start_date: u64,
+    /// Unix timestamp when the budget expires.
     pub end_date: u64,
+    /// Ledger timestamp when the budget was created.
     pub created_at: u64,
 }
 
@@ -31,7 +40,10 @@ pub struct Budget {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum DataKey {
+    /// Key for the global contract configuration.
     Config,
+    /// Key for a specific budget identified by its id.
     Budget(u64),
+    /// Key for the list of budget ids belonging to a user.
     UserBudgets(Address),
 }


### PR DESCRIPTION
Add `///` doc comments for every field in `Budget` struct and every variant in `DataKey` enum. Matches the existing field-level documentation style used in `Config`.

Closes #1163