### PR TITLE
docs: add doc comments to shared sanitizer, assets, rate_curve, events (#1206 #1208 #1209 #1211)

### DIFF
--- a/contracts/shared/src/assets.rs
+++ b/contracts/shared/src/assets.rs
@@ -1,5 +1,29 @@
+//! Shared asset-allowlist helpers for StellarSpend contracts.
+//!
+//! Centralises the list of assets accepted across all StellarSpend contract
+//! operations. Keeping the allowlist in one place ensures every contract
+//! rejects unsupported assets in a consistent, maintainable way.
 use soroban_sdk::Symbol;
-/// Returns whether an asset symbol is supported by StellarSpend.
+
+/// Returns `true` if `asset` is a supported StellarSpend asset symbol.
+///
+/// # Supported assets
+/// | Symbol | Description |
+/// |--------|-------------|
+/// | `XLM`  | Stellar Lumens — native Stellar asset |
+/// | `USDC` | USD Coin — Circle stablecoin on Stellar |
+/// | `EURC` | Euro Coin — Circle euro stablecoin on Stellar |
+///
+/// Any symbol not in this list returns `false`. Contracts should call this
+/// before accepting a deposit, transfer, or budget operation to ensure only
+/// whitelisted assets are processed.
+///
+/// # Examples
+/// ```
+/// let env = Env::default();
+/// assert!(is_supported_asset(Symbol::new(&env, "XLM")));
+/// assert!(!is_supported_asset(Symbol::new(&env, "BTC")));
+/// ```
 pub fn is_supported_asset(asset: Symbol) -> bool {
     asset == Symbol::new(&soroban_sdk::Env::default(), "XLM")
         || asset == Symbol::new(&soroban_sdk::Env::default(), "USDC")

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -1,5 +1,29 @@
+//! Shared event-emission helpers for StellarSpend contracts.
+//!
+//! Wraps the Soroban [`Env::events`] API with a single consistent call
+//! signature so every contract emits events in the same way. Using a
+//! shared helper prevents each contract from duplicating boilerplate and
+//! makes it easy to evolve the event schema in one place.
 use soroban_sdk::{Env, Symbol, Val};
-/// Emits a standard StellarSpend event.
+
+/// Emits a standard StellarSpend contract event.
+///
+/// Events are published to the Soroban event ledger under a single-element
+/// topic tuple `(name,)` with `data` as the event body. Downstream indexers
+/// and dApps can filter by `name` to track specific contract actions.
+///
+/// # Arguments
+/// * `env`  — The current contract execution environment.
+/// * `name` — A short [`Symbol`] identifying the event type (e.g.
+///   `symbol_short!("transfer")`, `symbol_short!("deposit")`).
+/// * `data` — An arbitrary [`Val`] payload attached to the event. Use
+///   `soroban_sdk::vec!` or a [`contracttype`]-annotated struct converted
+///   with `env.to_val()` for structured payloads.
+///
+/// # Examples
+/// ```
+/// emit_event(&env, symbol_short!("deposit"), amount.into_val(&env));
+/// ```
 pub fn emit_event(env: &Env, name: Symbol, data: Val) {
     env.events().publish((name,), data)
 }

--- a/contracts/shared/src/rate_curve.rs
+++ b/contracts/shared/src/rate_curve.rs
@@ -1,3 +1,8 @@
+//! Tiered rate-curve utilities for StellarSpend contracts.
+//!
+//! Provides a generic mechanism for applying step-function fee or reward
+//! rates based on configurable threshold tiers. Used by budget, savings,
+//! and rewards contracts to compute amounts without floating-point arithmetic.
 use soroban_sdk::contracttype;
 
 /// A single tier boundary: any value >= `threshold` (and below the next
@@ -11,14 +16,32 @@ pub struct Tier {
     pub rate_bps: u32, // basis points, e.g. 250 = 2.50%
 }
 
-/// Calculates a result by applying the rate of whichever tier the input
-/// value falls into. Tier boundaries are inclusive of their threshold
-/// (i.e. a value exactly equal to a tier's threshold uses that tier, not
-/// the previous one).
+/// Applies a stepped (tiered) rate to `value` and returns the resulting amount.
 ///
-/// Returns 0 if `tiers` is empty, rather than panicking — callers that
-/// require at least one tier should validate that themselves with a
-/// clearer domain-specific error message.
+/// The function walks `tiers` in order (assumed sorted ascending by `threshold`)
+/// and selects the **highest** tier whose `threshold` is ≤ `value`. The selected
+/// tier's `rate_bps` (basis points, where 10 000 bps = 100 %) is then applied:
+///
+/// ```text
+/// result = value * rate_bps / 10_000
+/// ```
+///
+/// Integer division is used throughout; sub-unit remainders are truncated.
+///
+/// # Arguments
+/// * `value` — The input amount in the contract's base unit (e.g. stroops).
+/// * `tiers` — A slice of [`Tier`] values sorted ascending by `threshold`.
+///
+/// # Returns
+/// The computed amount, or `0` when `tiers` is empty (rather than panicking —
+/// callers that require at least one tier should validate that themselves with
+/// a clearer domain-specific error message).
+///
+/// # Examples
+/// ```
+/// let tiers = [Tier { threshold: 0, rate_bps: 100 }]; // 1 %
+/// assert_eq!(calculate_tiered_rate(500, &tiers), 5);
+/// ```
 pub fn calculate_tiered_rate(value: i128, tiers: &[Tier]) -> i128 {
     if tiers.is_empty() {
         return 0;

--- a/contracts/shared/src/sanitizer.rs
+++ b/contracts/shared/src/sanitizer.rs
@@ -1,6 +1,26 @@
+//! Shared input-sanitization helpers for StellarSpend contracts.
+//!
+//! These utilities strip unsafe characters from user-supplied strings
+//! (e.g. payment memos) before they are stored on-chain, preventing
+//! null-byte injection and control-character pollution.
 use alloc::string::String;
 
-/// Removes null bytes and control characters from a memo.
+/// Removes null bytes (`\0`) and ASCII/Unicode control characters from a memo
+/// string before it is stored on-chain.
+///
+/// # What is stripped
+/// * Null bytes (`\0`, `U+0000`)
+/// * All Unicode control characters as defined by [`char::is_control`]
+///   (code points `U+0000`–`U+001F` and `U+007F`–`U+009F`)
+///
+/// Printable characters, whitespace that is not a control character,
+/// and all non-ASCII Unicode are preserved unchanged.
+///
+/// # Examples
+/// ```
+/// let clean = sanitize_memo("hello\0world".to_string());
+/// assert_eq!(clean, "helloworld");
+/// ```
 pub fn sanitize_memo(input: String) -> String {
     input
         .chars()


### PR DESCRIPTION
## Summary

Adds `///` doc comments to every `pub fn` and `//!` module-level doc comments across four shared modules.

Closes #1206
Closes #1208
Closes #1209
Closes #1211

---

## Changes

| File | Issue | What was added |
|------|-------|---------------|
| `contracts/shared/src/sanitizer.rs` | #1206 | `//!` module doc + `///` on `sanitize_memo` explaining null bytes and control chars stripped |
| `contracts/shared/src/rate_curve.rs` | #1208 | `//!` module doc + `///` on `calculate_tiered_rate` with arg table, return semantics, integer-division note |
| `contracts/shared/src/assets.rs` | #1209 | `//!` module doc + `///` on `is_supported_asset` with supported-asset table and example |
| `contracts/shared/src/events.rs` | #1211 | `//!` module doc + `///` on `emit_event` with arg descriptions and topic schema |

All existing logic is unchanged — documentation only.
